### PR TITLE
Add minimum `mosaicml-streaming` version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ classifiers = [
 ]
 
 install_requires = [
-    'composer[nlp,streaming,wandb]>=0.14.1,<0.15',
+    'composer[nlp,wandb]>=0.14.1,<0.15',
     'mosaicml-streaming>=0.4.1,<0.5',
     'torch==1.13.1',
     'datasets==2.10.1',

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,8 @@ classifiers = [
 ]
 
 install_requires = [
-    'mosaicml[nlp,streaming,wandb]>=0.14.1,<0.15',
+    'composer[nlp,streaming,wandb]>=0.14.1,<0.15',
+    'mosaicml-streaming>=0.4.1,<0.5',
     'torch==1.13.1',
     'datasets==2.10.1',
     'sentencepiece==0.1.97',


### PR DESCRIPTION
Our current requirements are `mosaicml[streaming,nlp,wandb]>0.14`, but the composer library itself has no minimum streaming requirement (`mosaicml-streaming<1`). This PR adds a `mosaicml-streaming>=0.4.1` minimum requirement since we use the `Streams` functionality introduced in 0.4.0. 

Fixes: #106 