### PR TITLE
Update inference benchmarking script

### DIFF
--- a/scripts/inference/benchmarking/README.md
+++ b/scripts/inference/benchmarking/README.md
@@ -2,13 +2,13 @@
 This folder provides scripts for benchmarking the inference performance of deep learning models. Currently, we support benchmarking with Deepspeed and Huggingface generate.
 
 ## Scripts
-The repository includes the benchmark.py script, along with associated `.yaml files,` to run benchmarking. The script takes a `.yaml` file as input and outputs the latency (in seconds) and tokens per second for each run. We average over `num_runs=5`, which is defined in the `.yaml` file. Additionally, we iterate over various `batch_sizes`, `input_lengths`, and `output_lengths` to produce varying throughput metrics.
+The repository includes the benchmark.py script, along with associated `.yaml files,` to run benchmarking. The script takes a `.yaml` file as input and outputs the latency (in seconds) and tokens per second for each run. We average over `num_batches=5`, which is defined in the `.yaml` file. Additionally, we iterate over various `batch_sizes`, `input_lengths`, and `output_lengths` to produce varying throughput metrics.
 
 ## Usage
 To use the `benchmark.py` script, you need to provide a `.yaml` file that specifies the model configuration and other parameters such as the path to the model checkpoint and the input data. You can modify the default `.yaml` files provided in the repository or create your own `.yaml` file.
 
 To run the benchmarking script, use the following command:
 
-`python benchmark.py config.yaml`
+`python benchmark.py yamls/1b.yaml`
 
 To run the scripts on [The MosaicML platform](https://www.mosaicml.com/blog/mosaicml-cloud-demo) we've also included scripts and associated `.yaml files` in the `mcloud` folder.

--- a/scripts/inference/benchmarking/benchmark.py
+++ b/scripts/inference/benchmarking/benchmark.py
@@ -97,7 +97,7 @@ def main(config):
 
                 start_time = 0
                 for i in range(config.num_batches + config.num_warmup_batches):
-                    if i >= config.num_warmup_batches:
+                    if i == config.num_warmup_batches:
                         torch.cuda.synchronize()
                         start_time = time.time()
                     with torch.no_grad():

--- a/scripts/inference/benchmarking/benchmark.py
+++ b/scripts/inference/benchmarking/benchmark.py
@@ -112,17 +112,19 @@ def main(config):
 
                 num_output_tokens = output_length * batch_size
                 tokens_per_second = num_output_tokens / mean_time
-                ms_per_seq_output_token = mean_time * 1000 / num_output_tokens
+                ms_per_seq_output_token = mean_time * 1000 / output_length
+                ms_per_output_token = mean_time * 1000 / num_output_tokens
 
                 result = (
                     f'{config.benchmark_name}_{batch_size}_{input_length}_{output_length}',
                     f'{mean_time:.3f}', f'{tokens_per_second:.3f}',
-                    f'{ms_per_seq_output_token:.3f}')
+                    f'{ms_per_seq_output_token:.3f}',
+                    f'{ms_per_output_token:.3f}')
 
                 run_name, latency, tokens_per_second, ms_per_seq_output_token = result
 
                 print(
-                    f'{run_name}, {latency}, {tokens_per_second}, {ms_per_seq_output_token}'
+                    f'{run_name}, {latency}, {tokens_per_second}, {ms_per_seq_output_token}, {ms_per_output_token}'
                 )
 
                 stats.append(result)

--- a/scripts/inference/benchmarking/benchmark.py
+++ b/scripts/inference/benchmarking/benchmark.py
@@ -37,8 +37,8 @@ def main(config):
         device = config.device
     else:
         device = 'cuda:0' if torch.cuda.is_available() else 'cpu'
-
     model_dtype = get_dtype(config.model_dtype)
+    print(f'Using device={device} and dtype={model_dtype}...')
 
     if config.autocast_dtype is not None:
         autocast_dtype = get_dtype(config.autocast_dtype)

--- a/scripts/inference/benchmarking/benchmark.py
+++ b/scripts/inference/benchmarking/benchmark.py
@@ -116,7 +116,7 @@ def main(config):
                 tokens_per_second = num_output_tokens / mean_time
                 ms_per_seq_output_token = mean_time * 1000 / output_length
 
-                run_name = f'{config.benchmark_name}_{batch_size}_{input_length}_{output_length}',
+                run_name = f'{config.benchmark_name}_{batch_size}_{input_length}_{output_length}'
                 print(
                     f'{run_name}, {mean_time:.3f}, {tokens_per_second:.3f}, {ms_per_seq_output_token:.3f}'
                 )

--- a/scripts/inference/benchmarking/yamls/1b.yaml
+++ b/scripts/inference/benchmarking/yamls/1b.yaml
@@ -8,7 +8,6 @@ tokenizer:
   name: ${tokenizer_name}
   kwargs:
     model_max_length: ${max_seq_len}
-  non_eos_token_id: 17
 
 model:
   name: mpt_causal_lm
@@ -27,14 +26,14 @@ model:
   attn_config:
     attn_impl: triton
 
-autocast_precision: bf16
 model_dtype: bf16
+autocast_dtype: null
 
 batch_sizes: [1, 2, 4, 8, 16, 32, 64]
 input_lengths: [128]
 output_lengths: [8]
-num_runs: 5
+use_cache: true
 
+num_batches: 5
 num_warmup_batches: 3
-
 use_deepspeed: false

--- a/scripts/inference/benchmarking/yamls/1b.yaml
+++ b/scripts/inference/benchmarking/yamls/1b.yaml
@@ -26,8 +26,10 @@ model:
   attn_config:
     attn_impl: triton
 
+device: null
 model_dtype: bf16
 autocast_dtype: null
+use_deepspeed: false
 
 batch_sizes: [1, 2, 4, 8, 16, 32, 64]
 input_lengths: [128]
@@ -36,4 +38,3 @@ use_cache: true
 
 num_batches: 5
 num_warmup_batches: 3
-use_deepspeed: false

--- a/scripts/inference/benchmarking/yamls/7b.yaml
+++ b/scripts/inference/benchmarking/yamls/7b.yaml
@@ -26,8 +26,10 @@ model:
   attn_config:
     attn_impl: triton
 
+device: null
 model_dtype: bf16
 autocast_dtype: null
+use_deepspeed: false
 
 batch_sizes: [1, 2, 4, 8, 16, 32, 64]
 input_lengths: [128]
@@ -36,4 +38,3 @@ use_cache: true
 
 num_batches: 5
 num_warmup_batches: 3
-use_deepspeed: false

--- a/scripts/inference/benchmarking/yamls/7b.yaml
+++ b/scripts/inference/benchmarking/yamls/7b.yaml
@@ -8,7 +8,6 @@ tokenizer:
   name: ${tokenizer_name}
   kwargs:
     model_max_length: ${max_seq_len}
-  non_eos_token_id: 17
 
 model:
   name: mpt_causal_lm
@@ -27,14 +26,14 @@ model:
   attn_config:
     attn_impl: triton
 
-autocast_precision: bf16
-model_dtype: fp32
+model_dtype: bf16
+autocast_dtype: null
 
 batch_sizes: [1, 2, 4, 8, 16, 32, 64]
 input_lengths: [128]
 output_lengths: [8]
-num_runs: 5
+use_cache: true
 
+num_batches: 5
 num_warmup_batches: 3
-
 use_deepspeed: false

--- a/scripts/inference/hf_chat.py
+++ b/scripts/inference/hf_chat.py
@@ -10,7 +10,6 @@ from typing import Any, Dict, Tuple, Union
 import torch
 from transformers import (AutoConfig, AutoModelForCausalLM, AutoTokenizer,
                           PreTrainedTokenizer, PreTrainedTokenizerFast)
-from contextlib import nullcontext
 
 Tokenizer = Union[PreTrainedTokenizer, PreTrainedTokenizerFast]
 

--- a/scripts/inference/hf_chat.py
+++ b/scripts/inference/hf_chat.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, Tuple, Union
 import torch
 from transformers import (AutoConfig, AutoModelForCausalLM, AutoTokenizer,
                           PreTrainedTokenizer, PreTrainedTokenizerFast)
+from contextlib import nullcontext
 
 Tokenizer = Union[PreTrainedTokenizer, PreTrainedTokenizerFast]
 


### PR DESCRIPTION
This PR:
* standardizes some config names
* simplifies the logic for profiling and warmup
* adds an option for `use_cache`
* corrects the calculation for `ms_per_seq_output_token`, this is the latency per sequence-level token, not the latency per batch token