### PR TITLE
Revert "Filter out sequences where prompt is longer than max length, rather than dropping them on the fly later"

### DIFF
--- a/llmfoundry/data/finetuning/dataloader.py
+++ b/llmfoundry/data/finetuning/dataloader.py
@@ -145,10 +145,7 @@ def build_finetuning_dataloader(cfg: DictConfig, tokenizer: Tokenizer,
         )
 
     else:
-        dataset = dataset_constructor.build_from_hf(
-            cfg.dataset,
-            max_seq_len=cfg.dataset.max_seq_len,
-            tokenizer=tokenizer)
+        dataset = dataset_constructor.build_from_hf(cfg.dataset, tokenizer)
 
         collate_fn, dataloader_batch_size = _build_collate_fn(
             cfg.dataset, tokenizer, device_batch_size)

--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -33,7 +33,6 @@ those keys are strings (i.e. text).
 
 import importlib
 import os
-import warnings
 from typing import Any, Callable, Dict, Optional, Union
 
 import datasets as hf_datasets
@@ -221,15 +220,11 @@ class DatasetConstructor:
 
         return preprocessing_fn
 
-    def build_from_hf(self, cfg: DictConfig, max_seq_len: int,
-                      tokenizer: Tokenizer):
+    def build_from_hf(self, cfg: DictConfig, tokenizer: Tokenizer):
         """Load a HuggingFace Datasets, preprocess, and tokenize.
-
-        Note: This function will drop examples where the prompt is longer than the max_seq_len
 
         Args:
             cfg (DictConfig): The dataset configuration.
-            max_seq_len (int): The maximum sequence length. Examples with prompts longer than this will be dropped.
             tokenizer (Tokenizer): The tokenizer to be used for tokenizing the dataset.
 
         Returns:
@@ -253,20 +248,9 @@ class DatasetConstructor:
             dataset_mapper,
             batched=False,
             remove_columns=columns_to_remove,
-            num_proc=max(os.cpu_count() - 2, 1),
         )
-        prompt_length_filtered_dataset = tokenized_dataset.filter(
-            lambda example: len(example['input_ids']) < max_seq_len,
-            num_proc=max(os.cpu_count() - 2, 1))
 
-        examples_removed = len(tokenized_dataset) - len(
-            prompt_length_filtered_dataset)
-        if examples_removed > 0:
-            warnings.warn(
-                f'Dropped {examples_removed} examples where the prompt was longer than {max_seq_len}.'
-            )
-
-        return prompt_length_filtered_dataset
+        return tokenized_dataset
 
     def build_from_streaming(self, *args: Any, **kwargs: Any):
         return StreamingFinetuningDataset(*args, **kwargs)


### PR DESCRIPTION
Reverts mosaicml/llm-foundry#348