### PR TITLE
Allow MPT past the tied word embeddings error

### DIFF
--- a/llmfoundry/callbacks/generate_callback.py
+++ b/llmfoundry/callbacks/generate_callback.py
@@ -6,7 +6,7 @@ from typing import List, Union, cast
 
 import torch
 import wandb
-from composer.core import Callback, State, _get_precision_context
+from composer.core import Callback, State, get_precision_context
 from composer.loggers import Logger, WandBLogger
 from composer.utils import dist, ensure_tuple
 from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast
@@ -72,7 +72,7 @@ class Generate(Callback):
         # dummy forward call needed for FSDP to work consistently
         dummy_input = torch.tensor([[0]], dtype=torch.long)
         dummy_input = device.tensor_to_device(dummy_input)
-        with _get_precision_context(state.precision, False):
+        with get_precision_context(state.precision, False):
             with torch.no_grad():
                 _ = model.model(input_ids=dummy_input)  # type: ignore
 

--- a/llmfoundry/callbacks/generate_callback.py
+++ b/llmfoundry/callbacks/generate_callback.py
@@ -6,7 +6,7 @@ from typing import List, Union, cast
 
 import torch
 import wandb
-from composer.core import Callback, State
+from composer.core import Callback, State, _get_precision_context
 from composer.loggers import Logger, WandBLogger
 from composer.utils import dist, ensure_tuple
 from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast
@@ -72,15 +72,16 @@ class Generate(Callback):
         # dummy forward call needed for FSDP to work consistently
         dummy_input = torch.tensor([[0]], dtype=torch.long)
         dummy_input = device.tensor_to_device(dummy_input)
-        with torch.no_grad():
-            _ = model.model(input_ids=dummy_input)  # type: ignore
+        with _get_precision_context(state.precision, False):
+            with torch.no_grad():
+                _ = model.model(input_ids=dummy_input)  # type: ignore
 
-        output_token_ids = model.model.generate(  # type: ignore
-            input_ids=tokenized_input['input_ids'],
-            attention_mask=tokenized_input['attention_mask'],
-            synced_gpus=True,
-            **self.generate_kwargs,
-        )
+            output_token_ids = model.model.generate(  # type: ignore
+                input_ids=tokenized_input['input_ids'],
+                attention_mask=tokenized_input['attention_mask'],
+                synced_gpus=True,
+                **self.generate_kwargs,
+            )
 
         if dist.get_global_rank() == 0:
             if self.wandb_logger is not None:

--- a/llmfoundry/callbacks/generate_callback.py
+++ b/llmfoundry/callbacks/generate_callback.py
@@ -72,7 +72,7 @@ class Generate(Callback):
         # dummy forward call needed for FSDP to work consistently
         dummy_input = torch.tensor([[0]], dtype=torch.long)
         dummy_input = device.tensor_to_device(dummy_input)
-        with get_precision_context(state.precision, False):
+        with get_precision_context(state.precision):
             with torch.no_grad():
                 _ = model.model(input_ids=dummy_input)  # type: ignore
 

--- a/llmfoundry/models/hf/hf_fsdp.py
+++ b/llmfoundry/models/hf/hf_fsdp.py
@@ -11,8 +11,6 @@ import torch
 from transformers import PreTrainedModel
 from transformers.models.opt.modeling_opt import OPTDecoder
 
-from llmfoundry.models.mpt.modeling_mpt import MPTForCausalLM
-
 
 # helper functions
 def rhasattr(obj: Any, attr: str):
@@ -165,8 +163,7 @@ def prepare_hf_causal_lm_model_for_fsdp(model: PreTrainedModel,
             if isinstance(child, torch.nn.Module):
                 child._fsdp_wrap = True
 
-        if model.config.tie_word_embeddings and not isinstance(
-                model, MPTForCausalLM):
+        if model.config.tie_word_embeddings and not model.config.model_type == 'mpt':
             raise ValueError(
                 'The passed in HuggingFaceModel has tied word embeddings '
                 'and the passed in initialization device is `mixed.` '

--- a/llmfoundry/models/hf/hf_fsdp.py
+++ b/llmfoundry/models/hf/hf_fsdp.py
@@ -5,6 +5,7 @@
 # which is MIT licensed
 
 import functools
+import warnings
 from typing import Any, Iterable, List
 
 import torch
@@ -165,7 +166,7 @@ def prepare_hf_causal_lm_model_for_fsdp(model: PreTrainedModel,
                 child._fsdp_wrap = True
 
         if model.config.tie_word_embeddings:
-            raise ValueError(
+            warnings.warn(
                 'The passed in HuggingFaceModel has tied word embeddings '
                 'and the passed in initialization device is `mixed.` '
                 'In order to support this initializaiton scheme, we would need to break '

--- a/llmfoundry/models/hf/hf_fsdp.py
+++ b/llmfoundry/models/hf/hf_fsdp.py
@@ -5,16 +5,16 @@
 # which is MIT licensed
 
 import functools
-import warnings
 from typing import Any, Iterable, List
 
 import torch
 from transformers import PreTrainedModel
 from transformers.models.opt.modeling_opt import OPTDecoder
 
+from llmfoundry.models.mpt.modeling_mpt import MPTForCausalLM
+
+
 # helper functions
-
-
 def rhasattr(obj: Any, attr: str):
     """A chain-able attribute version of hasattr.
 
@@ -165,8 +165,9 @@ def prepare_hf_causal_lm_model_for_fsdp(model: PreTrainedModel,
             if isinstance(child, torch.nn.Module):
                 child._fsdp_wrap = True
 
-        if model.config.tie_word_embeddings:
-            warnings.warn(
+        if model.config.tie_word_embeddings and not isinstance(
+                model, MPTForCausalLM):
+            raise ValueError(
                 'The passed in HuggingFaceModel has tied word embeddings '
                 'and the passed in initialization device is `mixed.` '
                 'In order to support this initializaiton scheme, we would need to break '


### PR DESCRIPTION
```
In [3]: cfg = transformers.AutoConfig.from_pretrained('mosaicml/mpt-7b', trust_remote_code=True)
Explicitly passing a `revision` is encouraged when loading a configuration with custom code to ensure no malicious code has been contributed in a newer revision.

In [4]: cfg.model_type
Out[4]: 'mpt'
```