### PR TITLE
Set pad_token_id to tokenizer.pad_token_id if not set on command line

### DIFF
--- a/scripts/inference/hf_chat.py
+++ b/scripts/inference/hf_chat.py
@@ -240,7 +240,7 @@ def main(args: Namespace) -> None:
         'use_cache': args.use_cache,
         'do_sample': args.do_sample,
         'eos_token_id': args.eos_token_id or tokenizer.eos_token_id,
-        'pad_token_id': args.pad_token_id,
+        'pad_token_id': args.pad_token_id or tokenizer.eos_token_id,
     }
     # Autocast
     if args.autocast_dtype is not None:


### PR DESCRIPTION
The hf_chat.py program emits this warning message before each chat response:

The attention mask and the pad token id were not set. As a consequence, you may observe unexpected behavior. Please pass your input's `attention_mask` to obtain reliable results.
Setting `pad_token_id` to `eos_token_id`:0 for open-end generation.

Fixed by setting pad_token_id to tokenizer.eos_token_id if not set on the command line.
