### PR TITLE
rm peft from pypi package

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,11 +32,13 @@ jobs:
           PYPI_PACKAGE_NAME="llm-foundry-test-$(date +%Y%m%d%H%M%S)"
         fi
 
-        # Remove the xentropy-cuda-lib and triton-pre-mlir dependencies as PyPI does not support
-        # direct installs. The error message for importing FusedCrossEntropy/flash_attn_triton
-        # gives instructions on how to install if a user tries to use it without this dependency.
+        # Remove the peft, xentropy-cuda-lib and triton-pre-mlir dependencies as PyPI does not
+        # support direct installs. The error message for importing PEFT, FusedCrossEntropy,
+        # and flash_attn_triton gives instructions on how to install if a user tries to use it
+        # without this dependency.
         sed '/xentropy-cuda-lib@git+https:\/\/github.com\/HazyResearch\/flash-attention.git@.*/d' -i setup.py
         sed '/triton-pre-mlir@git+https:\/\/github.com\/vchiley\/triton.git@.*/d' -i setup.py
+        sed '/peft@git+https:\/\/github.com\/huggingface\/peft.git@.*/d' -i setup.py
 
         python -m pip install --upgrade build twine
         python -m build

--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,7 @@ extra_deps['gpu'] = [
 
 extra_deps['peft'] = [
     'loralib==0.1.1',  # lora core
+    # PyPI does not support direct dependencies, so we remove this line before uploading from PyPI
     'peft @ git+https://github.com/huggingface/peft.git',  # TODO: pin it down only after it stabilizes.
     'bitsandbytes==0.39.1',  # 8bit
     'scipy>=1.10.0,<=1.11.0',  # bitsandbytes dependency; TODO: eliminate when incorporated to bitsandbytes


### PR DESCRIPTION
PyPI does not support direct dependencies, so we remove PEFT before PyPI build
