### PR TITLE
use mono checkpoints

### DIFF
--- a/scripts/train/yamls/finetune/mpt-30b-instruct.yaml
+++ b/scripts/train/yamls/finetune/mpt-30b-instruct.yaml
@@ -101,7 +101,6 @@ fsdp_config:
   activation_cpu_offload: false
   limit_all_gathers: true
   sync_module_states: true
-  state_dict_type: local
   verbose: false
 
 # Logging


### PR DESCRIPTION
Users are ending up with sharded checkpoints, unable to convert to HF format. I believe that removing this line will cause us to save mono checkpoints.