### PR TITLE
Add LLaMa and MPT HFCausalLM support

### DIFF
--- a/llmfoundry/models/hf/hf_causal_lm.py
+++ b/llmfoundry/models/hf/hf_causal_lm.py
@@ -49,7 +49,7 @@ class ComposerHFCausalLM(HuggingFaceModelWithZLoss):
         config = AutoConfig.from_pretrained(
             om_model_config.pretrained_model_name_or_path,
             trust_remote_code=om_model_config.get('trust_remote_code', True),
-            use_auth_token=om_model_config.get('use_auth_token', True),
+            use_auth_token=om_model_config.get('use_auth_token', False),
             **om_model_config.get('config_overrides', {}))
 
         train_metrics = [
@@ -73,7 +73,7 @@ class ComposerHFCausalLM(HuggingFaceModelWithZLoss):
                     om_model_config.pretrained_model_name_or_path,
                     trust_remote_code=om_model_config.get(
                         'trust_remote_code', True),
-                    use_auth_token=om_model_config.get('use_auth_token', True),
+                    use_auth_token=om_model_config.get('use_auth_token', False),
                     config=config)
             else:
                 model = AutoModelForCausalLM.from_config(config)

--- a/llmfoundry/models/hf/hf_causal_lm.py
+++ b/llmfoundry/models/hf/hf_causal_lm.py
@@ -48,6 +48,8 @@ class ComposerHFCausalLM(HuggingFaceModelWithZLoss):
     def __init__(self, om_model_config: DictConfig, tokenizer: Tokenizer):
         config = AutoConfig.from_pretrained(
             om_model_config.pretrained_model_name_or_path,
+            trust_remote_code=om_model_config.get('trust_remote_code', True),
+            use_auth_token=om_model_config.get('use_auth_token', True),
             **om_model_config.get('config_overrides', {}))
 
         train_metrics = [
@@ -69,6 +71,9 @@ class ComposerHFCausalLM(HuggingFaceModelWithZLoss):
             if om_model_config.pretrained:
                 model = AutoModelForCausalLM.from_pretrained(
                     om_model_config.pretrained_model_name_or_path,
+                    trust_remote_code=om_model_config.get(
+                        'trust_remote_code', True),
+                    use_auth_token=om_model_config.get('use_auth_token', True),
                     config=config)
             else:
                 model = AutoModelForCausalLM.from_config(config)

--- a/llmfoundry/models/hf/hf_fsdp.py
+++ b/llmfoundry/models/hf/hf_fsdp.py
@@ -55,12 +55,17 @@ def findattr(obj: Any, attrs: Iterable[str]):
 def hf_get_causal_base_model(model: PreTrainedModel):
     """Returns the causal decoder backbone of the specified HuggingFace model.
 
+    Newer HF models have a `self.get_decoder()` method. Older models do not.
+
     NOTE: Different model configurations have different causal decoder attribute
     names.
         - transformer: (GPT2LMHeadModel, GPTJConfig)
         - model.decoder: (OPTConfig, BloomConfig)
         - gpt_neox: (GPTNeoXConfig)
     """
+    if hasattr(model, 'get_decoder'):
+        return model.get_decoder()
+
     decoder_attrs = ('transformer', 'model.decoder', 'gpt_neox')
     return findattr(model, decoder_attrs)
 
@@ -72,6 +77,7 @@ def hf_get_hidden_layers(model: PreTrainedModel):
         - transformer.h: (BloomForCausalLM, GPT2LMHeadModel, GPTJForCausalLM)
         - model.decoder.layers: (OPTForCausalLM)
         - gpt_neox.layers: (GPTNeoXForCausalLM)
+        - model.layers: (LLaMaForCausalLM)
     """
     hidden_layers_attrs = (
         'transformer.h',
@@ -79,6 +85,7 @@ def hf_get_hidden_layers(model: PreTrainedModel):
         'gpt_neox.layers',
         'block',  # T5, BART, Pegasus (from encoder)
         'layers',  # ProphetNet, Marian (from encoder)
+        'model.layers'  # LLaMa
     )
     return findattr(model, hidden_layers_attrs)
 

--- a/llmfoundry/models/hf/hf_fsdp.py
+++ b/llmfoundry/models/hf/hf_fsdp.py
@@ -78,14 +78,17 @@ def hf_get_hidden_layers(model: PreTrainedModel):
         - model.decoder.layers: (OPTForCausalLM)
         - gpt_neox.layers: (GPTNeoXForCausalLM)
         - model.layers: (LLaMaForCausalLM)
+        - transformer.blocks: (MPTForCausalLM)
     """
+    print(model)
     hidden_layers_attrs = (
-        'transformer.h',
-        'model.decoder.layers',
-        'gpt_neox.layers',
+        'transformer.h',  # BOOM, GPT2, GPTJ
+        'model.decoder.layers',  # OPT
+        'gpt_neox.layers',  # GPTNeoX
         'block',  # T5, BART, Pegasus (from encoder)
         'layers',  # ProphetNet, Marian (from encoder)
-        'model.layers'  # LLaMa
+        'model.layers',  # LLaMa
+        'transformer.blocks',  # MPT
     )
     return findattr(model, hidden_layers_attrs)
 

--- a/llmfoundry/models/hf/hf_fsdp.py
+++ b/llmfoundry/models/hf/hf_fsdp.py
@@ -81,7 +81,7 @@ def hf_get_hidden_layers(model: PreTrainedModel):
         - transformer.blocks: (MPTForCausalLM)
     """
     hidden_layers_attrs = (
-        'transformer.h',  # BOOM, GPT2, GPTJ
+        'transformer.h',  # BLOOM, GPT2, GPTJ
         'model.decoder.layers',  # OPT
         'gpt_neox.layers',  # GPTNeoX
         'block',  # T5, BART, Pegasus (from encoder)

--- a/llmfoundry/models/hf/hf_fsdp.py
+++ b/llmfoundry/models/hf/hf_fsdp.py
@@ -80,7 +80,6 @@ def hf_get_hidden_layers(model: PreTrainedModel):
         - model.layers: (LLaMaForCausalLM)
         - transformer.blocks: (MPTForCausalLM)
     """
-    print(model)
     hidden_layers_attrs = (
         'transformer.h',  # BOOM, GPT2, GPTJ
         'model.decoder.layers',  # OPT

--- a/llmfoundry/utils/builders.py
+++ b/llmfoundry/utils/builders.py
@@ -212,8 +212,6 @@ def build_icl_evaluators(icl_tasks,
             metric_names = list(icl_cfg.metric_names)
             # TODO: fix Composer bug when copying local paths and destination exists
             destination_path = f'{destination_dir}/{icl_cfg.label}-{num_fewshot}.jsonl'
-            # if os.path.exists(destination_path):
-            #     os.remove(destination_path)
             dataloaders = get_icl_task_dataloader(
                 icl_cfg.icl_task_type,
                 icl_cfg.dataset_uri,

--- a/llmfoundry/utils/builders.py
+++ b/llmfoundry/utils/builders.py
@@ -9,6 +9,7 @@ from composer.callbacks import (HealthChecker, LRMonitor, MemoryMonitor,
                                 OptimizerMonitor, RuntimeEstimator,
                                 SpeedMonitor)
 from composer.core import Evaluator
+from composer.utils import dist
 from composer.datasets.in_context_learning_evaluation import \
     get_icl_task_dataloader
 from composer.loggers import WandBLogger
@@ -212,6 +213,9 @@ def build_icl_evaluators(icl_tasks,
             metric_names = list(icl_cfg.metric_names)
             # TODO: fix Composer bug when copying local paths and destination exists
             destination_path = f'{destination_dir}/{icl_cfg.label}-{num_fewshot}.jsonl'
+            with dist.run_local_rank_zero_first():
+                if os.path.exists(destination_path):
+                    os.remove(destination_path)
             dataloaders = get_icl_task_dataloader(
                 icl_cfg.icl_task_type,
                 icl_cfg.dataset_uri,

--- a/llmfoundry/utils/builders.py
+++ b/llmfoundry/utils/builders.py
@@ -212,8 +212,8 @@ def build_icl_evaluators(icl_tasks,
             metric_names = list(icl_cfg.metric_names)
             # TODO: fix Composer bug when copying local paths and destination exists
             destination_path = f'{destination_dir}/{icl_cfg.label}-{num_fewshot}.jsonl'
-            if os.path.exists(destination_path):
-                os.remove(destination_path)
+            # if os.path.exists(destination_path):
+            #     os.remove(destination_path)
             dataloaders = get_icl_task_dataloader(
                 icl_cfg.icl_task_type,
                 icl_cfg.dataset_uri,

--- a/llmfoundry/utils/builders.py
+++ b/llmfoundry/utils/builders.py
@@ -9,7 +9,6 @@ from composer.callbacks import (HealthChecker, LRMonitor, MemoryMonitor,
                                 OptimizerMonitor, RuntimeEstimator,
                                 SpeedMonitor)
 from composer.core import Evaluator
-from composer.utils import dist
 from composer.datasets.in_context_learning_evaluation import \
     get_icl_task_dataloader
 from composer.loggers import WandBLogger
@@ -17,6 +16,7 @@ from composer.optim import DecoupledAdamW
 from composer.optim.scheduler import (ConstantWithWarmupScheduler,
                                       CosineAnnealingWithWarmupScheduler,
                                       LinearWithWarmupScheduler)
+from composer.utils import dist
 from omegaconf import DictConfig
 from omegaconf import OmegaConf as om
 from transformers import (AutoTokenizer, PreTrainedTokenizer,

--- a/scripts/eval/yamls/gpt_neo_eval.yaml
+++ b/scripts/eval/yamls/gpt_neo_eval.yaml
@@ -11,7 +11,7 @@ tokenizer:
 model:
   name: hf_causal_lm
   pretrained_model_name_or_path: ${model_name_or_path}
-  device: cpu
+  init_device: cpu
   pretrained: true
 
 load_path: # Add your (optional) Composer checkpoint path here!


### PR DESCRIPTION
This uses the new `get_decoder()` feature. But to get the blocks, I still had to hardcode some layer names.