### PR TITLE
Fixing benchmark mcli example with proper path and image

### DIFF
--- a/mcli/mcli-benchmark-mpt.yaml
+++ b/mcli/mcli-benchmark-mpt.yaml
@@ -1,21 +1,13 @@
 run_name: deepspeed-inference
 gpu_num: 8
 cluster: r0z0 # Update with your cluster here!
-image: mosaicml/composer:0.13.4
+image: mosaicml/pytorch:1.13.1_cu117-python3.10-ubuntu20.04
 integrations:
 - integration_type: git_repo
   git_repo: mosaicml/llm-foundry
   pip_install: '.[gpu]'
-- integration_type: git_repo
-  git_repo: mosaicml/composer
-  # 0.13.4 doesn't have the right HF changes rn
-  # So this is the current commit hash as of 04/17/2023
-  # We will remove this install when we have a release
-  # with the appropriate changes.
-  git_commit: 20fb86b476d91749528a989265c3e211eb1d774d
-  pip_install: '.[all]'
 
 command: |
-  cd llm-foundry/llm/inference/benchmarking/
+  cd llm-foundry/scripts/inference/benchmarking
 
   python benchmark.py yamls/1b.yaml


### PR DESCRIPTION
The LLM-foundry benchmark script is out-of-date. Tested by running `mcli run -f mcli-benchmark-mpt.yaml` successfully