### PR TITLE
Add shift_labels arg to HF wrappers

### DIFF
--- a/llmfoundry/models/hf/hf_causal_lm.py
+++ b/llmfoundry/models/hf/hf_causal_lm.py
@@ -112,6 +112,7 @@ class ComposerHFCausalLM(HuggingFaceModelWithZLoss):
                 f'init_device="{init_device}" must be either "cpu" or "meta".')
 
         composer_model = super().__init__(model=model,
+                                          shift_labels=True,
                                           tokenizer=tokenizer,
                                           metrics=train_metrics,
                                           eval_metrics=eval_metrics,

--- a/llmfoundry/models/hf/hf_prefix_lm.py
+++ b/llmfoundry/models/hf/hf_prefix_lm.py
@@ -126,6 +126,7 @@ class ComposerHFPrefixLM(HuggingFaceModelWithZLoss):
         ]
 
         composer_model = super().__init__(model=model,
+                                          shift_labels=True,
                                           tokenizer=tokenizer,
                                           metrics=metrics,
                                           z_loss=om_model_config.get(

--- a/llmfoundry/models/hf/model_wrapper.py
+++ b/llmfoundry/models/hf/model_wrapper.py
@@ -44,12 +44,14 @@ class HuggingFaceModelWithZLoss(HuggingFaceModel):
                  tokenizer: Optional[Tokenizer] = None,
                  metrics: Optional[List[Metric]] = None,
                  eval_metrics: Optional[List[Metric]] = None,
-                 z_loss: float = 0.0):
+                 z_loss: float = 0.0,
+                 shift_labels: bool = False):
         super().__init__(model,
                          tokenizer,
                          use_logits=True,
                          metrics=metrics,
-                         eval_metrics=eval_metrics)
+                         eval_metrics=eval_metrics,
+                         shift_labels=shift_labels)
         self.z_loss = float(z_loss)
         if self.z_loss < 0.0:
             raise ValueError(f'z_loss(={z_loss}) cannot be negative.')


### PR DESCRIPTION
We forgot to set `shift_labels` to `True` for the `HFCausalLM` wrapper, because for all the models on the hub, we detect that they are causal lms inside `HuggingFaceModel` and automatically turn on label shifting, but MPT is not a registered causal lm so it is not auto detected. This specifically affects the _metrics_ (ce and ppl) when training an MPT model from the hub. All other settings/numbers are unaffected, so ultimately this is fairly harmless, just confusing.

Before this PR (loss and metric are different):
```
[batch=9/10]:
	 Train time/batch: 8
	 Train time/sample: 32
	 Train time/batch_in_epoch: 8
	 Train time/sample_in_epoch: 32
	 Train time/token: 65536
	 Train time/token_in_epoch: 65536
	 Train memory/allocated_mem: 2.9441
	 Train memory/active_mem: 2.9441
	 Train memory/inactive_mem: 2.3973
	 Train memory/reserved_mem: 11.5990
	 Train memory/alloc_retries: 0
	 Train trainer/device_train_microbatch_size: 4
	 Train loss/train/total: 10.2541
	 Train metrics/train/LanguageCrossEntropy: 9.2585
	 Train metrics/train/LanguagePerplexity: 10493.5527
	 Train time/train: 0.0014
	 Train time/val: 0.0000
	 Train time/total: 0.0014
	 Train lr-DecoupledAdamW/group0: 0.0000
	 Train time/remaining_estimate: 0.0000
[batch=10/10]:
	 Train time/batch: 9
	 Train time/sample: 36
	 Train time/batch_in_epoch: 9
	 Train time/sample_in_epoch: 36
	 Train time/token: 73728
	 Train time/token_in_epoch: 73728
	 Train memory/allocated_mem: 2.9449
	 Train memory/active_mem: 2.9449
	 Train memory/inactive_mem: 1.5074
	 Train memory/reserved_mem: 11.5990
	 Train memory/alloc_retries: 0
	 Train trainer/device_train_microbatch_size: 4
	 Train loss/train/total: 10.2286
	 Train metrics/train/LanguageCrossEntropy: 9.3055
	 Train metrics/train/LanguagePerplexity: 10998.7852
	 Train time/train: 0.0014
	 Train time/val: 0.0000
	 Train time/total: 0.0014
	 Train lr-DecoupledAdamW/group0: 0.0000
	 Train time/remaining_estimate: 0.0000
Done.
```

After this PR (loss and metric are same):
```[batch=9/10]:
	 Train time/batch: 8
	 Train time/sample: 32
	 Train time/batch_in_epoch: 8
	 Train time/sample_in_epoch: 32
	 Train time/token: 65536
	 Train time/token_in_epoch: 65536
	 Train memory/allocated_mem: 2.9441
	 Train memory/active_mem: 2.9441
	 Train memory/inactive_mem: 2.3973
	 Train memory/reserved_mem: 11.5990
	 Train memory/alloc_retries: 0
	 Train trainer/device_train_microbatch_size: 4
	 Train loss/train/total: 10.2541
	 Train metrics/train/LanguageCrossEntropy: 10.2541
	 Train metrics/train/LanguagePerplexity: 28398.8164
	 Train time/train: 0.0007
	 Train time/val: 0.0000
	 Train time/total: 0.0007
	 Train lr-DecoupledAdamW/group0: 0.0000
	 Train time/remaining_estimate: 0.0000
[batch=10/10]:
	 Train time/batch: 9
	 Train time/sample: 36
	 Train time/batch_in_epoch: 9
	 Train time/sample_in_epoch: 36
	 Train time/token: 73728
	 Train time/token_in_epoch: 73728
	 Train memory/allocated_mem: 2.9449
	 Train memory/active_mem: 2.9449
	 Train memory/inactive_mem: 1.5074
	 Train memory/reserved_mem: 11.5990
	 Train memory/alloc_retries: 0
	 Train trainer/device_train_microbatch_size: 4
	 Train loss/train/total: 10.2286
	 Train metrics/train/LanguageCrossEntropy: 10.2286
	 Train metrics/train/LanguagePerplexity: 27684.1348
	 Train time/train: 0.0008
	 Train time/val: 0.0000
	 Train time/total: 0.0008
	 Train lr-DecoupledAdamW/group0: 0.0000
	 Train time/remaining_estimate: 0.0000
Done.
```