### PR TITLE
Add step to free up some disk space on the worker

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
     - main
+  pull_request:
   workflow_dispatch: {}
 jobs:
   docker-build:
@@ -17,6 +18,14 @@ jobs:
           base_image: mosaicml/pytorch:2.0.1_cu118-python3.10-ubuntu20.04
 
     steps:
+    - name: Maximize Build Space on Worker
+      uses: easimon/maximize-build-space@v4
+      with:
+        overprovision-lvm: true
+        remove-dotnet: true
+        remove-android: true
+        remove-haskell: true
+
     - name: Checkout
       uses: actions/checkout@v3
 
@@ -48,7 +57,8 @@ jobs:
         context: .
         tags: mosaicml/llm-foundry:${{ matrix.name }}-latest,
           mosaicml/llm-foundry:${{ matrix.name }}-${{ env.IMAGE_TAG }}
-        push: true
+        #push: true
+        push: false
         cache-from: type=registry,ref=mosaicml/llm-foundry:${{ matrix.name }}-buildcache
         cache-to: type=registry,ref=mosaicml/llm-foundry:${{ matrix.name }}-buildcache,mode=max
         build-args: BASE_IMAGE=${{ matrix.base_image }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
     - main
-  pull_request:
   workflow_dispatch: {}
 jobs:
   docker-build:
@@ -57,8 +56,7 @@ jobs:
         context: .
         tags: mosaicml/llm-foundry:${{ matrix.name }}-latest,
           mosaicml/llm-foundry:${{ matrix.name }}-${{ env.IMAGE_TAG }}
-        #push: true
-        push: false
+        push: true
         cache-from: type=registry,ref=mosaicml/llm-foundry:${{ matrix.name }}-buildcache
         cache-to: type=registry,ref=mosaicml/llm-foundry:${{ matrix.name }}-buildcache,mode=max
         build-args: BASE_IMAGE=${{ matrix.base_image }}


### PR DESCRIPTION
This PR adds a step to the Docker build workflow to free up some disk space on the GHA worker to resolve the out of disk issue.

Tested the build in the PR by temporarily adding the `pull_request` trigger and disabling image pushing to not over-write production images. Test run is here:
https://github.com/mosaicml/llm-foundry/actions/runs/5337266091