### PR TITLE
Fix autocast dtype

### DIFF
--- a/scripts/inference/hf_chat.py
+++ b/scripts/inference/hf_chat.py
@@ -259,7 +259,7 @@ def main(args: Namespace) -> None:
     # Autocast
     if args.autocast_dtype is not None:
         autocast_dtype = get_dtype(args.autocast_dtype)
-        autocast_context = torch.autocast(model.device, autocast_dtype)
+        autocast_context = torch.autocast(model.device.type, autocast_dtype)
         print(f'Using autocast with dtype={autocast_dtype}...')
     else:
         autocast_context = nullcontext()

--- a/scripts/inference/hf_generate.py
+++ b/scripts/inference/hf_generate.py
@@ -228,7 +228,7 @@ def main(args: Namespace) -> None:
     # Autocast
     if args.autocast_dtype is not None:
         autocast_dtype = get_dtype(args.autocast_dtype)
-        autocast_context = torch.autocast(model.device, autocast_dtype)
+        autocast_context = torch.autocast(model.device.type, autocast_dtype)
         print(f'Using autocast with dtype={autocast_dtype}...')
     else:
         autocast_context = nullcontext()


### PR DESCRIPTION
Minor bug, we can't pass devices like `torch.device('cuda:0')` into the autocast funciton. Instead you need to pass `torch.device('cuda:0').type` which is `'cuda'`.

Tested on an interactive instance.