### PR TITLE
Add `device_map` support for `hf_generate.py` and `hf_chat.py`

### DIFF
--- a/scripts/inference/README.md
+++ b/scripts/inference/README.md
@@ -101,7 +101,10 @@ output_tok_per_sec=292.03tok/sec
 
 The argument for `--name_or_path` can be either the name of a model that exists on the HF Hub, such as `gpt2`, `facebook/opt-350m`, etc. or the path to a HF checkpoint folder, such as `my_hf_model/` like we exported above.
 
-For MPT models specifically, you can pass args like `--init_device cuda:0`, `--attn_impl triton`, and `--max_seq_len 4096` to speed up generation time or alter the max generation length at inference time (thanks to ALiBi).
+The script will automatically try to load the model on a GPU if available, or will fall back to CPU. You can also specify a specific device such as `--device cuda:0`.
+You can also use HuggingFace's `device_map` functionality to load large models across multiple GPUs. Just pass `--device_map auto` and it will attempt to split the model across all available GPU memory.
+
+For MPT models specifically, you can pass args like `--attn_impl triton`, and `--max_seq_len 4096` to speed up generation time or alter the max generation length at inference time (thanks to ALiBi).
 
 ## Interactive Chat with HF models
 

--- a/scripts/inference/hf_chat.py
+++ b/scripts/inference/hf_chat.py
@@ -176,13 +176,14 @@ def main(args: Namespace) -> None:
     # Set device or device_map
     if args.device and args.device_map:
         raise ValueError('You can only set one of `device` and `device_map`.')
-    if args.device is not None:
+    if args.device_map is None:
         device = args.device or ('cuda:0'
                                  if torch.cuda.is_available() else 'cpu')
         device_map = None
     else:
         device = None
         device_map = args.device_map
+    print(f'Using {device=} and {device_map=}')
 
     # Grab config first
     print(f'Loading HF Config...')

--- a/scripts/inference/hf_chat.py
+++ b/scripts/inference/hf_chat.py
@@ -105,6 +105,7 @@ def parse_args() -> Namespace:
                         default=None)
     parser.add_argument('--revision', type=str, default=None)
     parser.add_argument('--device', type=str, default=None)
+    parser.add_argument('--device_map', type=str, default=None)
     parser.add_argument('--attn_impl', type=str, default=None)
     parser.add_argument('--seed', type=int, default=42)
     parser.add_argument('--system_prompt', type=str, default=SYSTEM_PROMPT)
@@ -172,11 +173,16 @@ def have_conversation(model, tokenizer: Tokenizer,
 
 
 def main(args: Namespace) -> None:
-    # Set device
+    # Set device or device_map
+    if args.device and args.device_map:
+        raise ValueError('You can only set one of `device` and `device_map`.')
     if args.device is not None:
-        device = args.device
+        device = args.device or ('cuda:0'
+                                 if torch.cuda.is_available() else 'cpu')
+        device_map = None
     else:
-        device = 'cuda:0' if torch.cuda.is_available() else 'cpu'
+        device = None
+        device_map = args.device_map
 
     # Grab config first
     print(f'Loading HF Config...')
@@ -190,7 +196,7 @@ def main(args: Namespace) -> None:
                                             **from_pretrained_kwargs)
         if args.attn_impl is not None and hasattr(config, 'attn_config'):
             config.attn_config['attn_impl'] = args.attn_impl
-        if hasattr(config, 'init_device'):
+        if hasattr(config, 'init_device') and device is not None:
             config.init_device = device
         if args.max_seq_len is not None and hasattr(config, 'max_seq_len'):
             config.max_seq_len = args.max_seq_len
@@ -209,17 +215,21 @@ def main(args: Namespace) -> None:
         model_dtype = config.torch_dtype or torch.float32
 
     # Load HF Model
-    print(f'Loading HF model to device={device} and dtype={model_dtype}...')
+    print(f'Loading HF model with dtype={model_dtype}...')
     try:
         model = AutoModelForCausalLM.from_pretrained(args.name_or_path,
                                                      config=config,
                                                      torch_dtype=model_dtype,
+                                                     device_map=device_map,
                                                      **from_pretrained_kwargs)
-        model.to(device)
         model.eval()
         print(f'n_params={sum(p.numel() for p in model.parameters())}')
+        if device is not None:
+            print(f'Placing model on {device=}...')
+            model.to(device)
     except Exception as e:
         raise RuntimeError(
+            'Unable to load HF model. '
             'If you are having auth problems, try logging in via `huggingface-cli login` '
             'or by setting the environment variable `export HUGGING_FACE_HUB_TOKEN=... '
             'using your access token from https://huggingface.co/settings/tokens.'

--- a/scripts/inference/hf_generate.py
+++ b/scripts/inference/hf_generate.py
@@ -147,13 +147,14 @@ def main(args: Namespace) -> None:
     # Set device or device_map
     if args.device and args.device_map:
         raise ValueError('You can only set one of `device` and `device_map`.')
-    if args.device is not None:
+    if args.device_map is None:
         device = args.device or ('cuda:0'
                                  if torch.cuda.is_available() else 'cpu')
         device_map = None
     else:
         device = None
         device_map = args.device_map
+    print(f'Using {device=} and {device_map=}')
 
     # Load prompts
     prompt_strings = []


### PR DESCRIPTION
This PR enables `--device_map auto` which enables using these scripts with very large models that don't fit on a single GPU.

This also removes the need for FSDP support @alextrott16 !