### PR TITLE
Fix sed command for xentropy

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
         # Remove the xentropy-cuda-lib dependency as PyPI does not support direct installs. The
         # error message for importing FusedCrossEntropy gives instructions on how to install if a
         # user tries to use it without this dependency.
-        sed '/xentropy-cuda-lib@git+https:\/\/github.com\/HazyResearch\/flash-attention.git@.*' -i setup.py
+        sed '/xentropy-cuda-lib@git+https:\/\/github.com\/HazyResearch\/flash-attention.git@.*/d' -i setup.py
 
         python -m pip install --upgrade build twine
         python -m build


### PR DESCRIPTION
I accidentally removed the closer when editing the regex to filter all versions as requested by nikhil. PR fixes this. Manual test:

<img width="1316" alt="image" src="https://github.com/mosaicml/llm-foundry/assets/17102158/e8f83e7f-f7d1-4bf8-b330-d3d5331c1df9">
