### PR TITLE
Removing deprecated vocabulary size parameter from composer CE metrics

### DIFF
--- a/llmfoundry/models/hf/hf_causal_lm.py
+++ b/llmfoundry/models/hf/hf_causal_lm.py
@@ -71,12 +71,12 @@ class ComposerHFCausalLM(HuggingFaceModelWithZLoss):
                 setattr(config, k, v)
 
         train_metrics = [
-            LanguageCrossEntropy(len(tokenizer)),
-            LanguagePerplexity(len(tokenizer)),
+            LanguageCrossEntropy(),
+            LanguagePerplexity(),
         ]
         eval_metrics = [
-            LanguageCrossEntropy(len(tokenizer)),
-            LanguagePerplexity(len(tokenizer)),
+            LanguageCrossEntropy(),
+            LanguagePerplexity(),
             InContextLearningLMAccuracy(),
             InContextLearningMultipleChoiceAccuracy(),
             InContextLearningQAAccuracy(),

--- a/llmfoundry/models/hf/hf_prefix_lm.py
+++ b/llmfoundry/models/hf/hf_prefix_lm.py
@@ -121,8 +121,7 @@ class ComposerHFPrefixLM(HuggingFaceModelWithZLoss):
         model = convert_hf_causal_lm_to_prefix_lm(model)
 
         metrics = [
-            LanguageCrossEntropy(vocab_size=vocab_size,
-                                 ignore_index=_HF_IGNORE_INDEX),
+            LanguageCrossEntropy(ignore_index=_HF_IGNORE_INDEX),
             MaskedAccuracy(ignore_index=_HF_IGNORE_INDEX)
         ]
 

--- a/llmfoundry/models/hf/hf_t5.py
+++ b/llmfoundry/models/hf/hf_t5.py
@@ -111,8 +111,7 @@ class ComposerHFT5(HuggingFaceModelWithZLoss):
                 f'init_device="{init_device}" must be either "cpu" or "meta".')
 
         metrics = [
-            LanguageCrossEntropy(vocab_size=vocab_size,
-                                 ignore_index=_HF_IGNORE_INDEX),
+            LanguageCrossEntropy(ignore_index=_HF_IGNORE_INDEX),
             MaskedAccuracy(ignore_index=_HF_IGNORE_INDEX)
         ]
 

--- a/llmfoundry/models/mpt/modeling_mpt.py
+++ b/llmfoundry/models/mpt/modeling_mpt.py
@@ -593,12 +593,12 @@ class ComposerMPTCausalLM(HuggingFaceModel):
         model = MPTForCausalLM(hf_config)
 
         train_metrics = [
-            LanguageCrossEntropy(hf_config.vocab_size),
-            LanguagePerplexity(hf_config.vocab_size)
+            LanguageCrossEntropy(),
+            LanguagePerplexity()
         ]
         eval_metrics = [
-            LanguageCrossEntropy(hf_config.vocab_size),
-            LanguagePerplexity(hf_config.vocab_size),
+            LanguageCrossEntropy(),
+            LanguagePerplexity(),
             InContextLearningLMAccuracy(),
             InContextLearningMultipleChoiceAccuracy(),
             InContextLearningQAAccuracy(),

--- a/llmfoundry/models/mpt/modeling_mpt.py
+++ b/llmfoundry/models/mpt/modeling_mpt.py
@@ -592,10 +592,7 @@ class ComposerMPTCausalLM(HuggingFaceModel):
         hf_config = MPTConfig.from_dict(resolved_om_model_config)
         model = MPTForCausalLM(hf_config)
 
-        train_metrics = [
-            LanguageCrossEntropy(),
-            LanguagePerplexity()
-        ]
+        train_metrics = [LanguageCrossEntropy(), LanguagePerplexity()]
         eval_metrics = [
             LanguageCrossEntropy(),
             LanguagePerplexity(),


### PR DESCRIPTION
Vocabulary size being passed into the NLP metrics has been deprecated in latest composer.