### PR TITLE
Fastertransformer: replace config['mpt'] with config['gpt']

### DIFF
--- a/scripts/inference/convert_hf_mpt_to_ft.py
+++ b/scripts/inference/convert_hf_mpt_to_ft.py
@@ -204,30 +204,30 @@ def convert_mpt_to_ft(model_name_or_path: str,
     hf_config = vars(model.config)
 
     config = configparser.ConfigParser()
-    config['mpt'] = {}
+    config['gpt'] = {}
     try:
-        config['mpt']['model_name'] = 'mpt' if hf_config[
+        config['gpt']['model_name'] = 'mpt' if hf_config[
             '_name_or_path'] == '' else hf_config['_name_or_path']
-        config['mpt']['head_num'] = str(hf_config['n_heads'])
+        config['gpt']['head_num'] = str(hf_config['n_heads'])
         n_embd = hf_config['d_model']
-        config['mpt']['size_per_head'] = str(n_embd // hf_config['n_heads'])
-        config['mpt']['inter_size'] = str(n_embd * hf_config['expansion_ratio'])
-        config['mpt']['max_pos_seq_len'] = str(hf_config['max_seq_len'])
-        config['mpt']['num_layer'] = str(hf_config['n_layers'])
-        config['mpt']['vocab_size'] = str(hf_config['vocab_size'])
-        config['mpt']['start_id'] = str(
+        config['gpt']['size_per_head'] = str(n_embd // hf_config['n_heads'])
+        config['gpt']['inter_size'] = str(n_embd * hf_config['expansion_ratio'])
+        config['gpt']['max_pos_seq_len'] = str(hf_config['max_seq_len'])
+        config['gpt']['num_layer'] = str(hf_config['n_layers'])
+        config['gpt']['vocab_size'] = str(hf_config['vocab_size'])
+        config['gpt']['start_id'] = str(
             hf_config['bos_token_id']
         ) if hf_config['bos_token_id'] != None else str(tokenizer.bos_token_id)
-        config['mpt']['end_id'] = str(
+        config['gpt']['end_id'] = str(
             hf_config['eos_token_id']
         ) if hf_config['eos_token_id'] != None else str(tokenizer.eos_token_id)
-        config['mpt']['weight_data_type'] = weight_data_type
-        config['mpt']['tensor_para_size'] = str(infer_gpu_num)
+        config['gpt']['weight_data_type'] = weight_data_type
+        config['gpt']['tensor_para_size'] = str(infer_gpu_num)
         # nn.LayerNorm default eps is 1e-5
-        config['mpt']['layernorm_eps'] = str(1e-5)
+        config['gpt']['layernorm_eps'] = str(1e-5)
         if hf_config['attn_config']['alibi']:
-            config['mpt']['has_positional_encoding'] = str(False)
-            config['mpt']['use_attention_linear_bias'] = str(True)
+            config['gpt']['has_positional_encoding'] = str(False)
+            config['gpt']['use_attention_linear_bias'] = str(True)
         if hf_config['attn_config']['clip_qkv'] and not force:
             raise RuntimeError(
                 'clip_qkv is enabled for this MPT model. This may not work as expected in FT. Use --force to force a conversion.'

--- a/scripts/inference/run_mpt_with_ft.py
+++ b/scripts/inference/run_mpt_with_ft.py
@@ -229,7 +229,7 @@ def main():
     ckpt_config_path = os.path.join(args.ckpt_path, 'config.ini')
     if os.path.isfile(ckpt_config_path):
         ckpt_config.read(ckpt_config_path)
-    if 'mpt' in ckpt_config.keys():
+    if 'gpt' in ckpt_config.keys():
         for args_key, config_key, func in [
             ('layer_num', 'num_layer', ckpt_config.getint),
             ('max_seq_len', 'max_pos_seq_len', ckpt_config.getint),
@@ -237,9 +237,9 @@ def main():
             ('layernorm_eps', 'layernorm_eps', ckpt_config.getfloat),
             ('alibi', 'use_attention_linear_bias', ckpt_config.getboolean),
         ]:
-            if config_key in ckpt_config['mpt'].keys():
+            if config_key in ckpt_config['gpt'].keys():
                 prev_val = args.__dict__[args_key]
-                args.__dict__[args_key] = func('mpt', config_key)
+                args.__dict__[args_key] = func('gpt', config_key)
                 print(
                     'Loading {} from config.ini,    previous: {},    current: {}'
                     .format(args_key, prev_val, args.__dict__[args_key]))
@@ -248,7 +248,7 @@ def main():
         for key in ['head_num', 'size_per_head', 'tensor_para_size']:
             if key in args.__dict__:
                 prev_val = args.__dict__[key]
-                args.__dict__[key] = ckpt_config.getint('mpt', key)
+                args.__dict__[key] = ckpt_config.getint('gpt', key)
                 print(
                     'Loading {} from config.ini,    previous: {},    current: {}'
                     .format(key, prev_val, args.__dict__[key]))


### PR DESCRIPTION
Perhaps this works with PyTorch-based fastertransformer because `run_mpt_with_ft.py` manually instantiates a `ParallelGPT` model, but the [Triton fastertransformer backend](https://github.com/triton-inference-server/fastertransformer_backend) requires the `gpt` key in the `config.ini`

This change makes it so that `convert_hf_mpt_to_ft.py` will produce a checkpoint that works with the Triton fastertransformer backend. I've only tested `convert_hf_mpt_to_ft.py` on my branch, but I think `run_mpt_with_ft.py` should work 