### PR TITLE
Swap to PR target

### DIFF
--- a/.github/workflows/pr-gpu.yaml
+++ b/.github/workflows/pr-gpu.yaml
@@ -4,7 +4,7 @@ on:
     branches:
     - main
     - release/*
-  pull_request:
+  pull_request_target:
     branches:
     - main
     - release/**


### PR DESCRIPTION
Swaps to PR target so forks work. Requires force merge because it changes required workflow