### PR TITLE
Add support for `device_map`

### DIFF
--- a/llmfoundry/models/mpt/modeling_mpt.py
+++ b/llmfoundry/models/mpt/modeling_mpt.py
@@ -483,7 +483,9 @@ class MPTForCausalLM(MPTPreTrainedModel):
                                    output_hidden_states=output_hidden_states,
                                    use_cache=use_cache)
 
-        logits = F.linear(outputs.last_hidden_state,
+        # move outputs to same device as weights for token embedding
+        # needed to support HF `device_map`
+        logits = F.linear(outputs.last_hidden_state.to(self.transformer.wte.weight.device),
                           self.transformer.wte.weight)
 
         if self.logit_scale is not None:

--- a/llmfoundry/models/mpt/modeling_mpt.py
+++ b/llmfoundry/models/mpt/modeling_mpt.py
@@ -53,6 +53,7 @@ Tokenizer = Union[PreTrainedTokenizer, PreTrainedTokenizerFast]
 class MPTPreTrainedModel(PreTrainedModel):
     config_class = MPTConfig
     base_model_prefix = 'model'
+    _no_split_modules = ['MPTBlock']
 
 
 class MPTModel(MPTPreTrainedModel):

--- a/llmfoundry/models/mpt/modeling_mpt.py
+++ b/llmfoundry/models/mpt/modeling_mpt.py
@@ -513,8 +513,9 @@ class MPTForCausalLM(MPTPreTrainedModel):
 
         # move outputs to same device as weights for token embedding
         # needed to support HF `device_map`
-        logits = F.linear(outputs.last_hidden_state.to(self.transformer.wte.weight.device),
-                          self.transformer.wte.weight)
+        logits = F.linear(
+            outputs.last_hidden_state.to(self.transformer.wte.weight.device),
+            self.transformer.wte.weight)
 
         if self.logit_scale is not None:
             if self.logit_scale == 0:

--- a/scripts/inference/README.md
+++ b/scripts/inference/README.md
@@ -101,6 +101,8 @@ output_tok_per_sec=292.03tok/sec
 
 The argument for `--name_or_path` can be either the name of a model that exists on the HF Hub, such as `gpt2`, `facebook/opt-350m`, etc. or the path to a HF checkpoint folder, such as `my_hf_model/` like we exported above.
 
+For MPT models specifically, you can pass args like `--init_device cuda:0`, `--attn_impl triton`, and `--max_seq_len 4096` to speed up generation time or alter the max generation length at inference time (thanks to ALiBi).
+
 ## Interactive Chat with HF models
 
 Chat models need to pass conversation history back to the model for multi-turn conversations. To make that easier, we include `hf_chat.py`. Chat models usually require an introductory/system prompt, as well as a wrapper around user and model messages, to fit the training format. Default values work with our ChatML-trained models, but you can specify these values with CLI args:

--- a/scripts/inference/hf_chat.py
+++ b/scripts/inference/hf_chat.py
@@ -106,6 +106,7 @@ def parse_args() -> Namespace:
     parser.add_argument('--revision', type=str, default=None)
     parser.add_argument('--device', type=str, default=None)
     parser.add_argument('--attn_impl', type=str, default=None)
+    parser.add_argument('--init_device', type=str, default=None)
     parser.add_argument('--seed', type=int, default=42)
     parser.add_argument('--system_prompt', type=str, default=SYSTEM_PROMPT)
     parser.add_argument('--user_msg_fmt', type=str, default=USER_MSG_FMT)
@@ -184,6 +185,8 @@ def main(args: Namespace) -> None:
                                             **from_pretrained_kwargs)
         if args.attn_impl is not None and hasattr(config, 'attn_config'):
             config.attn_config['attn_impl'] = args.attn_impl
+        if args.init_device is not None and hasattr(config, 'init_device'):
+            config.init_device = args.init_device
         if args.max_seq_len is not None and hasattr(config, 'max_seq_len'):
             config.max_seq_len = args.max_seq_len
 

--- a/scripts/inference/hf_generate.py
+++ b/scripts/inference/hf_generate.py
@@ -120,6 +120,7 @@ def parse_args() -> Namespace:
     parser.add_argument('--revision', type=str, default=None)
     parser.add_argument('--device', type=str, default=None)
     parser.add_argument('--attn_impl', type=str, default=None)
+    parser.add_argument('--init_device', type=str, default=None)
     # TODO
     # parser.add_argument('--fsdp',
     #                     type=str2bool,
@@ -169,6 +170,8 @@ def main(args: Namespace) -> None:
     try:
         config = AutoConfig.from_pretrained(args.name_or_path,
                                             **from_pretrained_kwargs)
+        if args.init_device is not None and hasattr(config, 'init_device'):
+            config.init_device = args.init_device
         if args.attn_impl is not None and hasattr(config, 'attn_config'):
             config.attn_config['attn_impl'] = args.attn_impl
         if args.max_seq_len is not None and hasattr(config, 'max_seq_len'):

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ extra_deps['dev'] = [
     'pyright==1.1.296',
     'toml>=0.10.2,<0.11',
     'packaging>=21,<23',
+    'accelerate>=0.19,<0.20',
 ]
 
 extra_deps['tensorboard'] = [

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -755,7 +755,8 @@ def test_generate(attention_impl, device, alibi):
 
 @pytest.mark.gpu
 @pytest.mark.parametrize('world_size', [1, 2])
-def test_generate_with_device_map(tmp_path, world_size):
+@pytest.mark.parametrize('use_cache', [False, True])
+def test_generate_with_device_map(tmp_path, world_size, use_cache):
     if not torch.cuda.is_available():
         pytest.skip(f'This test requires CUDA to be available.')
     if not torch.cuda.device_count() >= world_size:
@@ -774,6 +775,7 @@ def test_generate_with_device_map(tmp_path, world_size):
         attn_config={
             'attn_impl': 'torch',
         },
+        use_cache=use_cache,
     )
     mpt = MPTForCausalLM(hf_config)
     mpt.save_pretrained(save_path)
@@ -804,7 +806,6 @@ def test_generate_with_device_map(tmp_path, world_size):
         max_length=10,
         do_sample=True,
     )
-    print(out)
 
 
 def check_hf_model_equivalence(model1, model2):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -758,7 +758,7 @@ def test_generate(attention_impl, device, alibi):
 def test_generate_with_device_map(tmp_path, world_size):
     if not torch.cuda.is_available():
         pytest.skip(f'This test requires CUDA to be available.')
-    if not torch.cuda.device_count() == world_size:
+    if not torch.cuda.device_count() >= world_size:
         pytest.skip(f'This test requires {world_size} GPUs.')
 
     save_path = tmp_path / 'test-device-map'

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -796,14 +796,12 @@ def test_generate_with_device_map(tmp_path, world_size):
         model=save_path,
         tokenizer=tokenizer,
         torch_dtype=torch.bfloat16,
-        trust_remote_code=True,
         device_map=device_map,
     )
     out = pipe(
         'The quick fox jumped over',
-        max_length=19,
+        max_length=10,
         do_sample=True,
-        top_k=10,
     )
     print(out)
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -796,6 +796,7 @@ def test_generate_with_device_map(tmp_path, world_size):
         model=save_path,
         tokenizer=tokenizer,
         torch_dtype=torch.bfloat16,
+        trust_remote_code=True,
         device_map=device_map,
     )
     out = pipe(


### PR DESCRIPTION
Based on community requests and PRs, adding these few lines should enable support for Accelerate's device map for multi-GPU inference (via naive pipelining)

After this is tested and merged, we should upgrade the `modeling_mpt.py` files on HF Hub for our 3 models.