### PR TITLE
Make ICL configurations more concise

### DIFF
--- a/llmfoundry/common/builders.py
+++ b/llmfoundry/common/builders.py
@@ -163,7 +163,8 @@ def build_dataloader(cfg, tokenizer, device_batch_size):
         raise ValueError(f'Not sure how to build dataloader with config: {cfg}')
 
 
-def build_icl_evaluators(cfg, tokenizer, default_batch_size):
+def build_icl_evaluators(icl_tasks, tokenizer, default_max_seq_len,
+                         default_batch_size):
     evaluators = []
     logger_keys = []
 
@@ -189,12 +190,13 @@ def build_icl_evaluators(cfg, tokenizer, default_batch_size):
             icl_cfg.example_delimiter = '\n'
         if 'continuation_delimiter' not in icl_cfg:
             icl_cfg.continuation_delimiter = ' '
+        if 'max_seq_len' not in icl_cfg:
+            icl_cfg.max_seq_len = default_max_seq_len
         if 'batch_size' not in icl_cfg:
             icl_cfg.batch_size = default_batch_size
 
-    for icl_cfg in cfg.icl_tasks:
+    for icl_cfg in icl_tasks:
         _validate_cfg(icl_cfg)
-        print(icl_cfg)
         for num_fewshot in list(icl_cfg.num_fewshot):
             if tokenizer.pad_token_id is None:
                 # Current workaround to support GPT2 tokenizer with `pad_token_id = None`
@@ -208,7 +210,7 @@ def build_icl_evaluators(cfg, tokenizer, default_batch_size):
                 icl_cfg.dataset_uri,
                 tokenizer,
                 batch_size=icl_cfg.batch_size,
-                max_seq_len=cfg.max_seq_len,
+                max_seq_len=icl_cfg.max_seq_len,
                 pad_tok_id=pad_tok_id,
                 num_fewshot=num_fewshot,
                 prompt_string=icl_cfg.prompt_string,

--- a/llmfoundry/common/builders.py
+++ b/llmfoundry/common/builders.py
@@ -176,9 +176,9 @@ def build_icl_evaluators(icl_tasks, tokenizer, default_max_seq_len,
 
         if 'metric_names' not in icl_cfg:
             if icl_cfg.icl_task_type == 'language_modeling':
-                icl_cfg.metric_names = 'InContextLearningLMAccuracy'
+                icl_cfg.metric_names = ['InContextLearningLMAccuracy']
             elif icl_cfg.icl_task_type == 'multiple_choice':
-                icl_cfg.metric_names = 'InContextLearningMultipleChoiceAccuracy'
+                icl_cfg.metric_names = ['InContextLearningMultipleChoiceAccuracy']
             else:
                 raise ValueError(
                     f'No metric_names defined, unable to build default metrics for icl_task_type={icl_cfg.icl_task_type}.'

--- a/llmfoundry/common/builders.py
+++ b/llmfoundry/common/builders.py
@@ -178,7 +178,9 @@ def build_icl_evaluators(icl_tasks, tokenizer, default_max_seq_len,
             if icl_cfg.icl_task_type == 'language_modeling':
                 icl_cfg.metric_names = ['InContextLearningLMAccuracy']
             elif icl_cfg.icl_task_type == 'multiple_choice':
-                icl_cfg.metric_names = ['InContextLearningMultipleChoiceAccuracy']
+                icl_cfg.metric_names = [
+                    'InContextLearningMultipleChoiceAccuracy'
+                ]
             else:
                 raise ValueError(
                     f'No metric_names defined, unable to build default metrics for icl_task_type={icl_cfg.icl_task_type}.'

--- a/llmfoundry/common/builders.py
+++ b/llmfoundry/common/builders.py
@@ -163,23 +163,38 @@ def build_dataloader(cfg, tokenizer, device_batch_size):
         raise ValueError(f'Not sure how to build dataloader with config: {cfg}')
 
 
-def build_icl_evaluators(cfg, tokenizer):
+def build_icl_evaluators(cfg, tokenizer, default_batch_size):
     evaluators = []
     logger_keys = []
 
     def _validate_cfg(icl_cfg):
+        assert 'label' in icl_cfg
         assert 'dataset_uri' in icl_cfg and icl_cfg.dataset_uri is not None
         assert 'icl_task_type' in icl_cfg
         assert 'num_fewshot' in icl_cfg
-        assert 'batch_size' in icl_cfg
-        assert 'metric_names' in icl_cfg
-        assert 'prompt_string' in icl_cfg
-        assert 'example_delimiter' in icl_cfg
-        assert 'continuation_delimiter' in icl_cfg
-        assert 'label' in icl_cfg
+
+        if 'metric_names' not in icl_cfg:
+            if icl_cfg.icl_task_type == 'language_modeling':
+                icl_cfg.metric_names = 'InContextLearningLMAccuracy'
+            elif icl_cfg.icl_task_type == 'multiple_choice':
+                icl_cfg.metric_names = 'InContextLearningMultipleChoiceAccuracy'
+            else:
+                raise ValueError(
+                    f'No metric_names defined, unable to build default metrics for icl_task_type={icl_cfg.icl_task_type}.'
+                )
+
+        if 'prompt_string' not in icl_cfg:
+            icl_cfg.prompt_string = ''
+        if 'example_delimiter' not in icl_cfg:
+            icl_cfg.example_delimiter = '\n'
+        if 'continuation_delimiter' not in icl_cfg:
+            icl_cfg.continuation_delimiter = ' '
+        if 'batch_size' not in icl_cfg:
+            icl_cfg.batch_size = default_batch_size
 
     for icl_cfg in cfg.icl_tasks:
         _validate_cfg(icl_cfg)
+        print(icl_cfg)
         for num_fewshot in list(icl_cfg.num_fewshot):
             if tokenizer.pad_token_id is None:
                 # Current workaround to support GPT2 tokenizer with `pad_token_id = None`

--- a/llmfoundry/data/denoising.py
+++ b/llmfoundry/data/denoising.py
@@ -637,8 +637,8 @@ def _get_max_starting_length(max_length: int, mask_ratio: float,
         total_inp_tokens, total_targ_tokens = sequence_stats(length)
         if decoder_only_format:
             return (total_inp_tokens + total_targ_tokens) <= max_length
-        return (total_inp_tokens <= max_length) and (total_targ_tokens
-                                                     <= max_length)
+        return (total_inp_tokens <= max_length) and (total_targ_tokens <=
+                                                     max_length)
 
     # Start with a definitely too-long sequence and reduce until it fits
     num_raw_tokens = max_length * 2

--- a/llmfoundry/data/denoising.py
+++ b/llmfoundry/data/denoising.py
@@ -476,7 +476,7 @@ def build_text_denoising_dataloader(
         download_timeout=cfg.dataset.get('download_timeout', 60),
         validate_hash=cfg.dataset.get('validate_hash'),
         shuffle_seed=cfg.dataset.get('shuffle_seed'),
-        num_canonical_nodes=cfg.dataset.get('num_canonical_nodes'),
+        num_canonical_nodes=cfg.dataset.get('num_canonical_nodes', 128),
         batch_size=device_batch_size)
 
     if dataset.tokenizer.pad_token is None:  # type: ignore
@@ -637,8 +637,8 @@ def _get_max_starting_length(max_length: int, mask_ratio: float,
         total_inp_tokens, total_targ_tokens = sequence_stats(length)
         if decoder_only_format:
             return (total_inp_tokens + total_targ_tokens) <= max_length
-        return (total_inp_tokens <= max_length) and (total_targ_tokens <=
-                                                     max_length)
+        return (total_inp_tokens <= max_length) and (total_targ_tokens
+                                                     <= max_length)
 
     # Start with a definitely too-long sequence and reduce until it fits
     num_raw_tokens = max_length * 2

--- a/llmfoundry/icl_eval/evaluate_model.py
+++ b/llmfoundry/icl_eval/evaluate_model.py
@@ -12,7 +12,8 @@ from composer.utils import reproducibility
 from omegaconf import DictConfig
 from omegaconf import OmegaConf as om
 
-from llmfoundry.common.builders import build_icl_evaluators, build_logger, build_tokenizer
+from llmfoundry.common.builders import (build_icl_evaluators, build_logger,
+                                        build_tokenizer)
 from llmfoundry.model_registry import COMPOSER_MODEL_REGISTRY
 
 if __name__ == '__main__':

--- a/llmfoundry/icl_eval/evaluate_model.py
+++ b/llmfoundry/icl_eval/evaluate_model.py
@@ -12,7 +12,7 @@ from composer.utils import reproducibility
 from omegaconf import DictConfig
 from omegaconf import OmegaConf as om
 
-from llmfoundry.common.builders import build_icl_evaluators, build_logger
+from llmfoundry.common.builders import build_icl_evaluators, build_logger, build_tokenizer
 from llmfoundry.model_registry import COMPOSER_MODEL_REGISTRY
 
 if __name__ == '__main__':
@@ -24,10 +24,14 @@ if __name__ == '__main__':
 
     reproducibility.seed_all(cfg.get('seed', 1234))
 
+    # Build tokenizer and model
+    tokenizer = build_tokenizer(cfg.tokenizer)
     composer_model = COMPOSER_MODEL_REGISTRY[cfg.model.name](cfg.model,
-                                                             cfg.tokenizer)
-    evaluators, logger_keys = build_icl_evaluators(cfg,
-                                                   composer_model.tokenizer)
+                                                             tokenizer)
+
+    evaluators, logger_keys = build_icl_evaluators(cfg.icl_tasks, tokenizer,
+                                                   cfg.max_seq_len,
+                                                   cfg.device_eval_batch_size)
 
     in_memory_logger = InMemoryLogger()  # track metrics in the in_memory_logger
     loggers: List[LoggerDestination] = [

--- a/llmfoundry/icl_eval/yamls/gpt_neo_eval.yaml
+++ b/llmfoundry/icl_eval/yamls/gpt_neo_eval.yaml
@@ -1,8 +1,10 @@
+max_seq_len: 2048
+
 # Tokenizer
 tokenizer:
   name: gpt2
   kwargs:
-    model_max_length: 2048
+    model_max_length: ${max_seq_len}
 
 model:
   name: hf_causal_lm
@@ -12,33 +14,19 @@ model:
 
 load_path: # Add your (optional) Composer checkpoint path here!
 
+device_eval_batch_size: 16
+
 # FSDP config for model sharding
 # fsdp_config:
 #   sharding_strategy: FULL_SHARD
 #   mixed_precision: PURE
 
 icl_tasks:
--
-  label: piqa
+- label: piqa
   dataset_uri: # ADD YOUR OWN DATASET URI
-  num_fewshot:
-  - 5
-  batch_size: 16
+  num_fewshot: [5]
   icl_task_type: multiple_choice
-  metric_names:
-  - InContextLearningMultipleChoiceAccuracy
-  prompt_string: '' # this goes at the beginning of each input
-  example_delimiter: '\n' # this goes between fewshot examples
-  continuation_delimiter: ' ' # this separates questions from answers
--
-  label: lambada
+- label: lambada
   dataset_uri: # ADD YOUR OWN DATASET URI
-  num_fewshot:
-  - 0
-  batch_size: 16
+  num_fewshot: [0]
   icl_task_type: language_modeling
-  metric_names:
-  - InContextLearningLMAccuracy
-  prompt_string: '' # this goes at the beginning of each input
-  example_delimiter: '\n' # this goes between fewshot examples
-  continuation_delimiter: ' ' # this separates contexts from continuations

--- a/llmfoundry/icl_eval/yamls/mosaic_gpt_eval.yaml
+++ b/llmfoundry/icl_eval/yamls/mosaic_gpt_eval.yaml
@@ -21,6 +21,8 @@ model:
 
 load_path: # Add your (optional) Composer checkpoint path here!
 
+device_eval_batch_size: 16
+
 # FSDP config for model sharding
 # fsdp_config:
 #   sharding_strategy: FULL_SHARD
@@ -30,24 +32,10 @@ icl_tasks:
 -
   label: piqa
   dataset_uri: # ADD YOUR OWN DATASET URI
-  num_fewshot:
-  - 5
-  batch_size: 16
+  num_fewshot: [5]
   icl_task_type: multiple_choice
-  metric_names:
-  - InContextLearningMultipleChoiceAccuracy
-  prompt_string: '' # this goes at the beginning of each input
-  example_delimiter: '\n' # this goes between fewshot examples
-  continuation_delimiter: ' ' # this separates questions from answers
 -
   label: lambada
   dataset_uri: # ADD YOUR OWN DATASET URI
-  num_fewshot:
-  - 0
-  batch_size: 16
+  num_fewshot: [0]
   icl_task_type: language_modeling
-  metric_names:
-  - InContextLearningLMAccuracy
-  prompt_string: '' # this goes at the beginning of each input
-  example_delimiter: '\n' # this goes between fewshot examples
-  continuation_delimiter: ' ' # this separates contexts from continuations

--- a/llmfoundry/main.py
+++ b/llmfoundry/main.py
@@ -101,7 +101,7 @@ def main(cfg):
         f'torch.distributed.*_base is a private function and will be deprecated.*'
     )
 
-    cfg.dist_timeout = cfg.get('dist_timeout', 1800.0)
+    cfg.dist_timeout = cfg.get('dist_timeout', 600.0)
 
     reproducibility.seed_all(cfg.seed)
     dist.initialize_dist(get_device(None), timeout=cfg.dist_timeout)
@@ -157,7 +157,7 @@ def main(cfg):
         evaluators.append(eval_loader)
 
     if 'icl_tasks' in cfg:
-        icl_evaluators, _ = build_icl_evaluators(cfg, tokenizer)
+        icl_evaluators, _ = build_icl_evaluators(cfg, tokenizer, cfg.device_eval_batch_size)
         evaluators.extend(icl_evaluators)
 
     # Optimizer

--- a/llmfoundry/main.py
+++ b/llmfoundry/main.py
@@ -157,7 +157,9 @@ def main(cfg):
         evaluators.append(eval_loader)
 
     if 'icl_tasks' in cfg:
-        icl_evaluators, _ = build_icl_evaluators(cfg, tokenizer, cfg.device_eval_batch_size)
+        icl_evaluators, _ = build_icl_evaluators(cfg.icl_tasks, tokenizer,
+                                                 cfg.max_seq_len,
+                                                 cfg.device_eval_batch_size)
         evaluators.extend(icl_evaluators)
 
     # Optimizer

--- a/llmfoundry/mcloud/mcli-1b-eval.yaml
+++ b/llmfoundry/mcloud/mcli-1b-eval.yaml
@@ -41,31 +41,21 @@ parameters:
 
   load_path: # Add your (optional) Composer checkpoint path here!
 
+  device_eval_batch_size: 16
+
   # FSDP config for model sharding
-  fsdp_config:
-    sharding_strategy: FULL_SHARD
-    mixed_precision: PURE
+  # fsdp_config:
+  #   sharding_strategy: FULL_SHARD
+  #   mixed_precision: PURE
 
   icl_tasks:
-  - label: piqa
+  -
+    label: piqa
     dataset_uri: # ADD YOUR OWN DATASET URI
-    num_fewshot:
-    - 5
-    batch_size: 16
+    num_fewshot: [5]
     icl_task_type: multiple_choice
-    metric_names:
-    - InContextLearningMultipleChoiceAccuracy
-    prompt_string: '' # this goes at the beginning of each input
-    example_delimiter: '\n' # this goes between fewshot examples
-    continuation_delimiter: ' ' # this separates questions from answers
-  - label: lambada
+  -
+    label: lambada
     dataset_uri: # ADD YOUR OWN DATASET URI
-    num_fewshot:
-    - 0
-    batch_size: 16
+    num_fewshot: [0]
     icl_task_type: language_modeling
-    metric_names:
-    - InContextLearningLMAccuracy
-    prompt_string: '' # this goes at the beginning of each input
-    example_delimiter: '\n' # this goes between fewshot examples
-    continuation_delimiter: ' ' # this separates contexts from continuations


### PR DESCRIPTION
Now you can specify like:

```yaml
icl_tasks:
- label: piqa
  dataset_uri: ./icl_eval/piqa.jsonl
  num_fewshot: [0, 1, 5]
  icl_task_type: multiple_choice
```

and it will default the rest based on the `icl_task_type`. You can still override everything.

@bmosaicml just FYI as I know you are working on #9 .