### PR TITLE
Increase default `t_warmup` to `1000ba`

### DIFF
--- a/mcli/mcli-1b-max-seq-len-8k.yaml
+++ b/mcli/mcli-1b-max-seq-len-8k.yaml
@@ -85,7 +85,7 @@ parameters:
   # Optimization
   scheduler:
     name: cosine_with_warmup
-    t_warmup: 100ba
+    t_warmup: 1000ba
     alpha_f: 0.1
 
   optimizer:

--- a/scripts/train/finetune_example/gpt2-arc-easy.yaml
+++ b/scripts/train/finetune_example/gpt2-arc-easy.yaml
@@ -41,7 +41,7 @@ train_loader:
 # Optimization
 scheduler:
   name: cosine_with_warmup
-  t_warmup: 100ba
+  t_warmup: 1000ba
   alpha_f: 0.1
 
 optimizer:

--- a/scripts/train/yamls/pretrain/gpt-neo-125m.yaml
+++ b/scripts/train/yamls/pretrain/gpt-neo-125m.yaml
@@ -56,7 +56,7 @@ eval_loader:
 # Optimization
 scheduler:
   name: cosine_with_warmup
-  t_warmup: 100ba
+  t_warmup: 1000ba
   alpha_f: 0.1
 
 optimizer:

--- a/scripts/train/yamls/pretrain/gpt2-small.yaml
+++ b/scripts/train/yamls/pretrain/gpt2-small.yaml
@@ -56,7 +56,7 @@ eval_loader:
 # Optimization
 scheduler:
   name: cosine_with_warmup
-  t_warmup: 100ba
+  t_warmup: 1000ba
   alpha_f: 0.1
 
 optimizer:

--- a/scripts/train/yamls/pretrain/mpt-125m.yaml
+++ b/scripts/train/yamls/pretrain/mpt-125m.yaml
@@ -53,7 +53,7 @@ eval_loader:
 # Optimization
 scheduler:
   name: cosine_with_warmup
-  t_warmup: 100ba
+  t_warmup: 1000ba
   alpha_f: 0.1
 
 optimizer:

--- a/scripts/train/yamls/pretrain/mpt-13b.yaml
+++ b/scripts/train/yamls/pretrain/mpt-13b.yaml
@@ -53,7 +53,7 @@ eval_loader:
 # Optimization
 scheduler:
   name: cosine_with_warmup
-  t_warmup: 100ba
+  t_warmup: 1000ba
   alpha_f: 0.1
 
 optimizer:

--- a/scripts/train/yamls/pretrain/mpt-1b.yaml
+++ b/scripts/train/yamls/pretrain/mpt-1b.yaml
@@ -53,7 +53,7 @@ eval_loader:
 # Optimization
 scheduler:
   name: cosine_with_warmup
-  t_warmup: 100ba
+  t_warmup: 1000ba
   alpha_f: 0.1
 
 optimizer:

--- a/scripts/train/yamls/pretrain/mpt-30b.yaml
+++ b/scripts/train/yamls/pretrain/mpt-30b.yaml
@@ -53,7 +53,7 @@ eval_loader:
 # Optimization
 scheduler:
   name: cosine_with_warmup
-  t_warmup: 100ba
+  t_warmup: 1000ba
   alpha_f: 0.1
 
 optimizer:

--- a/scripts/train/yamls/pretrain/mpt-350m.yaml
+++ b/scripts/train/yamls/pretrain/mpt-350m.yaml
@@ -53,7 +53,7 @@ eval_loader:
 # Optimization
 scheduler:
   name: cosine_with_warmup
-  t_warmup: 100ba
+  t_warmup: 1000ba
   alpha_f: 0.1
 
 optimizer:

--- a/scripts/train/yamls/pretrain/mpt-3b.yaml
+++ b/scripts/train/yamls/pretrain/mpt-3b.yaml
@@ -53,7 +53,7 @@ eval_loader:
 # Optimization
 scheduler:
   name: cosine_with_warmup
-  t_warmup: 100ba
+  t_warmup: 1000ba
   alpha_f: 0.1
 
 optimizer:

--- a/scripts/train/yamls/pretrain/mpt-70b.yaml
+++ b/scripts/train/yamls/pretrain/mpt-70b.yaml
@@ -53,7 +53,7 @@ eval_loader:
 # Optimization
 scheduler:
   name: cosine_with_warmup
-  t_warmup: 100ba
+  t_warmup: 1000ba
   alpha_f: 0.1
 
 optimizer:

--- a/scripts/train/yamls/pretrain/mpt-760m.yaml
+++ b/scripts/train/yamls/pretrain/mpt-760m.yaml
@@ -53,7 +53,7 @@ eval_loader:
 # Optimization
 scheduler:
   name: cosine_with_warmup
-  t_warmup: 100ba
+  t_warmup: 1000ba
   alpha_f: 0.1
 
 optimizer:

--- a/scripts/train/yamls/pretrain/mpt-7b.yaml
+++ b/scripts/train/yamls/pretrain/mpt-7b.yaml
@@ -53,7 +53,7 @@ eval_loader:
 # Optimization
 scheduler:
   name: cosine_with_warmup
-  t_warmup: 100ba
+  t_warmup: 1000ba
   alpha_f: 0.1
 
 optimizer:

--- a/scripts/train/yamls/pretrain/opt-3b.yaml
+++ b/scripts/train/yamls/pretrain/opt-3b.yaml
@@ -49,7 +49,7 @@ eval_loader:
 # Optimization
 scheduler:
   name: cosine_with_warmup
-  t_warmup: 100ba
+  t_warmup: 1000ba
   alpha_f: 0.1
 
 optimizer:

--- a/scripts/train/yamls/pretrain/testing.yaml
+++ b/scripts/train/yamls/pretrain/testing.yaml
@@ -54,7 +54,7 @@ eval_loader:
 # Optimization
 scheduler:
   name: cosine_with_warmup
-  t_warmup: 100ba
+  t_warmup: 1000ba
   alpha_f: 0.1
 
 optimizer:


### PR DESCRIPTION
Our pretraining YAMLs use a very aggressive LR warmup schedule that may be partly responsible for some loss spikes #317 #232 . This PR increases the default to `1000ba` for better stability.