### PR TITLE
Fix convert_dataset_hf.py hanging with excessive num_workers

### DIFF
--- a/scripts/data_prep/README.md
+++ b/scripts/data_prep/README.md
@@ -22,7 +22,7 @@ Using the `convert_dataset_json.py` script...
 ```bash
 # Convert json dataset to StreamingDataset format
 python convert_dataset_json.py \
-  --path ./example_data/arxiv.json \
+  --path ./example_data/arxiv.jsonl \
   --out_root my-copy-arxiv --split train \
   --concat_tokens 2048 --tokenizer EleutherAI/gpt-neox-20b --eos_text '<|endoftext|>' \
   --compression zstd

--- a/scripts/data_prep/convert_dataset_hf.py
+++ b/scripts/data_prep/convert_dataset_hf.py
@@ -3,7 +3,6 @@
 
 """Streaming dataset conversion scripts for C4 and The Pile."""
 import os
-import psutil
 import platform
 from argparse import ArgumentParser, Namespace
 from dataclasses import dataclass
@@ -11,6 +10,7 @@ from enum import Enum
 from typing import Dict, Iterable, Optional, Union
 
 import datasets as hf_datasets
+import psutil
 from streaming import MDSWriter
 from torch.utils.data import DataLoader, IterableDataset
 from tqdm import tqdm
@@ -347,7 +347,9 @@ def main(args: Namespace) -> None:
                                    eos_text=args.eos_text,
                                    no_wrap=args.no_wrap,
                                    tokenizer=tokenizer)
-        loader = build_dataloader(dataset=dataset, batch_size=512, num_workers=args.num_workers)
+        loader = build_dataloader(dataset=dataset,
+                                  batch_size=512,
+                                  num_workers=args.num_workers)
         samples = generate_samples(loader,
                                    truncate_num_samples=truncate_num_samples)
 

--- a/scripts/data_prep/convert_dataset_json.py
+++ b/scripts/data_prep/convert_dataset_json.py
@@ -140,6 +140,7 @@ def _est_progress_denominator(total_samples: int, chars_per_sample: int,
     elif mode == ConcatMode.CONCAT_TOKENS:
         return total_samples * est_tokens_per_sample // max_length
 
+
 def generate_samples(
         loader: DataLoader,
         truncate_num_samples: Optional[int] = None

--- a/scripts/data_prep/convert_dataset_json.py
+++ b/scripts/data_prep/convert_dataset_json.py
@@ -3,7 +3,6 @@
 
 """Streaming dataset conversion scripts for json files."""
 import os
-import platform
 from argparse import ArgumentParser, Namespace
 from enum import Enum
 from glob import glob
@@ -140,30 +139,6 @@ def _est_progress_denominator(total_samples: int, chars_per_sample: int,
         return total_samples
     elif mode == ConcatMode.CONCAT_TOKENS:
         return total_samples * est_tokens_per_sample // max_length
-
-
-def build_dataloader(dataset, batch_size) -> DataLoader:
-    # Multiple workers is only supported on linux machines
-    if 'linux' in platform.platform().lower():
-        num_workers = 64
-    else:
-        num_workers = 0
-
-    # If using multiple workers, configure each worker to prefetch as many samples as it can, up to
-    # the aggregate device batch size
-    # If not using workers, the torch DataLoader expects the default value for prefetch_factor,
-    # which non-intuitively must be 2.
-    prefetch_factor = max(1, 2 * batch_size //
-                          num_workers) if num_workers > 0 else 2
-
-    return DataLoader(
-        dataset=dataset,
-        sampler=None,
-        batch_size=batch_size,
-        num_workers=num_workers,
-        prefetch_factor=prefetch_factor,
-    )
-
 
 def generate_samples(
         loader: DataLoader,

--- a/scripts/data_prep/convert_finetuning_dataset.py
+++ b/scripts/data_prep/convert_finetuning_dataset.py
@@ -2,12 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-import psutil
 import platform
 from argparse import ArgumentParser, Namespace
 from typing import Dict, Iterable, List, Optional, Union
 
 import datasets as hf_datasets
+import psutil
 from streaming import MDSWriter
 from torch.utils.data import DataLoader, IterableDataset
 from tqdm import tqdm
@@ -96,7 +96,8 @@ class SimpleDataset(IterableDataset):
             yield {key: sample[key].encode('utf-8') for key in self.columns}
 
 
-def build_dataloader(dataset: SimpleDataset, batch_size: int, num_workers: int) -> DataLoader:
+def build_dataloader(dataset: SimpleDataset, batch_size: int,
+                     num_workers: int) -> DataLoader:
     if num_workers is None:
         # Multiple workers is only supported on linux machines
         if 'linux' in platform.platform().lower():
@@ -113,7 +114,7 @@ def build_dataloader(dataset: SimpleDataset, batch_size: int, num_workers: int) 
         prefetch_factor = None
     else:
         prefetch_factor = max(1, 2 * batch_size //
-                            num_workers) if num_workers > 0 else 2
+                              num_workers) if num_workers > 0 else 2
 
     return DataLoader(
         dataset=dataset,
@@ -177,7 +178,9 @@ def main(args: Namespace) -> None:
                                            name=args.data_subset,
                                            split=split_name,
                                            streaming=True)
-        loader = build_dataloader(dataset=dataset, batch_size=512, num_workers=args.num_workers)
+        loader = build_dataloader(dataset=dataset,
+                                  batch_size=512,
+                                  num_workers=args.num_workers)
         samples = generate_samples(loader)
 
         # Write samples

--- a/scripts/data_prep/convert_finetuning_dataset.py
+++ b/scripts/data_prep/convert_finetuning_dataset.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+import psutil
 import platform
 from argparse import ArgumentParser, Namespace
 from typing import Dict, Iterable, List, Optional, Union
@@ -61,6 +62,7 @@ def parse_args() -> Namespace:
                         type=str,
                         default=None,
                         help='(Optional) name of compression algorithm to use.')
+    parser.add_argument('--num_workers', type=int, required=False, default=None)
 
     parsed = parser.parse_args()
 
@@ -94,19 +96,24 @@ class SimpleDataset(IterableDataset):
             yield {key: sample[key].encode('utf-8') for key in self.columns}
 
 
-def build_dataloader(dataset: SimpleDataset, batch_size: int) -> DataLoader:
-    # Multiple workers is only supported on linux machines
-    if 'linux' in platform.platform().lower():
-        num_workers = min(64, dataset.hf_dataset.n_shards)  # type: ignore
-    else:
-        num_workers = 0
+def build_dataloader(dataset: SimpleDataset, batch_size: int, num_workers: int) -> DataLoader:
+    if num_workers is None:
+        # Multiple workers is only supported on linux machines
+        if 'linux' in platform.platform().lower():
+            num_workers = max(1, psutil.cpu_count())  # type: ignore
+        else:
+            num_workers = 0
 
     # If using multiple workers, configure each worker to prefetch as many samples as it can, up to
     # the aggregate device batch size
     # If not using workers, the torch DataLoader expects the default value for prefetch_factor,
     # which non-intuitively must be 2.
-    prefetch_factor = max(1, 2 * batch_size //
-                          num_workers) if num_workers > 0 else 2
+    # If on macOS, PyTorch requires prefetch_factor set to None since num_workers is always zero
+    if 'macos' in platform.platform().lower() and num_workers == 0:
+        prefetch_factor = None
+    else:
+        prefetch_factor = max(1, 2 * batch_size //
+                            num_workers) if num_workers > 0 else 2
 
     return DataLoader(
         dataset=dataset,
@@ -170,7 +177,7 @@ def main(args: Namespace) -> None:
                                            name=args.data_subset,
                                            split=split_name,
                                            streaming=True)
-        loader = build_dataloader(dataset=dataset, batch_size=512)
+        loader = build_dataloader(dataset=dataset, batch_size=512, num_workers=args.num_workers)
         samples = generate_samples(loader)
 
         # Write samples

--- a/tests/test_data_prep_scripts.py
+++ b/tests/test_data_prep_scripts.py
@@ -28,7 +28,8 @@ def test_download_script_from_api():
                 'concat_tokens': None,
                 'bos_text': None,
                 'eos_text': None,
-                'no_wrap': False
+                'no_wrap': False,
+                'num_workers': None
             }))
     assert os.path.exists(path)
     shutil.rmtree(path, ignore_errors=False)
@@ -48,7 +49,8 @@ def test_json_script_from_api():
                 'concat_tokens': None,
                 'bos_text': None,
                 'eos_text': None,
-                'no_wrap': False
+                'no_wrap': False,
+                'num_workers': None
             }))
     assert os.path.exists(path)
     shutil.rmtree(path, ignore_errors=False)

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -68,7 +68,8 @@ def test_correct_padding(tokenizer_name, pretokenize, batch_size=4):
                     'tokenizer': tokenizer_name,
                     'bos_text': bos_text,
                     'eos_text': eos_text,
-                    'no_wrap': False
+                    'no_wrap': False,
+                    'num_workers': None
                 }))
     else:
         main_hf(
@@ -83,7 +84,8 @@ def test_correct_padding(tokenizer_name, pretokenize, batch_size=4):
                     'tokenizer': tokenizer_name,
                     'bos_text': bos_text,
                     'eos_text': eos_text,
-                    'no_wrap': False
+                    'no_wrap': False,
+                    'num_workers': None,
                 }))
     if not os.path.isdir(path):
         raise RuntimeError(f'c4 dataset at {path} not set up as expected')
@@ -170,6 +172,7 @@ def test_denoising_dataloader(decoder_only_format, pretokenize, packing_ratio):
                 'packing_ratio': packing_ratio,
                 'predownload': 1000,
                 'keep_zip': False,
+                'num_workers': None
             },
             'mixture_of_denoisers': {
                 'decoder_only_format': decoder_only_format,


### PR DESCRIPTION
Background: PyTorch's DataLoader hangs on several machines (locally, VM, colab) because of the `num_workers` argument being excessive. Generally, when using multiple processes, we want to scale with the number of CPUs, and if we always force a minimum of 64 workers, a lot of systems will hang as it simply does not have 64 CPUs. 

This pull request does the following:

1. Implement `num_workers` based on `psutil.cpu_count()`, scale with number of CPUs
    - FIX: `min(64, dataset.hf_dataset.n_shards)` causes the DataLoader to hang on VMs that are not large since it will always force a minimum of 64 workers.
    - FIX: PyTorch DataLoader gives UserWarning suggesting that your `num_workers` should be equal to the number of CPUs on your machine *"excessive worker creation might get DataLoader running slow or even freeze"*.
2. Implement an argument `num_workers` which sets the `num_workers` argument for the DataLoader. If this argument is set to a number, we run with that number instead of `psutil.cpu_count()`.
3. Enable macOS users to run this locally, the same way as it is implemented for Linux users (both are Unix operating systems).
    - FIX: `ValueError: prefetch_factor option could only be specified in multiprocessing.let num_workers > 0 to enable multiprocessing, otherwise set prefetch_factor to None.`

Usage example:

```
python data_prep/convert_dataset_hf.py \
  --dataset c4 --data_subset en \
  --out_root my-copy-c4 --splits train_small val_small \
  --concat_tokens 2048 \
  --tokenizer EleutherAI/gpt-neox-20b \
  --eos_text '<|endoftext|>' \
  --num_workers 8
```