### PR TITLE
Use torch.repeat instead of expand on key & value in Triton MQA to prevent NaNs with certain h_dims

### DIFF
--- a/llmfoundry/models/layers/attention.py
+++ b/llmfoundry/models/layers/attention.py
@@ -312,6 +312,8 @@ def triton_flash_attn_fn(
                       h=1 if multiquery else n_heads)
 
     if multiquery:
+        # necessary to repeat instead of expand tensor because
+        # output contains NaN in edge cases such as with head dimension = 8
         key = key.repeat(1, 1, n_heads, 1)
         value = value.repeat(1, 1, n_heads, 1)
 

--- a/llmfoundry/models/layers/attention.py
+++ b/llmfoundry/models/layers/attention.py
@@ -312,14 +312,8 @@ def triton_flash_attn_fn(
                       h=1 if multiquery else n_heads)
 
     if multiquery:
-        # Expanding a tensor does not allocate new memory, but only creates a new
-        # view on the existing tensor where a dimension of size one is expanded
-        # to a larger size by setting the stride to 0.
-        # - pytorch docs
-        #
-        # hopefully the kernels can utilize this and we're jot just wasting BW here
-        key = key.expand(*key.shape[:2], n_heads, key.size(-1))
-        value = value.expand(*value.shape[:2], n_heads, value.size(-1))
+        key = key.repeat(1, 1, n_heads, 1)
+        value = value.repeat(1, 1, n_heads, 1)
 
     reset_is_causal = _reset_is_causal(query.size(1), key.size(1), is_causal)
     attn_output = flash_attn_func(query, key, value, attn_bias, reset_is_causal,


### PR DESCRIPTION
For h_dim=8, we see NaNs due to a `.expand` of the key value tensors, which can be resolved with `.repeat`. While h_dim=8 is an edge case, we are not sure if there are other cases of h_dims for which this might be problematic, or if there might be silent failures. 

Note that this does come at a performance hit, see MFU for 7b, so it may be desirable to revert this change in the future.

(blue curve: `.expand()` green curve `.repeat()` red curve `.expand().clone()`)
<img width="376" alt="image" src="https://github.com/mosaicml/llm-foundry/assets/4717972/385f222f-5ac4-430d-b10c-67c084b97955">
