### PR TITLE
Kv cache speed

### DIFF
--- a/llmfoundry/models/layers/attention.py
+++ b/llmfoundry/models/layers/attention.py
@@ -89,8 +89,7 @@ def scaled_multihead_dot_product_attention(
         attn_weight = attn_weight.masked_fill(
             ~key_padding_mask.view((b, 1, 1, s_k)), min_val)
 
-    reset_is_causal = _reset_is_causal(query.size(1), key.size(1), is_causal)
-    if reset_is_causal:
+    if is_causal and (not q.size(2) == 1):
         s = max(s_q, s_k)
         causal_mask = attn_weight.new_ones(s, s, dtype=torch.float16)
         causal_mask = causal_mask.tril()

--- a/llmfoundry/models/layers/attention.py
+++ b/llmfoundry/models/layers/attention.py
@@ -57,10 +57,10 @@ def scaled_multihead_dot_product_attention(
 
     if past_key_value is not None:
         if len(past_key_value) != 0:
-            k = torch.cat([past_key_value[0], k.clone().detach()], dim=3)
-            v = torch.cat([past_key_value[1], v.clone().detach()], dim=2)
+            k = torch.cat([past_key_value[0], k], dim=3)
+            v = torch.cat([past_key_value[1], v], dim=2)
 
-        past_key_value = (k.clone().detach(), v.clone().detach())
+        past_key_value = (k, v)
 
     b, _, s_q, d = q.shape
     s_k = k.size(-1)

--- a/llmfoundry/models/layers/attention.py
+++ b/llmfoundry/models/layers/attention.py
@@ -394,7 +394,7 @@ class MultiheadAttention(nn.Module):
         if self.clip_qkv:
             qkv.clamp_(min=-self.clip_qkv, max=self.clip_qkv)
 
-        query, key, value = torch.chunk(qkv, 3, dim=2)
+        query, key, value = qkv.chunk(3, dim=2)
 
         key_padding_mask = attention_mask
 

--- a/llmfoundry/models/layers/blocks.py
+++ b/llmfoundry/models/layers/blocks.py
@@ -92,13 +92,15 @@ class MPTBlock(nn.Module):
         is_causal: bool = True,
     ) -> Tuple[torch.Tensor, Optional[Tuple[torch.Tensor]]]:
         a = self.norm_1(x)
-        b, _, past_key_value = self.attn(a,
-                                         past_key_value=past_key_value,
-                                         attn_bias=attn_bias,
-                                         attention_mask=attention_mask,
-                                         is_causal=is_causal)
+        b, attn_weights, past_key_value = self.attn(
+            a,
+            past_key_value=past_key_value,
+            attn_bias=attn_bias,
+            attention_mask=attention_mask,
+            is_causal=is_causal,
+        )
         x = x + self.resid_attn_dropout(b)
         m = self.norm_2(x)
         n = self.ffn(m)
         x = x + self.resid_ffn_dropout(n)
-        return x, past_key_value
+        return x, attn_weights, past_key_value

--- a/llmfoundry/models/mpt/modeling_mpt.py
+++ b/llmfoundry/models/mpt/modeling_mpt.py
@@ -197,7 +197,9 @@ class MPTModel(MPTPreTrainedModel):
                                         device=device,
                                         dtype=dtype)
             else:
-                attn_bias = attn_bias[:, :, :, -s_k:]
+                # clamp to 0 necessary for torch 2.0 compile()
+                _s_k = max(0, attn_bias.size(-1) - s_k)
+                attn_bias = attn_bias[:, :, :, _s_k:]
             if prefix_mask is not None and (attention_mask.shape !=
                                             prefix_mask.shape):
                 raise ValueError(

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -863,19 +863,21 @@ def test_forward_with_cache_and_padding(alibi):
                                rtol=1e-6)
 
 
-@pytest.mark.parametrize('attention_impl,device', [('torch', 'cpu'),
-                                                   ('flash', 'gpu'),
-                                                   ('triton', 'gpu'),
-                                                   ('torch', 'gpu')])
+@pytest.mark.parametrize('attn_impl,device', [
+    ('torch', 'cpu'),
+    ('flash', 'gpu'),
+    ('triton', 'gpu'),
+    ('torch', 'gpu'),
+])
 @pytest.mark.parametrize('alibi', [True, False])
-def test_forward_with_cache(attention_impl, device, alibi):
+def test_forward_with_cache(attn_impl, device, alibi):
     # Test that model forward with and without the key-value cache produces the
     # same output.
     if not torch.cuda.is_available() and device == 'gpu':
         pytest.skip(
-            f'This test requires CUDA to be available in order to run with {attention_impl} attention.'
+            f'This test requires CUDA to be available in order to run with {attn_impl} attention.'
         )
-    if alibi and attention_impl == 'flash':
+    if alibi and attn_impl == 'flash':
         pytest.skip(f'alibi only implemented with torch and triton attention.')
 
     device = get_device(device)
@@ -890,10 +892,10 @@ def test_forward_with_cache(attention_impl, device, alibi):
         emb_pdrop=0.1,
         resid_pdrop=0.2,
         attn_config={
-            'attn_impl': attention_impl,
+            'attn_impl': attn_impl,
             'alibi': alibi,
         },
-        attn_impl=attention_impl,
+        attn_impl=attn_impl,
         alibi=alibi,
         use_cache=True,
         init_config={
@@ -903,8 +905,8 @@ def test_forward_with_cache(attention_impl, device, alibi):
     )
     reproducibility.seed_all(1234)
     mpt = MPTForCausalLM(hf_config)
-    mpt.eval()
     mpt = device.module_to_device(mpt)
+    mpt.eval()
 
     with get_precision_context('amp_bf16' if device.name == 'gpu' else 'fp32'):
         reproducibility.seed_all(1234)
@@ -917,14 +919,20 @@ def test_forward_with_cache(attention_impl, device, alibi):
         first_output = mpt(first_input_ids, attention_mask=first_attention_mask)
 
         assert first_output.logits.shape == (1, 3, hf_config.vocab_size)
-        # assert len(first_output.past_key_values) == 2
-        # assert all(
-        #     len(past_key_value) == 2
-        #     for past_key_value in first_output.past_key_values)
-        # assert all(past_key_value[0].shape == (1, 3, 128)
-        #            for past_key_value in first_output.past_key_values)
-        # assert all(past_key_value[1].shape == (1, 3, 128)
-        #            for past_key_value in first_output.past_key_values)
+        assert len(first_output.past_key_values) == hf_config.n_layers
+        assert all(
+            len(past_key_value) == 2
+            for past_key_value in first_output.past_key_values)
+        if attn_impl == 'torch':
+            assert all(past_key_value[0].shape == (1, 4, 32, 3)
+                       for past_key_value in first_output.past_key_values)
+            assert all(past_key_value[1].shape == (1, 4, 3, 32)
+                       for past_key_value in first_output.past_key_values)
+        else:
+            assert all(past_key_value[0].shape == (1, 3, 128)
+                       for past_key_value in first_output.past_key_values)
+            assert all(past_key_value[1].shape == (1, 3, 128)
+                       for past_key_value in first_output.past_key_values)
 
         reproducibility.seed_all(1234)
         second_input_ids = torch.tensor([[11274, 16390, 11, 11274]])
@@ -933,19 +941,27 @@ def test_forward_with_cache(attention_impl, device, alibi):
         second_attention_mask = device.tensor_to_device(second_attention_mask)
 
         # pass through the fourth token by itself, using the key-value cache
-        second_output = mpt(second_input_ids[:, -1].unsqueeze(-1),
-                            attention_mask=second_attention_mask,
-                            past_key_values=first_output.past_key_values)
+        second_output = mpt(
+            second_input_ids[:, -1].unsqueeze(-1),
+            past_key_values=first_output.past_key_values,
+            attention_mask=second_attention_mask,
+        )
 
         assert second_output.logits.shape == (1, 1, hf_config.vocab_size)
-        # assert len(second_output.past_key_values) == 2
-        # assert all(
-        #     len(past_key_value) == 2
-        #     for past_key_value in second_output.past_key_values)
-        # assert all(past_key_value[0].shape == (1, 4, 128)
-        #            for past_key_value in second_output.past_key_values)
-        # assert all(past_key_value[1].shape == (1, 4, 128)
-        #            for past_key_value in second_output.past_key_values)
+        assert len(second_output.past_key_values) == hf_config.n_layers
+        assert all(
+            len(past_key_value) == 2
+            for past_key_value in second_output.past_key_values)
+        if attn_impl == 'torch':
+            assert all(past_key_value[0].shape == (1, 4, 32, 4)
+                       for past_key_value in second_output.past_key_values)
+            assert all(past_key_value[1].shape == (1, 4, 4, 32)
+                       for past_key_value in second_output.past_key_values)
+        else:
+            assert all(past_key_value[0].shape == (1, 4, 128)
+                       for past_key_value in second_output.past_key_values)
+            assert all(past_key_value[1].shape == (1, 4, 128)
+                       for past_key_value in second_output.past_key_values)
 
         reproducibility.seed_all(1234)
         # pass through the first four tokens without the key-value cache

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -917,14 +917,14 @@ def test_forward_with_cache(attention_impl, device, alibi):
         first_output = mpt(first_input_ids, attention_mask=first_attention_mask)
 
         assert first_output.logits.shape == (1, 3, hf_config.vocab_size)
-        assert len(first_output.past_key_values) == 2
-        assert all(
-            len(past_key_value) == 2
-            for past_key_value in first_output.past_key_values)
-        assert all(past_key_value[0].shape == (1, 3, 128)
-                   for past_key_value in first_output.past_key_values)
-        assert all(past_key_value[1].shape == (1, 3, 128)
-                   for past_key_value in first_output.past_key_values)
+        # assert len(first_output.past_key_values) == 2
+        # assert all(
+        #     len(past_key_value) == 2
+        #     for past_key_value in first_output.past_key_values)
+        # assert all(past_key_value[0].shape == (1, 3, 128)
+        #            for past_key_value in first_output.past_key_values)
+        # assert all(past_key_value[1].shape == (1, 3, 128)
+        #            for past_key_value in first_output.past_key_values)
 
         reproducibility.seed_all(1234)
         second_input_ids = torch.tensor([[11274, 16390, 11, 11274]])
@@ -938,14 +938,14 @@ def test_forward_with_cache(attention_impl, device, alibi):
                             past_key_values=first_output.past_key_values)
 
         assert second_output.logits.shape == (1, 1, hf_config.vocab_size)
-        assert len(second_output.past_key_values) == 2
-        assert all(
-            len(past_key_value) == 2
-            for past_key_value in second_output.past_key_values)
-        assert all(past_key_value[0].shape == (1, 4, 128)
-                   for past_key_value in second_output.past_key_values)
-        assert all(past_key_value[1].shape == (1, 4, 128)
-                   for past_key_value in second_output.past_key_values)
+        # assert len(second_output.past_key_values) == 2
+        # assert all(
+        #     len(past_key_value) == 2
+        #     for past_key_value in second_output.past_key_values)
+        # assert all(past_key_value[0].shape == (1, 4, 128)
+        #            for past_key_value in second_output.past_key_values)
+        # assert all(past_key_value[1].shape == (1, 4, 128)
+        #            for past_key_value in second_output.past_key_values)
 
         reproducibility.seed_all(1234)
         # pass through the first four tokens without the key-value cache


### PR DESCRIPTION
There are rearranges (reshape and transpose) that happen [here](https://github.com/mosaicml/llm-foundry/blob/main/llmfoundry/models/layers/attention.py#L47)

you can kv cache before or after the transposes
if you do it before, then the entire cache needs to be transposed instead of just a seq len 1 tensor.
we do it before 🤦‍♂️ 

this PR makes it happen after
\+ some random style things.

Note: this only affects `attn_impl: torch`; triton and flash expect input shape: `[b, s, h, d_head]`


This PR also
- makes some code style changes
- fixes bug with `output_hidden_states` where the last state wasn't output (cc @dakinggg)
  - in [hf docs](https://huggingface.co/docs/transformers/main_classes/output#transformers.modeling_outputs.BaseModelOutputWithPast) its noted that last hidden state should be part of hidden states as well
- enable `output_attentions` if using `attn_impl: torch` (cc @samhavens)


# Results
Using the `llm-foundry/scripts/inference/benchmarking/benchmark.py` script with `yamls/1b.yaml` updating
```
model:
  attn_config:
    attn_impl: torch

model_dtype: bf16
autocast_dtype: bf16

batch_sizes: [1]
input_lengths: [3072]
output_lengths: [1, 11, 101]
```

we get:

```
name, latency (s), throughput (tokens/s), latency_per_sequence_output_token (ms)

============================== MAIN =============================================

MosaicDeepspeed_1xA100-80GB-bf16-GPT-1B_1_128_1, 0.015, 68.862, 14.522
MosaicDeepspeed_1xA100-80GB-bf16-GPT-1B_1_128_11, 0.156, 70.695, 14.145
MosaicDeepspeed_1xA100-80GB-bf16-GPT-1B_1_128_101, 1.443, 69.989, 14.288

MosaicDeepspeed_1xA100-80GB-bf16-GPT-1B_1_3072_1, 0.182, 5.489, 182.167
MosaicDeepspeed_1xA100-80GB-bf16-GPT-1B_1_3072_11, 0.328, 33.494, 29.857
MosaicDeepspeed_1xA100-80GB-bf16-GPT-1B_1_3072_101, 1.629, 61.994, 16.131

============================== This Branch =============================================

MosaicDeepspeed_1xA100-80GB-bf16-GPT-1B_1_128_1, 0.014, 69.881, 14.310
MosaicDeepspeed_1xA100-80GB-bf16-GPT-1B_1_128_11, 0.136, 80.677, 12.395
MosaicDeepspeed_1xA100-80GB-bf16-GPT-1B_1_128_101, 1.235, 81.767, 12.230

MosaicDeepspeed_1xA100-80GB-bf16-GPT-1B_1_3072_1, 0.182, 5.498, 181.882
MosaicDeepspeed_1xA100-80GB-bf16-GPT-1B_1_3072_11, 0.304, 36.217, 27.611
MosaicDeepspeed_1xA100-80GB-bf16-GPT-1B_1_3072_101, 1.393, 72.526, 13.788
```

We see that this new code path helps with torch inference speed when using kv-cache.