### PR TITLE
fixed rmsnorm bug. Changed division to multiply since using torch.rsqrt

### DIFF
--- a/llmfoundry/models/layers/norm.py
+++ b/llmfoundry/models/layers/norm.py
@@ -52,7 +52,7 @@ class LPLayerNorm(torch.nn.LayerNorm):
 
 
 def rms_norm(x, weight=None, eps=1e-5):
-    output = x / torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + eps)
+    output = x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + eps)
     if weight is not None:
         return output * weight
     return output


### PR DESCRIPTION
RMSNorm was implemented incorrectly as noted in #371. This is the fix.