### PR TITLE
Updates to prefixlm and t5

### DIFF
--- a/llmfoundry/models/hf/hf_causal_lm.py
+++ b/llmfoundry/models/hf/hf_causal_lm.py
@@ -39,10 +39,7 @@ class ComposerHFCausalLM(HuggingFaceModelWithZLoss):
             cfg.init_device ('cpu' | 'meta'): Which device, 'cpu' or 'meta', to
                 initialize the model on. Currently, `meta` is only supported when
                 cfg.pretrained is ``False``. Default: ``'cpu'``.
-            cfg.add_exact_match (bool, optional): CURRENTLY UNUSED. Whether to add ExactMatch metric used
-                in some fine-tuning settings. Default: ``False``.
-            cfg.add_rouge (bool, optional): CURRENTLY UNUSED. Whether to add RougeWithDetokenizer metric
-                to validation metrics. Default: ``False``.
+        tokenizer (PreTrainedTokenizer): The tokenizer that the model will use.
     """
 
     def __init__(self, om_model_config: DictConfig, tokenizer: Tokenizer):
@@ -88,18 +85,11 @@ class ComposerHFCausalLM(HuggingFaceModelWithZLoss):
             raise ValueError(
                 f'init_device="{init_device}" must be either "cpu" or "meta".')
 
-        # if cfg.add_exact_match:
-        #     metrics.append(ExactMatch(ignore_index=_HF_IGNORE_INDEX))
-
         composer_model = super().__init__(model=model,
                                           tokenizer=tokenizer,
                                           metrics=train_metrics,
                                           eval_metrics=eval_metrics,
                                           z_loss=om_model_config.get(
                                               'z_loss', 0.0))
-
-        # if cfg.add_rouge:
-        #     rouge_metric = RougeWithDetokenizer(detokenizer=tokenizer)
-        #     composer_model.val_metrics[RougeWithDetokenizer.__name__] = rouge_metric
 
         return composer_model

--- a/llmfoundry/models/hf/hf_prefix_lm.py
+++ b/llmfoundry/models/hf/hf_prefix_lm.py
@@ -5,18 +5,22 @@
 
 from __future__ import annotations
 
+from typing import Union
+
 from composer.metrics.nlp import LanguageCrossEntropy, MaskedAccuracy
 from omegaconf import DictConfig
-from omegaconf import OmegaConf as om
-from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
+from transformers import (AutoConfig, AutoModelForCausalLM, PreTrainedTokenizer,
+                          PreTrainedTokenizerFast)
 
 from llmfoundry.models.hf.model_wrapper import HuggingFaceModelWithZLoss
-from llmfoundry.models.utils import (AutoTokenizerForMOD,
+from llmfoundry.models.utils import (adapt_tokenizer_for_denoising,
                                      add_bidirectional_mask_if_missing,
                                      convert_hf_causal_lm_to_prefix_lm,
                                      init_empty_weights)
 
 __all__ = ['ComposerHFPrefixLM']
+
+Tokenizer = Union[PreTrainedTokenizer, PreTrainedTokenizerFast]
 
 # HuggingFace hardcodes the ignore index to -100
 _HF_IGNORE_INDEX = -100
@@ -59,37 +63,18 @@ class ComposerHFPrefixLM(HuggingFaceModelWithZLoss):
                 checkpoint that was trained on such a task, set this to ``True`` to ensure
                 that the model vocab size matches your checkpoint's vocab size when loading
                 the weights. Default: ``False``.
-            cfg.add_exact_match (bool, optional): CURRENTLY UNUSED. Whether to add ExactMatch metric used
-                in some fine-tuning settings. Default: ``False``.
-            cfg.add_rouge (bool, optional): CURRENTLY UNUSED. Whether to add RougeWithDetokenizer metric
-                to validation metrics. Default: ``False``.
+        tokenizer (PreTrainedTokenizer): The tokenizer that the model will use.
     """
 
-    def __init__(self, om_model_config: DictConfig,
-                 om_tokenizer_config: DictConfig):
+    def __init__(self, om_model_config: DictConfig, tokenizer: Tokenizer):
         config = AutoConfig.from_pretrained(
             om_model_config.pretrained_model_name_or_path,
             **om_model_config.get('config_overrides', {}))
 
         # Set up the tokenizer (add tokens for denoising sentinels if needed)
         if om_model_config.get('adapt_vocab_for_denoising', False):
-            resolved_om_tokenizer_config = om.to_container(om_tokenizer_config,
-                                                           resolve=True)
-            tokenizer_kwargs = resolved_om_tokenizer_config.get(  # type: ignore
-                'kwargs', {})
-            tokenizer_name = resolved_om_tokenizer_config[  # type: ignore
-                'name']
-            tokenizer = AutoTokenizerForMOD.from_pretrained(
-                tokenizer_name, **tokenizer_kwargs)
-        else:
-            resolved_om_tokenizer_config = om.to_container(om_tokenizer_config,
-                                                           resolve=True)
-            tokenizer_kwargs = resolved_om_tokenizer_config.get(  # type: ignore
-                'kwargs', {})
-            tokenizer_name = resolved_om_tokenizer_config[  # type: ignore
-                'name']
-            tokenizer = AutoTokenizer.from_pretrained(tokenizer_name,
-                                                      **tokenizer_kwargs)
+            adapt_tokenizer_for_denoising(tokenizer)
+
         vocab_size = len(tokenizer)
 
         init_device = om_model_config.get('init_device', 'cpu')
@@ -120,18 +105,11 @@ class ComposerHFPrefixLM(HuggingFaceModelWithZLoss):
             MaskedAccuracy(ignore_index=_HF_IGNORE_INDEX)
         ]
 
-        # if cfg.add_exact_match:
-        #     metrics.append(ExactMatch(ignore_index=_HF_IGNORE_INDEX))
-
         composer_model = super().__init__(model=model,
                                           tokenizer=tokenizer,
                                           metrics=metrics,
                                           z_loss=om_model_config.get(
                                               'z_loss', 0.0))
-
-        # if cfg.add_rouge:
-        #     rouge_metric = RougeWithDetokenizer(detokenizer=tokenizer)
-        #     composer_model.val_metrics[RougeWithDetokenizer.__name__] = rouge_metric
 
         return composer_model
 

--- a/scripts/train/yamls/hf_t5/t5-small_dolly_sft.yaml
+++ b/scripts/train/yamls/hf_t5/t5-small_dolly_sft.yaml
@@ -1,0 +1,105 @@
+max_seq_len: 1024
+global_seed: 17
+model_name: t5-small
+
+# Run Name
+run_name: # If left blank, will be read from env var $COMPOSER_RUN_NAME
+
+# Model
+model:
+  name: hf_t5
+  pretrained_model_name_or_path: ${model_name}
+  device: cpu
+  pretrained: true
+
+# Tokenizer
+tokenizer:
+  name: ${model_name}
+
+# Dataloaders
+train_loader:
+  name: finetuning
+  dataset:
+    hf_name: HuggingFaceH4/databricks_dolly_15k
+    split: train
+    max_seq_len: ${max_seq_len}
+    allow_pad_trimming: false
+    decoder_only_format: false
+    shuffle: true
+  drop_last: true
+  num_workers: 8
+  pin_memory: false
+  prefetch_factor: 2
+  persistent_workers: true
+  timeout: 0
+
+# There is no validation split so we skip eval_loader
+
+# Optimization
+scheduler:
+  name: linear_decay_with_warmup # linear no warmup is HF default which dolly used
+  t_warmup: 0ba
+  alpha_f: 0
+
+optimizer:
+  # mimic HF defaults to replicate dolly
+  name: decoupled_adamw
+  lr: 1.0e-5
+  betas:
+  - 0.9
+  - 0.999
+  eps: 1.0e-8
+  weight_decay: 0
+
+algorithms:
+  gradient_clipping:
+    clipping_type: norm
+    clipping_threshold: 1.0
+
+max_duration: 1ep
+eval_interval: 1 # this is the only allowed value for no eval
+# eval_first: false
+# eval_subset_num_batches: -1
+global_train_batch_size: 64 # assuming 8 gpus
+
+# System
+seed: ${global_seed}
+device_eval_batch_size: 8
+device_train_microbatch_size: 8
+# device_train_microbatch_size: auto
+precision: amp_bf16
+
+# FSDP
+fsdp_config:
+  sharding_strategy: FULL_SHARD
+  mixed_precision: PURE
+  activation_checkpointing: true
+  activation_checkpointing_reentrant: false
+  activation_cpu_offload: false
+  limit_all_gathers: true
+  verbose: false
+
+# Logging
+progress_bar: false
+log_to_console: true
+console_log_interval: 1ba
+
+callbacks:
+  speed_monitor:
+    window_size: 10
+  lr_monitor: {}
+  memory_monitor: {}
+  runtime_estimator: {}
+
+# loggers:
+#   wandb: {}
+
+# Checkpoint to local filesystem or remote object store
+# save_interval: 5000ba
+# save_num_checkpoints_to_keep: 1  # Important, this cleans up checkpoints saved to DISK
+# save_folder: ./{run_name}/checkpoints
+# save_folder: s3://my-bucket/my-folder/{run_name}/checkpoints
+
+# Load from remote object store
+# REPLACE THE BELOW with you own checkpoint!
+# load_path: oci://my-bucket/my-folder/mpt-7b/checkpoints/some_checkpoint.pt

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -22,6 +22,7 @@ from llmfoundry import (COMPOSER_MODEL_REGISTRY, ComposerHFCausalLM,
                         ComposerHFPrefixLM)
 from llmfoundry.models.layers import NORM_CLASS_REGISTRY, build_alibi_bias
 from llmfoundry.models.mpt import MPTConfig, MPTForCausalLM
+from llmfoundry.utils import build_tokenizer
 
 
 def get_config(conf_path='scripts/train/yamls/mpt/testing.yaml') -> DictConfig:
@@ -205,8 +206,10 @@ def test_full_forward_and_backward_gpt2_small(prefixlm, batch_size=2):
     else:
         neo_cfg.model.name = 'hf_causal_lm'
 
-    model = COMPOSER_MODEL_REGISTRY[neo_cfg.model.name](
-        neo_cfg.model, neo_cfg.tokenizer).to(device)
+    tokenizer = build_tokenizer(neo_cfg.tokenizer)
+
+    model = COMPOSER_MODEL_REGISTRY[neo_cfg.model.name](neo_cfg.model,
+                                                        tokenizer).to(device)
 
     assert neo_cfg.optimizer.name == 'decoupled_adamw'
     optimizer = DecoupledAdamW(model.parameters(),
@@ -235,42 +238,31 @@ def test_full_forward_and_backward_t5_small(batch_size=2):
     warnings.filterwarnings(
         action='ignore',
         message='Torchmetrics v0.9 introduced a new argument class property')
-    from omegaconf import OmegaConf
-
-    cfg = OmegaConf.create({
-        'model': {
-            'pretrained_model_name_or_path': 't5-small',
-            'pretrained': False,
-            'z_loss': 0.0001,
-        },
-        'optimizer': {
-            'lr': 0.0001,
-            'betas': [0.9, 0.99],
-            'eps': 1e-6,
-            'weight_decay': 0.00001
-        },
-        'tokenizer': {
-            'name': 't5-small',
-        }
-    })
+    conf_path = 'scripts/train/yamls/hf_t5/t5-small_dolly_sft.yaml'
+    with open(conf_path) as f:
+        t5_cfg = om.load(f)
 
     device = 'cpu'
-    max_seq_len = 16
+    t5_cfg.device = device
+    t5_cfg.max_seq_len = 16
 
-    model = COMPOSER_MODEL_REGISTRY['hf_t5'](cfg.model,
-                                             cfg.tokenizer).to(device)
+    tokenizer = build_tokenizer(t5_cfg.tokenizer)
+
+    model = COMPOSER_MODEL_REGISTRY[t5_cfg.model.name](t5_cfg.model,
+                                                       tokenizer).to(device)
 
     optimizer = DecoupledAdamW(model.parameters(),
-                               lr=cfg.optimizer.lr,
-                               betas=cfg.optimizer.betas,
-                               eps=cfg.optimizer.eps,
-                               weight_decay=cfg.optimizer.weight_decay)
+                               lr=t5_cfg.optimizer.lr,
+                               betas=t5_cfg.optimizer.betas,
+                               eps=t5_cfg.optimizer.eps,
+                               weight_decay=t5_cfg.optimizer.weight_decay)
 
     # set vocab size using model num_embeddings
     batch = gen_random_enc_dec_batch(batch_size, model.model.config.vocab_size,
-                                     max_seq_len, device)
+                                     t5_cfg.max_seq_len, device)
 
-    assert batch['input_ids'].shape == torch.Size([batch_size, max_seq_len])
+    assert batch['input_ids'].shape == torch.Size(
+        [batch_size, t5_cfg.max_seq_len])
     model.train()
     original_params = next(model.parameters()).clone().data
     outputs = model(batch)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -15,6 +15,7 @@ from composer.optim import DecoupledAdamW
 from composer.utils import get_device, reproducibility
 from omegaconf import DictConfig
 from omegaconf import OmegaConf as om
+from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast
 from transformers.modeling_outputs import CausalLMOutputWithPast
 from transformers.models.bloom.modeling_bloom import build_alibi_tensor
 
@@ -211,6 +212,9 @@ def test_full_forward_and_backward_gpt2_small(prefixlm, batch_size=2):
     model = COMPOSER_MODEL_REGISTRY[neo_cfg.model.name](neo_cfg.model,
                                                         tokenizer).to(device)
 
+    assert isinstance(model.tokenizer,
+                      (PreTrainedTokenizer, PreTrainedTokenizerFast))
+
     assert neo_cfg.optimizer.name == 'decoupled_adamw'
     optimizer = DecoupledAdamW(model.parameters(),
                                lr=neo_cfg.optimizer.lr,
@@ -250,6 +254,9 @@ def test_full_forward_and_backward_t5_small(batch_size=2):
 
     model = COMPOSER_MODEL_REGISTRY[t5_cfg.model.name](t5_cfg.model,
                                                        tokenizer).to(device)
+
+    assert isinstance(model.tokenizer,
+                      (PreTrainedTokenizer, PreTrainedTokenizerFast))
 
     optimizer = DecoupledAdamW(model.parameters(),
                                lr=t5_cfg.optimizer.lr,


### PR DESCRIPTION
Some of our past updates didn't reach the prefixlm or t5 model classes. This resolves that and updates the tests that missed this.

Adds a t5-small example YAML for dolly IFT, which runs locally on CPU w/:
`composer train.py yamls/hf_t5/t5-small_dolly_sft.yaml global_train_batch_size=2 device_eval_batch_size=2 device_train_microbatch_size=2 precision=fp32 fsdp_config=null`