### PR TITLE
Set eval shuffle to False

### DIFF
--- a/scripts/train/yamls/finetune/mpt-7b_dolly_sft.yaml
+++ b/scripts/train/yamls/finetune/mpt-7b_dolly_sft.yaml
@@ -51,7 +51,7 @@ eval_loader:
     allow_pad_trimming: false
     decoder_only_format: true
     # packing_ratio:
-    shuffle: true
+    shuffle: false
   drop_last: true
   num_workers: 8
   pin_memory: false


### PR DESCRIPTION
I think eval dataloaders should not shuffle data for consistent evaluation results