### PR TITLE
Filter out sequences where prompt is longer than max length, rather than dropping them on the fly later

### DIFF
--- a/llmfoundry/data/finetuning/dataloader.py
+++ b/llmfoundry/data/finetuning/dataloader.py
@@ -145,7 +145,10 @@ def build_finetuning_dataloader(cfg: DictConfig, tokenizer: Tokenizer,
         )
 
     else:
-        dataset = dataset_constructor.build_from_hf(cfg.dataset, tokenizer)
+        dataset = dataset_constructor.build_from_hf(
+            cfg.dataset,
+            max_seq_len=cfg.dataset.max_seq_len,
+            tokenizer=tokenizer)
 
         collate_fn, dataloader_batch_size = _build_collate_fn(
             cfg.dataset, tokenizer, device_batch_size)

--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -255,7 +255,7 @@ class DatasetConstructor:
             num_proc=os.cpu_count() - 2,
         )
         prompt_length_filtered_dataset = tokenized_dataset.filter(
-            lambda example: len(example['text']) < max_seq_len,
+            lambda example: len(example['input_ids']) < max_seq_len,
             num_proc=os.cpu_count() - 2)
 
         return prompt_length_filtered_dataset


### PR DESCRIPTION
For the HuggingFace code path for finetuning datasets, we prefilter out examples where the prompt is longer than max sequence length. This was previously causing the run to hang when using small dtms

before: `test-finetune-hang-before-9UXsdA` (hangs at batch 7)
after: `test-finetune-hang-after-o8hS44` (past batch 7, and emitted warning)