### PR TITLE
Bump Xentropy Version

### DIFF
--- a/mcli/mcli-1b-eval.yaml
+++ b/mcli/mcli-1b-eval.yaml
@@ -44,11 +44,12 @@ parameters:
   load_path: # Add your (optional) Composer checkpoint path here!
 
   device_eval_batch_size: 16
+  precision: fp32
 
   # FSDP config for model sharding
   # fsdp_config:
   #   sharding_strategy: FULL_SHARD
-  #   mixed_precision: PURE
+  #   mixed_precision: FULL
 
   icl_tasks:
   -

--- a/mcli/mcli-hf-eval.yaml
+++ b/mcli/mcli-hf-eval.yaml
@@ -24,6 +24,7 @@ parameters:
   seed: 1
   max_seq_len: 1024
   device_eval_batch_size: 8
+  precision: fp32
 
   model_name_or_path: huggyllama/llama-7b
   # model_name_or_path: EleutherAI/gpt-j-6b
@@ -52,6 +53,6 @@ parameters:
   # FSDP config for model sharding
   fsdp_config:
     sharding_strategy: FULL_SHARD
-    mixed_precision: PURE
+    mixed_precision: FULL
 
   icl_tasks: 'eval/yamls/tasks.yaml'


### PR DESCRIPTION
v1.0.3 for Xentropy CUDA Lib (used for Fused CrossEntropy) should [support H100s](https://github.com/HazyResearch/flash-attention/commit/dc08ea1c33afca500a3d4ada907608f7815a11d9) (sm_90), while v0.2.8 does not. This PR upgrades the default version of Xentropy.
