### PR TITLE
hard set bias(alibi) precision

### DIFF
--- a/llmfoundry/models/mpt/modeling_mpt.py
+++ b/llmfoundry/models/mpt/modeling_mpt.py
@@ -376,7 +376,7 @@ class MPTModel(MPTPreTrainedModel):
 
         attn_bias, attention_mask = self._attn_bias(
             device=x.device,
-            dtype=x.dtype,
+            dtype=torch.float32,
             attention_mask=attention_mask,
             prefix_mask=prefix_mask,
             sequence_id=sequence_id)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1374,7 +1374,8 @@ def test_hf_init(tmp_path,
 
     original_params = next(model.parameters()).clone().data
 
-    outputs = model(batch)
+    with torch.autocast('cuda', dtype=torch.bfloat16, enabled=True):
+       outputs = model(batch)
     loss = model.loss(outputs, batch)
     loss.backward()
     optimizer.step()

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -806,11 +806,12 @@ def test_generate_with_device_map(tmp_path, world_size, use_cache):
         trust_remote_code=True,
         device_map=device_map,
     )
-    out = pipe(
-        'The quick fox jumped over',
-        max_length=10,
-        do_sample=True,
-    )
+    with torch.autocast('cuda', dtype=torch.bfloat16):
+        out = pipe(
+            'The quick fox jumped over',
+            max_length=10,
+            do_sample=True,
+        )
 
 
 def check_hf_model_equivalence(model1, model2):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1181,7 +1181,8 @@ def test_model_to(attention_impl, alibi):
     # verify the model still works
     if attention_impl == 'torch':
         with torch.autocast('cpu', dtype=torch.bfloat16, enabled=True):
-            _ = mpt(input_ids.to('cpu'), attention_mask=attention_mask.to('cpu'))
+            _ = mpt(input_ids.to('cpu'),
+                    attention_mask=attention_mask.to('cpu'))
 
     mpt = mpt.cuda()
     mpt = mpt.bfloat16()
@@ -1204,7 +1205,7 @@ def test_model_to(attention_impl, alibi):
 
     # verify the model still works
     with torch.autocast('cuda', dtype=torch.bfloat16, enabled=True):
-       _ = mpt(input_ids, attention_mask=attention_mask)
+        _ = mpt(input_ids, attention_mask=attention_mask)
 
 
 def test_alibi_vs_hf():
@@ -1375,7 +1376,7 @@ def test_hf_init(tmp_path,
     original_params = next(model.parameters()).clone().data
 
     with torch.autocast('cuda', dtype=torch.bfloat16, enabled=True):
-       outputs = model(batch)
+        outputs = model(batch)
     loss = model.loss(outputs, batch)
     loss.backward()
     optimizer.step()

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1169,20 +1169,26 @@ def test_model_to(attention_impl, alibi):
     input_ids = torch.tensor([[11274, 16390, 11]]).to('cuda')
     attention_mask = torch.tensor([[1, 1, 1]]).bool().to('cuda')
 
-    _ = mpt(input_ids, attention_mask=attention_mask)
+    # with get_precision_context('amp_bf16'):
+    with torch.autocast('cuda', dtype=torch.bfloat16, enabled=True):
+        _ = mpt(input_ids, attention_mask=attention_mask)
 
     # move the model around using different methods
+    mpt = mpt.bfloat16()
     mpt = mpt.to('cpu')
 
     # verify the model still works
     if attention_impl == 'torch':
-        _ = mpt(input_ids.to('cpu'), attention_mask=attention_mask.to('cpu'))
+        with torch.autocast('cpu', dtype=torch.bfloat16, enabled=True):
+            _ = mpt(input_ids.to('cpu'), attention_mask=attention_mask.to('cpu'))
 
     mpt = mpt.cuda()
+    mpt = mpt.bfloat16()
 
     # verify the model still works
     if attention_impl == 'torch':
-        _ = mpt(input_ids, attention_mask=attention_mask)
+        with torch.autocast('cuda', dtype=torch.bfloat16, enabled=True):
+            _ = mpt(input_ids, attention_mask=attention_mask)
 
     mpt = mpt.to('cpu')
     mpt = mpt.float()
@@ -1196,7 +1202,8 @@ def test_model_to(attention_impl, alibi):
     mpt = mpt.bfloat16()
 
     # verify the model still works
-    _ = mpt(input_ids, attention_mask=attention_mask)
+    with torch.autocast('cuda', dtype=torch.bfloat16, enabled=True):
+       _ = mpt(input_ids, attention_mask=attention_mask)
 
 
 def test_alibi_vs_hf():


### PR DESCRIPTION
Hard set bias(alibi) precision so that `FSDP: mixed_precision: PURE | FULL` produce same eval scores.

We can see that when running eval from main with `PURE`, eval perf degredes.
If we run it with this fix, we improve and are within noise of eval with `FULL`
<img width="1010" alt="Screenshot 2023-06-14 at 10 38 34 AM" src="https://github.com/mosaicml/llm-foundry/assets/6439018/552e4b2d-259a-421a-a6dd-29ea4f79d6b5">
