### PR TITLE
Adding different device intialization to eval

### DIFF
--- a/llmfoundry/utils/config_utils.py
+++ b/llmfoundry/utils/config_utils.py
@@ -1,7 +1,9 @@
 # Copyright 2022 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
+import contextlib
 import math
+import warnings
 from typing import Union
 
 from composer.utils import dist
@@ -49,6 +51,39 @@ def update_batch_size_info(cfg: DictConfig):
         else:
             cfg.device_eval_batch_size = cfg.device_train_microbatch_size
     return cfg
+
+
+def process_init_device(model_cfg: DictConfig, fsdp_config: dict):
+    # Restrict model init_device to 'meta' and 'cpu',
+    # using 'cuda' vs. 'cuda:id' is tricky and can lead to common user errors
+    # when multiple GPUs are available.
+    # Also 'meta' is only valid when using FSDP
+    init_context = contextlib.nullcontext()
+    if 'init_device' in model_cfg:
+        assert model_cfg.init_device in ['meta', 'cpu', 'mixed']
+        if fsdp_config is None and model_cfg.init_device == 'meta':
+            warnings.warn(
+                "Using `cfg.model.init_device='meta'` is only valid when using FSDP! " +\
+                "Reverting to `cfg.model.init_device='cpu'`.")
+            model_cfg.init_device = 'cpu'
+        if model_cfg.init_device == 'meta':
+            init_context = init_empty_weights()
+        if model_cfg.init_device == 'mixed':
+            if fsdp_config is None:
+                raise NotImplementedError(
+                    'Using init_device `mixed` is only supported with FSDP. '
+                    'Please add a FSDP config.')
+            # Always set `sync_module_states` to True for mixed initialization
+            if not fsdp_config.get('sync_module_states', False):
+                warnings.warn((
+                    'Setting `sync_module_states = True` for FSDP. This is required '
+                    'when using mixed initialization.'))
+                fsdp_config['sync_module_states'] = True
+
+            # Set defaults for mixed initialization
+            fsdp_config.setdefault('use_orig_params', False)
+            fsdp_config.setdefault('load_monolith_rank0_only', True)
+    return init_context
 
 
 def log_config(cfg: DictConfig):

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -22,7 +22,8 @@ from llmfoundry.utils.builders import (build_algorithm, build_callback,
                                        build_icl_evaluators, build_logger,
                                        build_optimizer, build_scheduler,
                                        build_tokenizer)
-from llmfoundry.utils.config_utils import log_config, update_batch_size_info
+from llmfoundry.utils.config_utils import (log_config, process_init_device,
+                                           update_batch_size_info)
 
 
 def validate_config(cfg):
@@ -199,35 +200,7 @@ def main(cfg):
         cfg.pop('fsdp_config')
         fsdp_config = None
 
-    # Restrict model init_device to 'meta' and 'cpu',
-    # using 'cuda' vs. 'cuda:id' is tricky and can lead to common user errors
-    # when multiple GPUs are available.
-    # Also 'meta' is only valid when using FSDP
-    init_context = init_on_device(device=torch.device('cpu'))
-    if 'init_device' in cfg.model:
-        assert cfg.model.init_device in ['meta', 'cpu', 'mixed']
-        if fsdp_config is None and cfg.model.init_device == 'meta':
-            warnings.warn(
-                "Using `cfg.model.init_device='meta'` is only valid when using FSDP! " +\
-                "Reverting to `cfg.model.init_device='cpu'`.")
-            cfg.model.init_device = 'cpu'
-        if cfg.model.init_device == 'meta':
-            init_context = init_empty_weights()
-        if cfg.model.init_device == 'mixed':
-            if fsdp_config is None:
-                raise NotImplementedError(
-                    'Using init_device `mixed` is only supported with FSDP. '
-                    'Please add a FSDP config.')
-            # Always set `sync_module_states` to True for mixed initialization
-            if not fsdp_config.get('sync_module_states', False):
-                warnings.warn((
-                    'Setting `sync_module_states = True` for FSDP. This is required '
-                    'when using mixed initialization.'))
-                fsdp_config['sync_module_states'] = True
-
-            # Set defaults for mixed initialization
-            fsdp_config.setdefault('use_orig_params', False)
-            fsdp_config.setdefault('load_monolith_rank0_only', True)
+    init_context = process_init_device(cfg.model, fsdp_config)
 
     # build tokenizer
     tokenizer = build_tokenizer(cfg.tokenizer)


### PR DESCRIPTION
Allow `mixed` initialization for eval.py in LLM-Foundry. Run on `r1z1` here:

mpt30b-chat-hf-eval-r1z1-hs6a7u