### PR TITLE
Remove xentropy from pypi

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,8 +35,8 @@ jobs:
         # Remove the xentropy-cuda-lib dependency as PyPI does not support direct installs. The
         # error message for importing FusedCrossEntropy gives instructions on how to install if a
         # user tries to use it without this dependency.
-        sed '/xentropy-cuda-lib@git+https:\/\/github.com\/HazyResearch\/flash-attention.git@v0.2.8#subdirectory=csrc\/xentropy/d' -i setup.py
-        
+        sed '/xentropy-cuda-lib@git+https:\/\/github.com\/HazyResearch\/flash-attention.git@v0.2.8#subdirectory=csrc\/xentropy/d' -i setup.py  # yamllint disable-line rule:line-length
+
         python -m pip install --upgrade build twine
         python -m build
         twine check --strict dist/*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
         # Remove the xentropy-cuda-lib dependency as PyPI does not support direct installs. The
         # error message for importing FusedCrossEntropy gives instructions on how to install if a
         # user tries to use it without this dependency.
-        sed '/xentropy-cuda-lib@git+https:\/\/github.com\/HazyResearch\/flash-attention.git@.*#subdirectory=csrc\/xentropy/d' -i setup.py  # yamllint disable-line rule:line-length
+        sed '/xentropy-cuda-lib@git+https:\/\/github.com\/HazyResearch\/flash-attention.git@.*' -i setup.py
 
         python -m pip install --upgrade build twine
         python -m build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,6 +32,11 @@ jobs:
           PYPI_PACKAGE_NAME="llm-foundry-test-$(date +%Y%m%d%H%M%S)"
         fi
 
+        # Remove the xentropy-cuda-lib dependency as PyPI does not support direct installs. The
+        # error message for importing FusedCrossEntropy gives instructions on how to install if a
+        # user tries to use it without this dependency.
+        sed '/xentropy-cuda-lib@git+https:\/\/github.com\/HazyResearch\/flash-attention.git@v0.2.8#subdirectory=csrc\/xentropy/d' -i setup.py
+        
         python -m pip install --upgrade build twine
         python -m build
         twine check --strict dist/*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
         # Remove the xentropy-cuda-lib dependency as PyPI does not support direct installs. The
         # error message for importing FusedCrossEntropy gives instructions on how to install if a
         # user tries to use it without this dependency.
-        sed '/xentropy-cuda-lib@git+https:\/\/github.com\/HazyResearch\/flash-attention.git@v0.2.8#subdirectory=csrc\/xentropy/d' -i setup.py  # yamllint disable-line rule:line-length
+        sed '/xentropy-cuda-lib@git+https:\/\/github.com\/HazyResearch\/flash-attention.git@.*#subdirectory=csrc\/xentropy/d' -i setup.py  # yamllint disable-line rule:line-length
 
         python -m pip install --upgrade build twine
         python -m build

--- a/llmfoundry/models/mpt/modeling_mpt.py
+++ b/llmfoundry/models/mpt/modeling_mpt.py
@@ -622,7 +622,9 @@ class ComposerMPTCausalLM(HuggingFaceModel):
                 self.loss_fn = FusedCrossEntropyLoss(ignore_index=-100)
             except:
                 raise ValueError(
-                    'Fused Cross Entropy is not installed. Either (1) have a CUDA-compatible GPU and `pip install .[gpu]`, or (2) set your config model.loss_fn=torch_crossentropy.'
+                    'Fused Cross Entropy is not installed. Either (1) have a CUDA-compatible GPU '
+                    'and `pip install .[gpu]` if installing from source or `pip install xentropy-cuda-lib@git+https://github.com/HazyResearch/flash-attention.git@v0.2.8#subdirectory=csrc/xentropy` '
+                    'if installing from pypi, or (2) set your config model.loss_fn=torch_crossentropy.'
                 )
         elif loss_fn_config == 'torch_crossentropy':
             self.loss_fn = nn.CrossEntropyLoss(ignore_index=-100)

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ extra_deps['dev'] = [
 extra_deps['gpu'] = [
     'flash-attn==v1.0.3.post0',
     'triton==2.0.0.dev20221202',
+    # PyPI does not support direct dependencies, so we remove this line before uploading from PyPI
     'xentropy-cuda-lib@git+https://github.com/HazyResearch/flash-attention.git@v0.2.8#subdirectory=csrc/xentropy',
 ]
 


### PR DESCRIPTION
Removes xentropy from setup.py for pypi so we can release. Otherwise, pypi blocks direct dependencies. Uses sed to slice out the xentropy line:
```
diff --git a/setup.py b/setup.py
index 11d47de..992e795 100644
--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,6 @@ extra_deps['dev'] = [
 extra_deps['gpu'] = [
     'flash-attn==v1.0.3.post0',
     'triton==2.0.0.dev20221202',
-    'xentropy-cuda-lib@git+https://github.com/HazyResearch/flash-attention.git@v0.2.8#subdirectory=csrc/xentropy',
 ]
```

Also updates error to give a more clear description of what's wrong