### PR TITLE
Add MaxSeqLen to ICL tasks

### DIFF
--- a/scripts/eval/yamls/tasks.yaml
+++ b/scripts/eval/yamls/tasks.yaml
@@ -1,3 +1,4 @@
+icl_seq_len: 2048
 icl_tasks:
 -
   label: jeopardy
@@ -6,23 +7,27 @@ icl_tasks:
   icl_task_type: language_modeling
   continuation_delimiter: "\nAnswer: " # this separates questions from answers
   has_categories: true
+  max_seq_len: ${icl_seq_len}
 -
   label: bigbench_qa_wikidata
   dataset_uri: eval/local_data/world_knowledge/bigbench_qa_wikidata.jsonl # ADD YOUR OWN DATASET URI
   num_fewshot: [10]
   icl_task_type: language_modeling
+  max_seq_len: ${icl_seq_len}
 -
   label: arc_easy
   dataset_uri: eval/local_data/world_knowledge/arc_easy.jsonl # ADD YOUR OWN DATASET URI
   num_fewshot: [10]
   icl_task_type: multiple_choice
   continuation_delimiter: "\nAnswer: " # this separates questions from answers
+  max_seq_len: ${icl_seq_len}
 -
   label: arc_challenge
   dataset_uri: eval/local_data/world_knowledge/arc_challenge.jsonl # ADD YOUR OWN DATASET URI
   num_fewshot: [10]
   icl_task_type: multiple_choice
   continuation_delimiter: "\nAnswer: " # this separates questions from answers
+  max_seq_len: ${icl_seq_len}
 -
   label: mmlu
   dataset_uri: eval/local_data/world_knowledge/mmlu.jsonl # ADD YOUR OWN DATASET URI
@@ -30,146 +35,175 @@ icl_tasks:
   icl_task_type: multiple_choice
   continuation_delimiter: "\nAnswer: " # this separates questions from answers
   has_categories: true
+  max_seq_len: ${icl_seq_len}
 -
   label: bigbench_misconceptions
   dataset_uri: eval/local_data/world_knowledge/bigbench_misconceptions.jsonl # ADD YOUR OWN DATASET URI
   num_fewshot: [10]
   icl_task_type: multiple_choice
+  max_seq_len: ${icl_seq_len}
 -
   label: copa
   dataset_uri: eval/local_data/commonsense_reasoning/copa.jsonl # ADD YOUR OWN DATASET URI
   num_fewshot: [0]
   icl_task_type: multiple_choice
+  max_seq_len: ${icl_seq_len}
 -
   label: piqa
   dataset_uri: eval/local_data/commonsense_reasoning/piqa.jsonl  # ADD YOUR OWN DATASET URI
   num_fewshot: [10]
   icl_task_type: multiple_choice
   continuation_delimiter: "\nAnswer: " # this separates questions from answers
+  max_seq_len: ${icl_seq_len}
 -
   label: openbook_qa
   dataset_uri: eval/local_data/commonsense_reasoning/openbook_qa.jsonl # ADD YOUR OWN DATASET URI
   num_fewshot: [0]
   icl_task_type: multiple_choice
+  max_seq_len: ${icl_seq_len}
 -
   label: bigbench_novel_concepts
   dataset_uri: eval/local_data/commonsense_reasoning/bigbench_novel_concepts.jsonl # ADD YOUR OWN DATASET URI
   num_fewshot: [10]
   icl_task_type: multiple_choice
+  max_seq_len: ${icl_seq_len}
 -
   label: bigbench_strange_stories
   dataset_uri: eval/local_data/commonsense_reasoning/bigbench_strange_stories.jsonl # ADD YOUR OWN DATASET URI
   num_fewshot: [10]
   icl_task_type: multiple_choice
+  max_seq_len: ${icl_seq_len}
 -
   label: bigbench_strategy_qa
   dataset_uri: eval/local_data/commonsense_reasoning/bigbench_strategy_qa.jsonl # ADD YOUR OWN DATASET URI
   num_fewshot: [10]
   icl_task_type: multiple_choice
+  max_seq_len: ${icl_seq_len}
 -
   label: lambada_openai
   dataset_uri: eval/local_data/language_understanding/lambada_openai.jsonl
   num_fewshot: [0]
   icl_task_type: language_modeling
+  max_seq_len: ${icl_seq_len}
 -
   label: hellaswag
   dataset_uri: eval/local_data/language_understanding/hellaswag.jsonl # ADD YOUR OWN DATASET URI
   num_fewshot: [10]
   icl_task_type: multiple_choice
+  max_seq_len: ${icl_seq_len}
 -
   label: winograd
   dataset_uri: eval/local_data/language_understanding/winograd_wsc.jsonl # ADD YOUR OWN DATASET URI
   num_fewshot: [0]
   icl_task_type: schema
+  max_seq_len: ${icl_seq_len}
 -
   label: winogrande
   dataset_uri: eval/local_data/language_understanding/winogrande.jsonl # ADD YOUR OWN DATASET URI
   num_fewshot: [0]
   icl_task_type: schema
+  max_seq_len: ${icl_seq_len}
 -
   label: bigbench_conlang_translation
   dataset_uri: eval/local_data/language_understanding/bigbench_conlang_translation.jsonl
   num_fewshot: [0]
   icl_task_type: language_modeling
+  max_seq_len: ${icl_seq_len}
 -
   label: bigbench_language_identification
   dataset_uri: eval/local_data/language_understanding/bigbench_language_identification.jsonl
   num_fewshot: [10]
   icl_task_type: multiple_choice
+  max_seq_len: ${icl_seq_len}
 -
   label: bigbench_conceptual_combinations
   dataset_uri: eval/local_data/language_understanding/bigbench_conceptual_combinations.jsonl
   num_fewshot: [10]
   icl_task_type: multiple_choice
+  max_seq_len: ${icl_seq_len}
 -
   label: bigbench_elementary_math_qa
   dataset_uri: eval/local_data/symbolic_problem_solving/bigbench_elementary_math_qa.jsonl
   num_fewshot: [10]
   icl_task_type: multiple_choice
+  max_seq_len: ${icl_seq_len}
 -
   label: bigbench_dyck_languages
   dataset_uri: eval/local_data/symbolic_problem_solving/bigbench_dyck_languages.jsonl
   num_fewshot: [10]
   icl_task_type: language_modeling
+  max_seq_len: ${icl_seq_len}
 -
   label: bigbench_cs_algorithms
   dataset_uri: eval/local_data/symbolic_problem_solving/bigbench_cs_algorithms.jsonl
   num_fewshot: [10]
   icl_task_type: language_modeling
+  max_seq_len: ${icl_seq_len}
 -
   label: bigbench_logical_deduction
   dataset_uri: eval/local_data/symbolic_problem_solving/bigbench_logical_deduction.jsonl
   num_fewshot: [10]
   icl_task_type: multiple_choice
+  max_seq_len: ${icl_seq_len}
 -
   label: bigbench_operators
   dataset_uri: eval/local_data/symbolic_problem_solving/bigbench_operators.jsonl
   num_fewshot: [10]
   icl_task_type: language_modeling
+  max_seq_len: ${icl_seq_len}
 -
   label: bigbench_repeat_copy_logic
   dataset_uri: eval/local_data/symbolic_problem_solving/bigbench_repeat_copy_logic.jsonl
   num_fewshot: [10]
   icl_task_type: language_modeling
+  max_seq_len: ${icl_seq_len}
 -
   label: simple_arithmetic_nospaces
   dataset_uri: eval/local_data/symbolic_problem_solving/simple_arithmetic_nospaces.jsonl
   num_fewshot: [10]
   icl_task_type: language_modeling
+  max_seq_len: ${icl_seq_len}
 -
   label: simple_arithmetic_withspaces
   dataset_uri: eval/local_data/symbolic_problem_solving/simple_arithmetic_withspaces.jsonl
   num_fewshot: [10]
   icl_task_type: language_modeling
+  max_seq_len: ${icl_seq_len}
 -
   label: math_qa
   dataset_uri: eval/local_data/symbolic_problem_solving/math_qa.jsonl
   num_fewshot: [10]
   icl_task_type: multiple_choice
+  max_seq_len: ${icl_seq_len}
 -
   label: logi_qa
   dataset_uri: eval/local_data/symbolic_problem_solving/logi_qa.jsonl
   num_fewshot: [10]
   icl_task_type: multiple_choice
   continuation_delimiter: "\nAnswer: " # this separates questions from answers
+  max_seq_len: ${icl_seq_len}
 -
   label: pubmed_qa_labeled
   dataset_uri: eval/local_data/reading_comprehension/pubmed_qa_labeled.jsonl # ADD YOUR OWN DATASET URI
   num_fewshot: [10]
   icl_task_type: language_modeling
+  max_seq_len: ${icl_seq_len}
 -
   label: squad
   dataset_uri: eval/local_data/reading_comprehension/squad.jsonl # ADD YOUR OWN DATASET URI
   num_fewshot: [10]
   icl_task_type: language_modeling
+  max_seq_len: ${icl_seq_len}
 -
   label: bigbench_understanding_fables
   dataset_uri: eval/local_data/reading_comprehension/bigbench_understanding_fables.jsonl # ADD YOUR OWN DATASET URI
   num_fewshot: [10]
   icl_task_type: multiple_choice
+  max_seq_len: ${icl_seq_len}
 -
   label: boolq
   dataset_uri: eval/local_data/reading_comprehension/boolq.jsonl # ADD YOUR OWN DATASET URI
   num_fewshot: [10]
   icl_task_type: multiple_choice
   continuation_delimiter: "\nAnswer: " # this separates questions from answers
+  max_seq_len: ${icl_seq_len}

--- a/scripts/eval/yamls/tasks.yaml
+++ b/scripts/eval/yamls/tasks.yaml
@@ -1,4 +1,3 @@
-icl_seq_len: 2048
 icl_tasks:
 -
   label: jeopardy
@@ -7,27 +6,23 @@ icl_tasks:
   icl_task_type: language_modeling
   continuation_delimiter: "\nAnswer: " # this separates questions from answers
   has_categories: true
-  max_seq_len: ${icl_seq_len}
 -
   label: bigbench_qa_wikidata
   dataset_uri: eval/local_data/world_knowledge/bigbench_qa_wikidata.jsonl # ADD YOUR OWN DATASET URI
   num_fewshot: [10]
   icl_task_type: language_modeling
-  max_seq_len: ${icl_seq_len}
 -
   label: arc_easy
   dataset_uri: eval/local_data/world_knowledge/arc_easy.jsonl # ADD YOUR OWN DATASET URI
   num_fewshot: [10]
   icl_task_type: multiple_choice
   continuation_delimiter: "\nAnswer: " # this separates questions from answers
-  max_seq_len: ${icl_seq_len}
 -
   label: arc_challenge
   dataset_uri: eval/local_data/world_knowledge/arc_challenge.jsonl # ADD YOUR OWN DATASET URI
   num_fewshot: [10]
   icl_task_type: multiple_choice
   continuation_delimiter: "\nAnswer: " # this separates questions from answers
-  max_seq_len: ${icl_seq_len}
 -
   label: mmlu
   dataset_uri: eval/local_data/world_knowledge/mmlu.jsonl # ADD YOUR OWN DATASET URI
@@ -35,175 +30,146 @@ icl_tasks:
   icl_task_type: multiple_choice
   continuation_delimiter: "\nAnswer: " # this separates questions from answers
   has_categories: true
-  max_seq_len: ${icl_seq_len}
 -
   label: bigbench_misconceptions
   dataset_uri: eval/local_data/world_knowledge/bigbench_misconceptions.jsonl # ADD YOUR OWN DATASET URI
   num_fewshot: [10]
   icl_task_type: multiple_choice
-  max_seq_len: ${icl_seq_len}
 -
   label: copa
   dataset_uri: eval/local_data/commonsense_reasoning/copa.jsonl # ADD YOUR OWN DATASET URI
   num_fewshot: [0]
   icl_task_type: multiple_choice
-  max_seq_len: ${icl_seq_len}
 -
   label: piqa
   dataset_uri: eval/local_data/commonsense_reasoning/piqa.jsonl  # ADD YOUR OWN DATASET URI
   num_fewshot: [10]
   icl_task_type: multiple_choice
   continuation_delimiter: "\nAnswer: " # this separates questions from answers
-  max_seq_len: ${icl_seq_len}
 -
   label: openbook_qa
   dataset_uri: eval/local_data/commonsense_reasoning/openbook_qa.jsonl # ADD YOUR OWN DATASET URI
   num_fewshot: [0]
   icl_task_type: multiple_choice
-  max_seq_len: ${icl_seq_len}
 -
   label: bigbench_novel_concepts
   dataset_uri: eval/local_data/commonsense_reasoning/bigbench_novel_concepts.jsonl # ADD YOUR OWN DATASET URI
   num_fewshot: [10]
   icl_task_type: multiple_choice
-  max_seq_len: ${icl_seq_len}
 -
   label: bigbench_strange_stories
   dataset_uri: eval/local_data/commonsense_reasoning/bigbench_strange_stories.jsonl # ADD YOUR OWN DATASET URI
   num_fewshot: [10]
   icl_task_type: multiple_choice
-  max_seq_len: ${icl_seq_len}
 -
   label: bigbench_strategy_qa
   dataset_uri: eval/local_data/commonsense_reasoning/bigbench_strategy_qa.jsonl # ADD YOUR OWN DATASET URI
   num_fewshot: [10]
   icl_task_type: multiple_choice
-  max_seq_len: ${icl_seq_len}
 -
   label: lambada_openai
   dataset_uri: eval/local_data/language_understanding/lambada_openai.jsonl
   num_fewshot: [0]
   icl_task_type: language_modeling
-  max_seq_len: ${icl_seq_len}
 -
   label: hellaswag
   dataset_uri: eval/local_data/language_understanding/hellaswag.jsonl # ADD YOUR OWN DATASET URI
   num_fewshot: [10]
   icl_task_type: multiple_choice
-  max_seq_len: ${icl_seq_len}
 -
   label: winograd
   dataset_uri: eval/local_data/language_understanding/winograd_wsc.jsonl # ADD YOUR OWN DATASET URI
   num_fewshot: [0]
   icl_task_type: schema
-  max_seq_len: ${icl_seq_len}
 -
   label: winogrande
   dataset_uri: eval/local_data/language_understanding/winogrande.jsonl # ADD YOUR OWN DATASET URI
   num_fewshot: [0]
   icl_task_type: schema
-  max_seq_len: ${icl_seq_len}
 -
   label: bigbench_conlang_translation
   dataset_uri: eval/local_data/language_understanding/bigbench_conlang_translation.jsonl
   num_fewshot: [0]
   icl_task_type: language_modeling
-  max_seq_len: ${icl_seq_len}
 -
   label: bigbench_language_identification
   dataset_uri: eval/local_data/language_understanding/bigbench_language_identification.jsonl
   num_fewshot: [10]
   icl_task_type: multiple_choice
-  max_seq_len: ${icl_seq_len}
 -
   label: bigbench_conceptual_combinations
   dataset_uri: eval/local_data/language_understanding/bigbench_conceptual_combinations.jsonl
   num_fewshot: [10]
   icl_task_type: multiple_choice
-  max_seq_len: ${icl_seq_len}
 -
   label: bigbench_elementary_math_qa
   dataset_uri: eval/local_data/symbolic_problem_solving/bigbench_elementary_math_qa.jsonl
   num_fewshot: [10]
   icl_task_type: multiple_choice
-  max_seq_len: ${icl_seq_len}
 -
   label: bigbench_dyck_languages
   dataset_uri: eval/local_data/symbolic_problem_solving/bigbench_dyck_languages.jsonl
   num_fewshot: [10]
   icl_task_type: language_modeling
-  max_seq_len: ${icl_seq_len}
 -
   label: bigbench_cs_algorithms
   dataset_uri: eval/local_data/symbolic_problem_solving/bigbench_cs_algorithms.jsonl
   num_fewshot: [10]
   icl_task_type: language_modeling
-  max_seq_len: ${icl_seq_len}
 -
   label: bigbench_logical_deduction
   dataset_uri: eval/local_data/symbolic_problem_solving/bigbench_logical_deduction.jsonl
   num_fewshot: [10]
   icl_task_type: multiple_choice
-  max_seq_len: ${icl_seq_len}
 -
   label: bigbench_operators
   dataset_uri: eval/local_data/symbolic_problem_solving/bigbench_operators.jsonl
   num_fewshot: [10]
   icl_task_type: language_modeling
-  max_seq_len: ${icl_seq_len}
 -
   label: bigbench_repeat_copy_logic
   dataset_uri: eval/local_data/symbolic_problem_solving/bigbench_repeat_copy_logic.jsonl
   num_fewshot: [10]
   icl_task_type: language_modeling
-  max_seq_len: ${icl_seq_len}
 -
   label: simple_arithmetic_nospaces
   dataset_uri: eval/local_data/symbolic_problem_solving/simple_arithmetic_nospaces.jsonl
   num_fewshot: [10]
   icl_task_type: language_modeling
-  max_seq_len: ${icl_seq_len}
 -
   label: simple_arithmetic_withspaces
   dataset_uri: eval/local_data/symbolic_problem_solving/simple_arithmetic_withspaces.jsonl
   num_fewshot: [10]
   icl_task_type: language_modeling
-  max_seq_len: ${icl_seq_len}
 -
   label: math_qa
   dataset_uri: eval/local_data/symbolic_problem_solving/math_qa.jsonl
   num_fewshot: [10]
   icl_task_type: multiple_choice
-  max_seq_len: ${icl_seq_len}
 -
   label: logi_qa
   dataset_uri: eval/local_data/symbolic_problem_solving/logi_qa.jsonl
   num_fewshot: [10]
   icl_task_type: multiple_choice
   continuation_delimiter: "\nAnswer: " # this separates questions from answers
-  max_seq_len: ${icl_seq_len}
 -
   label: pubmed_qa_labeled
   dataset_uri: eval/local_data/reading_comprehension/pubmed_qa_labeled.jsonl # ADD YOUR OWN DATASET URI
   num_fewshot: [10]
   icl_task_type: language_modeling
-  max_seq_len: ${icl_seq_len}
 -
   label: squad
   dataset_uri: eval/local_data/reading_comprehension/squad.jsonl # ADD YOUR OWN DATASET URI
   num_fewshot: [10]
   icl_task_type: language_modeling
-  max_seq_len: ${icl_seq_len}
 -
   label: bigbench_understanding_fables
   dataset_uri: eval/local_data/reading_comprehension/bigbench_understanding_fables.jsonl # ADD YOUR OWN DATASET URI
   num_fewshot: [10]
   icl_task_type: multiple_choice
-  max_seq_len: ${icl_seq_len}
 -
   label: boolq
   dataset_uri: eval/local_data/reading_comprehension/boolq.jsonl # ADD YOUR OWN DATASET URI
   num_fewshot: [10]
   icl_task_type: multiple_choice
   continuation_delimiter: "\nAnswer: " # this separates questions from answers
-  max_seq_len: ${icl_seq_len}

--- a/scripts/eval/yamls/tasks_light.yaml
+++ b/scripts/eval/yamls/tasks_light.yaml
@@ -1,48 +1,40 @@
-icl_seq_len: 2048
 icl_tasks:
 -
   label: lambada_openai
   dataset_uri: eval/local_data/language_understanding/lambada_openai.jsonl  # or use your own dataset URI
   num_fewshot: [0]
   icl_task_type: language_modeling
-  max_seq_len: ${icl_seq_len}
 -
   label: piqa
   dataset_uri: eval/local_data/commonsense_reasoning/piqa.jsonl
   num_fewshot: [10]
   icl_task_type: multiple_choice
   continuation_delimiter: "\nAnswer: " # this separates questions from answers
-  max_seq_len: ${icl_seq_len}
 -
   label: hellaswag
   dataset_uri: eval/local_data/language_understanding/hellaswag.jsonl
   num_fewshot: [10]
   icl_task_type: multiple_choice
-  max_seq_len: ${icl_seq_len}
 -
   label: arc_easy
   dataset_uri: eval/local_data/world_knowledge/arc_easy.jsonl
   num_fewshot: [10]
   icl_task_type: multiple_choice
   continuation_delimiter: "\nAnswer: "
-  max_seq_len: ${icl_seq_len}
 -
   label: arc_challenge
   dataset_uri: eval/local_data/world_knowledge/arc_challenge.jsonl
   num_fewshot: [10]
   icl_task_type: multiple_choice
   continuation_delimiter: "\nAnswer: "
-  max_seq_len: ${icl_seq_len}
 -
   label: copa
   dataset_uri: eval/local_data/commonsense_reasoning/copa.jsonl
   num_fewshot: [0]
   icl_task_type: multiple_choice
-  max_seq_len: ${icl_seq_len}
 -
   label: boolq
   dataset_uri: eval/local_data/reading_comprehension/boolq.jsonl
   num_fewshot: [10]
   icl_task_type: multiple_choice
   continuation_delimiter: "\nAnswer: "
-  max_seq_len: ${icl_seq_len}

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -235,7 +235,7 @@ def main(cfg):
 
     if 'icl_tasks' in cfg:
         icl_evaluators, _ = build_icl_evaluators(cfg.icl_tasks, tokenizer,
-                                                 cfg.max_seq_len,
+                                                 cfg.get('icl_max_seq_len', cfg.max_seq_len),
                                                  cfg.device_eval_batch_size)
         evaluators.extend(icl_evaluators)
 


### PR DESCRIPTION
~~Add MaxSeqLen to ICL tasks in `tasks.yaml`~~

~~We have it in [`tasks_light.yaml`](https://github.com/mosaicml/llm-foundry/blob/main/scripts/eval/yamls/tasks_light.yaml) but not here~~

Seems like the more correct approach would be to enable a `icl_max_seq_len` cfg setting.