### PR TITLE
Change mcli eval YAMLs to use `mixed_precision: FULL`

### DIFF
--- a/mcli/mcli-1b-eval.yaml
+++ b/mcli/mcli-1b-eval.yaml
@@ -44,6 +44,7 @@ parameters:
   load_path: # Add your (optional) Composer checkpoint path here!
 
   device_eval_batch_size: 16
+  precision: fp32
 
   # FSDP config for model sharding
   # fsdp_config:

--- a/mcli/mcli-1b-eval.yaml
+++ b/mcli/mcli-1b-eval.yaml
@@ -48,7 +48,7 @@ parameters:
   # FSDP config for model sharding
   # fsdp_config:
   #   sharding_strategy: FULL_SHARD
-  #   mixed_precision: PURE
+  #   mixed_precision: FULL
 
   icl_tasks:
   -

--- a/mcli/mcli-hf-eval.yaml
+++ b/mcli/mcli-hf-eval.yaml
@@ -24,6 +24,7 @@ parameters:
   seed: 1
   max_seq_len: 1024
   device_eval_batch_size: 8
+  precision: fp32
 
   model_name_or_path: huggyllama/llama-7b
   # model_name_or_path: EleutherAI/gpt-j-6b

--- a/mcli/mcli-hf-eval.yaml
+++ b/mcli/mcli-hf-eval.yaml
@@ -52,6 +52,6 @@ parameters:
   # FSDP config for model sharding
   fsdp_config:
     sharding_strategy: FULL_SHARD
-    mixed_precision: PURE
+    mixed_precision: FULL
 
   icl_tasks: 'eval/yamls/tasks.yaml'


### PR DESCRIPTION
We have been seeing some inconsistency with MPT-7B eval with FSDP `mixed_precision: PURE` but everything is fine with `mixed_precision: FULL`. While we debug this, we should set the default values in our example YAMLs to `mixed_precision: FULL`.