### PR TITLE
Support eval loader when finetuning from JSONL files in object stores

### DIFF
--- a/llmfoundry/data/finetuning/dataloader.py
+++ b/llmfoundry/data/finetuning/dataloader.py
@@ -157,7 +157,8 @@ def build_finetuning_dataloader(cfg: DictConfig, tokenizer: Tokenizer,
                     '`split` key in the dataset config.'
                 )
             supported_extensions = ['jsonl', 'csv', 'parquet']
-            finetune_dir = "/data/finetuning"
+            # using Tempdir causes issues with HF datasets caching
+            finetune_dir = f'/llm-foundry/data/finetuning/{cfg.dataset.split}'
             for extension in supported_extensions:
                 name = f'{cfg.dataset.hf_name.strip("/")}/{cfg.dataset.split}.{extension}'
                 destination = str(
@@ -178,11 +179,7 @@ def build_finetuning_dataloader(cfg: DictConfig, tokenizer: Tokenizer,
                             f'Could not find {name}, looking for another extension'
                         )
                     continue
-                # 'json' causes special behavior in the dataset constructor
-                cfg.dataset.hf_name = extension if extension != 'jsonl' else 'json'
-                kwargs = cfg.dataset.get('hf_kwargs', {})
-                kwargs['data_files'] = destination
-                cfg.dataset['hf_kwargs'] = kwargs
+                cfg.dataset.hf_name = finetune_dir
                 print(cfg.dataset)
                 dataset = dataset_constructor.build_from_hf(
                     cfg.dataset,

--- a/llmfoundry/data/finetuning/dataloader.py
+++ b/llmfoundry/data/finetuning/dataloader.py
@@ -249,7 +249,7 @@ def _build_hf_dataset_from_remote(cfg: DictConfig, tokenizer: Tokenizer):
     Args:
         cfg (DictConfig): The configuration dictionary containing the necessary parameters to load the dataset.
             This includes:
-                - dataset.hf_name: The name of the HuggingFace dataset to download.
+                - dataset.hf_name: The path of the HuggingFace dataset to download.
                 - dataset.split: The dataset split to download (e.g., 'train', 'validation', 'test').
                 - dataset.max_seq_len: The maximum sequence length for tokenizing the dataset.
 

--- a/llmfoundry/data/finetuning/dataloader.py
+++ b/llmfoundry/data/finetuning/dataloader.py
@@ -272,7 +272,7 @@ def _build_hf_dataset_from_remote(cfg: DictConfig, tokenizer: Tokenizer):
             os.path.abspath(f'{finetune_dir}/{cfg.dataset.split}.{extension}'))
         # Since we don't know exactly what the extension will be, since it is one of a list
         # use a signal file to wait for instead of the desired file
-        signal_file_path = os.path.join(finetune_dir, 'the_eagle_has_landed')
+        signal_file_path = os.path.join(finetune_dir, '.the_eagle_has_landed')
         if dist.get_local_rank() == 0:
             try:
                 get_file(name, destination, overwrite=True)
@@ -290,7 +290,7 @@ def _build_hf_dataset_from_remote(cfg: DictConfig, tokenizer: Tokenizer):
 
             os.makedirs(os.path.dirname(signal_file_path), exist_ok=True)
             with open(signal_file_path, 'wb') as f:
-                f.write(b'local_rank0_completed_autoresume')
+                f.write(b'local_rank0_completed_download')
 
         # Avoid the collective call until the local rank zero has finished trying to download the checkpoint
         # so that we don't timeout for large downloads. This syncs all processes on the node

--- a/llmfoundry/data/finetuning/dataloader.py
+++ b/llmfoundry/data/finetuning/dataloader.py
@@ -157,7 +157,9 @@ def build_finetuning_dataloader(cfg: DictConfig, tokenizer: Tokenizer,
                 )
             supported_extensions = ['jsonl', 'csv', 'parquet']
             # using Tempdir causes issues with HF datasets caching
-            finetune_dir = f'/llm-foundry/data/finetuning/{cfg.dataset.split}'
+            finetune_dir = os.path.join(
+                os.path.dirname(os.path.realpath(__file__)),
+                f'downloaded_finetuning_data/{cfg.dataset.split}')
             for extension in supported_extensions:
                 name = f'{cfg.dataset.hf_name.strip("/")}/{cfg.dataset.split}.{extension}'
                 destination = str(

--- a/llmfoundry/data/finetuning/dataloader.py
+++ b/llmfoundry/data/finetuning/dataloader.py
@@ -239,13 +239,12 @@ def _build_hf_dataset_from_remote(cfg: DictConfig, tokenizer: Tokenizer):
     """Builds a dataset from a remote object store.
 
     This function supports 'jsonl', 'csv', and 'parquet' file formats for the dataset. It will attempt to download
-    the dataset, convert it into a format that can be used for fine-tuning the model, and then return this dataset.
-    This function uses HuggingFace's datasets module to load the dataset from remote and then converts it into the
-    appropriate format.
+    the dataset, then once it is downloaded, convert it into HuggingFace ``datasets`` format, and then return this
+    dataset.
 
-    The function also ensures synchronicity across multiple nodes during the download and file handling processes. It
-    creates a signal file that is used to synchronize the start of the download process across different nodes. Once
-    the download is completed, the function removes the signal file.
+    The function also ensures synchronicity across multiple processes during the file download. It creates a signal
+    file that is used to synchronize the start of the download across different processes. Once the download is
+    completed, the function removes the signal file.
 
     Args:
         cfg (DictConfig): The configuration dictionary containing the necessary parameters to load the dataset.
@@ -257,7 +256,7 @@ def _build_hf_dataset_from_remote(cfg: DictConfig, tokenizer: Tokenizer):
         tokenizer (Tokenizer): The tokenizer to be used to tokenize the dataset.
 
     Returns:
-        Dataset: A dataset built from the remote file, prepared and tokenized for fine-tuning the model.
+        Dataset: A HuggingFace dataset built from the remote file, prepared and tokenized for fine-tuning the model.
 
     Raises:
         FileNotFoundError: Raised if the dataset file cannot be found with any of the supported extensions.

--- a/llmfoundry/data/finetuning/dataloader.py
+++ b/llmfoundry/data/finetuning/dataloader.py
@@ -194,7 +194,7 @@ def build_finetuning_dataloader(cfg: DictConfig, tokenizer: Tokenizer,
                 # Avoid the collective call until the local rank zero has finished trying to download the file
                 # so that we don't timeout for large downloads. This syncs all processes on the node
                 with dist.local_rank_zero_download_and_wait(signal_file_path):
-                    # Then, wait to ensure every node has finished downloading the checkpoint
+                    # Then, wait to ensure every node has finished downloading the file
                     dist.barrier()
 
                 # clean up signal file

--- a/llmfoundry/data/finetuning/dataloader.py
+++ b/llmfoundry/data/finetuning/dataloader.py
@@ -169,7 +169,7 @@ def build_finetuning_dataloader(cfg: DictConfig, tokenizer: Tokenizer,
                 # use a signal file to wait for instead of the desired file
                 signal_file_path = os.path.join(
                     os.path.dirname(os.path.realpath(__file__)),
-                    'the_eagle_has_landed.txt')
+                    '.the_eagle_has_landed')
                 if dist.get_local_rank() == 0:
                     try:
                         get_file(name, destination, overwrite=True)
@@ -189,9 +189,9 @@ def build_finetuning_dataloader(cfg: DictConfig, tokenizer: Tokenizer,
                     os.makedirs(os.path.dirname(signal_file_path),
                                 exist_ok=True)
                     with open(signal_file_path, 'wb') as f:
-                        f.write(b'local_rank0_completed_autoresume')
+                        f.write(b'local_rank0_download_successful')
 
-                # Avoid the collective call until the local rank zero has finished trying to download the checkpoint
+                # Avoid the collective call until the local rank zero has finished trying to download the file
                 # so that we don't timeout for large downloads. This syncs all processes on the node
                 with dist.local_rank_zero_download_and_wait(signal_file_path):
                     # Then, wait to ensure every node has finished downloading the checkpoint

--- a/llmfoundry/data/finetuning/dataloader.py
+++ b/llmfoundry/data/finetuning/dataloader.py
@@ -3,7 +3,6 @@
 
 import logging
 import os
-import tempfile
 from typing import Union
 
 import torch


### PR DESCRIPTION
`datasets` caching was causing the error, saving to a non-temp dir, with different dirs per split, fixes it