### PR TITLE
Update accelerate to 0.20.3 for LLaMa-2 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ classifiers = [
 
 install_requires = [
     'mosaicml[libcloud,nlp,wandb]>=0.15.0,<0.16',
-    'accelerate>=0.19,<0.20',  # for HF inference `device_map`
+    'accelerate>=0.20,<0.21',  # for HF inference `device_map`
     'mosaicml-streaming>=0.5.1,<0.6',
     'torch>=1.13.1,<=2.0.1',
     'datasets==2.10.1',


### PR DESCRIPTION
Accelerate 0.20.3 is needed for transformers 4.31 and hence LLaMa-2-70B