### PR TITLE
setup.py: replace composer with mosaicml

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ classifiers = [
 ]
 
 install_requires = [
-    'composer[libcloud,nlp,wandb]>=0.15.0,<0.16',
+    'mosaicml[libcloud,nlp,wandb]>=0.15.0,<0.16',
     'accelerate>=0.19,<0.20',  # for HF inference `device_map`
     'mosaicml-streaming>=0.5.1,<0.6',
     'torch>=1.13.1,<=2.0.1',
@@ -77,7 +77,7 @@ extra_deps['dev'] = [
 ]
 
 extra_deps['tensorboard'] = [
-    'composer[tensorboard]>=0.15.0,<0.16',
+    'mosaicml[tensorboard]>=0.15.0,<0.16',
 ]
 
 extra_deps['gpu'] = [


### PR DESCRIPTION
When we build mosaicml with "pip install -e .", we'll see package mosaicml is installed with link to the code tree of composer.

Without this change, we'll see package composer is again installed without link to the code tree of composer. mosaicml and composer are two different packages and llm-foundry will call into package composer which is not what we expect.

With this change, llm-foundry will call into the code tree of composer which is our expectation.