### PR TITLE
Fix bug with saving optimizer states with MonolithicCheckpointSaver Callback

### DIFF
--- a/llmfoundry/callbacks/monolithic_ckpt_callback.py
+++ b/llmfoundry/callbacks/monolithic_ckpt_callback.py
@@ -8,7 +8,8 @@ from pathlib import Path
 
 import torch
 from composer.core import Callback, State
-from composer.core.state import fsdp_state_dict_type_context, fsdp_get_optim_state_dict
+from composer.core.state import (fsdp_get_optim_state_dict,
+                                 fsdp_state_dict_type_context)
 from composer.loggers import Logger
 from composer.loggers.remote_uploader_downloader import RemoteUploaderDownloader
 from composer.utils import (dist, format_name_with_dist_and_time, parse_uri,
@@ -92,13 +93,14 @@ class MonolithicCheckpointSaver(Callback):
             if self.keep_optimizers:
                 optimizer = state.optimizers[0]
                 state_dict['state']['optimizers'] = {
-                    type(optimizer).__qualname__: fsdp_get_optim_state_dict(
-                                                                    state.model,
-                                                                    optimizer, 
-                                                                    state_dict_type='full')}
+                    type(optimizer).__qualname__:
+                        fsdp_get_optim_state_dict(state.model,
+                                                  optimizer,
+                                                  state_dict_type='full')
+                }
             if dist.get_global_rank() == 0:
                 torch.save(state_dict, save_path)
-                
+
             if self.upload_to_object_store and self.remote_ud is not None and dist.get_global_rank(
             ) == 0:
                 remote_file_name = str(Path(save_dir) / Path(filename))

--- a/llmfoundry/callbacks/monolithic_ckpt_callback.py
+++ b/llmfoundry/callbacks/monolithic_ckpt_callback.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import torch
 from composer.core import Callback, State
-from composer.core.state import fsdp_state_dict_type_context
+from composer.core.state import fsdp_state_dict_type_context, fsdp_get_optim_state_dict
 from composer.loggers import Logger
 from composer.loggers.remote_uploader_downloader import RemoteUploaderDownloader
 from composer.utils import (dist, format_name_with_dist_and_time, parse_uri,
@@ -79,13 +79,26 @@ class MonolithicCheckpointSaver(Callback):
                 'state': state.state_dict(),
                 'rng': reproducibility.get_rng_state()
             }
-            if not self.keep_optimizers:
-                state_dict['state'].pop('optimizers')
+            # Remove sharded model and optimizer state dicts
+            state_dict['state'].pop('optimizers')
+            state_dict['state'].pop('model')
+
+            # Add in unsharded model params.
             with fsdp_state_dict_type_context(state.model,
                                               state_dict_type='full'):
                 state_dict['state']['model'] = state.model.state_dict()
-                if dist.get_global_rank() == 0:
-                    torch.save(state_dict, save_path)
+
+            # Add in unsharded optimizer state dict.
+            if self.keep_optimizers:
+                optimizer = state.optimizers[0]
+                state_dict['state']['optimizers'] = {
+                    type(optimizer).__qualname__: fsdp_get_optim_state_dict(
+                                                                    state.model,
+                                                                    optimizer, 
+                                                                    state_dict_type='full')}
+            if dist.get_global_rank() == 0:
+                torch.save(state_dict, save_path)
+                
             if self.upload_to_object_store and self.remote_ud is not None and dist.get_global_rank(
             ) == 0:
                 remote_file_name = str(Path(save_dir) / Path(filename))


### PR DESCRIPTION
Currently there is a bug where only the model state_dict_type is 'full' and not the optimizer state state dict type.
This PR fixes that using the `fsdp_get_optim_state_dict` helper function
