### PR TITLE
updt tritonpremlir to sm90 version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ install_requires = [
     'onnxruntime==1.14.1',
     'cmake>=3.25.0,<=3.26.3',  # required for triton-pre-mlir below
     # PyPI does not support direct dependencies, so we remove this line before uploading from PyPI
-    'triton-pre-mlir@git+https://github.com/vchiley/triton.git@triton_pre_mlir#subdirectory=python',
+    'triton-pre-mlir@git+https://github.com/vchiley/triton.git@triton_pre_mlir_sm90#subdirectory=python',
 ]
 
 extra_deps = {}


### PR DESCRIPTION
details [here](https://github.com/vchiley/triton/pull/2)

New branch of triton_pre_mlir still works on A100s and in my (limited) testing worked on H100s.