### PR TITLE
Grouped Query Attention + Refactor Attn

### DIFF
--- a/llmfoundry/models/layers/attention.py
+++ b/llmfoundry/models/layers/attention.py
@@ -36,7 +36,7 @@ def scaled_multihead_dot_product_attention(
     key: torch.Tensor,
     value: torch.Tensor,
     n_heads: int,
-    kv_n_heads: int,
+    kv_n_heads: Optional[int] = None,
     past_key_value: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
     softmax_scale: Optional[float] = None,
     attn_bias: Optional[torch.Tensor] = None,
@@ -55,6 +55,12 @@ def scaled_multihead_dot_product_attention(
                 'The direct use of the multiquery arg is deprecated. Setting kv_n_heads=1 automatically. Please set kv_n_heads=1 explicitly to remove this warning.'
             ))
         kv_n_heads = 1
+    elif kv_n_heads is None:
+        warnings.warn(
+            DeprecationWarning(
+                'Not specifying a value for the kv_n_heads arg is deprecated. Setting kv_n_heads=n_heads automatically. Please set kv_n_heads=n_heads explicitly to remove this warning.'
+            ))
+        kv_n_heads = n_heads
 
     q = rearrange(query, 'b s (h d) -> b h s d', h=n_heads)
     k = rearrange(key, 'b s (h d) -> b h d s', h=kv_n_heads)
@@ -156,7 +162,7 @@ def flash_attn_fn(
     key: torch.Tensor,
     value: torch.Tensor,
     n_heads: int,
-    kv_n_heads: int,
+    kv_n_heads: Optional[int] = None,
     past_key_value: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
     softmax_scale: Optional[float] = None,
     attn_bias: Optional[torch.Tensor] = None,
@@ -181,6 +187,12 @@ def flash_attn_fn(
                 'The direct use of the multiquery arg is deprecated. Setting kv_n_heads=1 automatically. Please set kv_n_heads=1 explicitly to remove this warning.'
             ))
         kv_n_heads = 1
+    elif kv_n_heads is None:
+        warnings.warn(
+            DeprecationWarning(
+                'Not specifying a value for the kv_n_heads arg is deprecated. Setting kv_n_heads=n_heads automatically. Please set kv_n_heads=n_heads explicitly to remove this warning.'
+            ))
+        kv_n_heads = n_heads
 
     if past_key_value is not None:
         if len(past_key_value) != 0:
@@ -264,7 +276,7 @@ def triton_flash_attn_fn(
     key: torch.Tensor,
     value: torch.Tensor,
     n_heads: int,
-    kv_n_heads: int,
+    kv_n_heads: Optional[int] = None,
     past_key_value: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
     softmax_scale: Optional[float] = None,
     attn_bias: Optional[torch.Tensor] = None,
@@ -311,6 +323,12 @@ def triton_flash_attn_fn(
                 'The direct use of the multiquery arg is deprecated. Setting kv_n_heads=1 automatically. Please set kv_n_heads=1 explicitly to remove this warning.'
             ))
         kv_n_heads = 1
+    elif kv_n_heads is None:
+        warnings.warn(
+            DeprecationWarning(
+                'Not specifying a value for the kv_n_heads arg is deprecated. Setting kv_n_heads=n_heads automatically. Please set kv_n_heads=n_heads explicitly to remove this warning.'
+            ))
+        kv_n_heads = n_heads
 
     if past_key_value is not None:
         if len(past_key_value) != 0:

--- a/llmfoundry/models/layers/attention.py
+++ b/llmfoundry/models/layers/attention.py
@@ -462,12 +462,12 @@ class GroupedQueryAttention(nn.Module):
             qkv = qkv.clamp(min=-self.clip_qkv, max=self.clip_qkv)
 
         query, key, value = qkv.split(
-        [
-            self.d_model, 
-            self.kv_n_heads * self.head_dim,
-            self.kv_n_heads * self.head_dim,
-        ],
-        dim=2,
+            [
+                self.d_model,
+                self.kv_n_heads * self.head_dim,
+                self.kv_n_heads * self.head_dim,
+            ],
+            dim=2,
         )
 
         key_padding_mask = attention_mask

--- a/llmfoundry/models/layers/attention.py
+++ b/llmfoundry/models/layers/attention.py
@@ -354,7 +354,7 @@ def triton_flash_attn_fn(
 
 
 class GroupedQueryAttention(nn.Module):
-    """GQA is a generalization of Multi-head and Multi-query attention.
+    """ Grouped Query Attention (GQA) is a generalization of Multi-head (MHA) and Multi-query attention (MQA).
 
     This allows the user to set a variable of number of kv_n_heads, rather than
     just n_heads or 1, as in MHA and MQA. Using torch or triton attention

--- a/llmfoundry/models/layers/attention.py
+++ b/llmfoundry/models/layers/attention.py
@@ -425,7 +425,7 @@ class GroupedQueryAttention(nn.Module):
 
         if self.n_heads % self.kv_n_heads != 0:
             raise ValueError(
-                'Each Q head should get the same number of KV heads, so n_heads must be divisible by kv_n_heads'
+                'Each Q head should get the same number of KV heads, so n_heads must be divisible by kv_n_heads.'
             )
 
         self.softmax_scale = softmax_scale

--- a/llmfoundry/models/layers/attention.py
+++ b/llmfoundry/models/layers/attention.py
@@ -45,7 +45,8 @@ def scaled_multihead_dot_product_attention(
     dropout_p: float = 0.0,
     training: bool = False,
     needs_weights: bool = False,
-):
+) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor,
+                                                                torch.Tensor]]]:
     q = rearrange(query, 'b s (h d) -> b h s d', h=n_heads)
     k = rearrange(key, 'b s (h d) -> b h d s', h=kv_n_heads)
     v = rearrange(value, 'b s (h d) -> b h s d', h=kv_n_heads)
@@ -155,7 +156,8 @@ def flash_attn_fn(
     dropout_p: float = 0.0,
     training: bool = False,
     needs_weights: bool = False,
-):
+) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor,
+                                                                torch.Tensor]]]:
     try:
         from flash_attn import bert_padding, flash_attn_interface  # type: ignore # yapf: disable # isort: skip
     except:
@@ -254,7 +256,8 @@ def triton_flash_attn_fn(
     dropout_p: float = 0.0,
     training: bool = False,
     needs_weights: bool = False,
-):
+) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor,
+                                                                torch.Tensor]]]:
     try:
         from llmfoundry.models.layers.flash_attn_triton import flash_attn_func
     except:

--- a/llmfoundry/models/layers/attention.py
+++ b/llmfoundry/models/layers/attention.py
@@ -343,7 +343,7 @@ def triton_flash_attn_fn(
 
 
 class GeneralizedAttention(nn.Module):
-    """A generalization of Multi-head, Multi-Query, and MHA attention.
+    """A generalization of Multi-head, Multi-Query, Multi-Grouped Attention.
 
     Using torch or triton attention implemetation enables user to also use
     additive bias.

--- a/llmfoundry/models/layers/attention.py
+++ b/llmfoundry/models/layers/attention.py
@@ -356,7 +356,7 @@ def triton_flash_attn_fn(
 class GeneralizedAttention(nn.Module):
     """A generalization of Multi-head, Multi-Query, Multi-Grouped Attention.
 
-    Using torch or triton attention implemetation enables user to also use
+    Using torch or triton attention implementation enables user to also use
     additive bias.
     """
 

--- a/llmfoundry/models/layers/attention.py
+++ b/llmfoundry/models/layers/attention.py
@@ -416,7 +416,7 @@ class GroupedQueryAttention(nn.Module):
         self.head_dim = d_model // n_heads
 
         if self.kv_n_heads <= 0:
-            raise ValueError('kv_n_heads should be greater than zero')
+            raise ValueError('kv_n_heads should be greater than zero.')
 
         if self.kv_n_heads > self.n_heads:
             raise ValueError(

--- a/llmfoundry/models/layers/attention.py
+++ b/llmfoundry/models/layers/attention.py
@@ -353,11 +353,12 @@ def triton_flash_attn_fn(
     return output, None, past_key_value
 
 
-class GeneralizedAttention(nn.Module):
-    """A generalization of Multi-head, Multi-Query, Multi-Grouped Attention.
+class GroupedQueryAttention(nn.Module):
+    """GQA is a generalization of Multi-head and Multi-query attention.
 
-    Using torch or triton attention implementation enables user to also use
-    additive bias.
+    This allows the user to set a variable of number of kv_n_heads, rather than
+    just n_heads or 1, as in MHA and MQA. Using torch or triton attention
+    implementation enables user to also use additive bias.
     """
 
     def __init__(
@@ -493,7 +494,7 @@ class GeneralizedAttention(nn.Module):
         return self.out_proj(context), attn_weights, past_key_value
 
 
-class MultiheadAttention(GeneralizedAttention):
+class MultiheadAttention(GroupedQueryAttention):
     """Multi-head self attention.
 
     Using torch or triton attention implementation enables user to also use
@@ -529,7 +530,7 @@ class MultiheadAttention(GeneralizedAttention):
             device=device)
 
 
-class MultiQueryAttention(GeneralizedAttention):
+class MultiQueryAttention(GroupedQueryAttention):
     """Multi-Query self attention.
 
     Using torch or triton attention implementation enables user to also use
@@ -653,5 +654,5 @@ def build_alibi_bias(
 ATTN_CLASS_REGISTRY = {
     'multihead_attention': MultiheadAttention,
     'multiquery_attention': MultiQueryAttention,
-    'grouped_query_attention': GeneralizedAttention
+    'grouped_query_attention': GroupedQueryAttention
 }

--- a/llmfoundry/models/layers/attention.py
+++ b/llmfoundry/models/layers/attention.py
@@ -178,7 +178,7 @@ def flash_attn_fn(
     if multiquery:
         warnings.warn(
             DeprecationWarning(
-                'The direct use of the multiquery arg is deprecated. Set kv_n_heads=1 instead.'
+                'The direct use of the multiquery arg is deprecated. Setting kv_n_heads=1 automatically. Please set kv_n_heads=1 explicitly to remove this warning.'
             ))
         kv_n_heads = 1
 

--- a/llmfoundry/models/layers/attention.py
+++ b/llmfoundry/models/layers/attention.py
@@ -394,8 +394,10 @@ class GeneralizedAttention(nn.Module):
             **fc_kwargs,
         )
         # for param init fn; enables shape based init of fused layers
-        fuse_splits = (i * self.head_dim
-                       for i in range(1, self.n_heads + 2 * self.kv_n_heads))
+        fuse_splits = [
+            i * self.head_dim
+            for i in range(1, self.n_heads + 2 * self.kv_n_heads)
+        ]
         self.Wqkv._fused = (0, fuse_splits)  # type: ignore
 
         if self.qk_ln:

--- a/llmfoundry/models/layers/attention.py
+++ b/llmfoundry/models/layers/attention.py
@@ -32,19 +32,19 @@ def _reset_is_causal(num_query_tokens: int, num_key_tokens: int,
 
 
 def scaled_multihead_dot_product_attention(
-    query,
-    key,
-    value,
-    n_heads,
-    kv_n_heads,
-    past_key_value=None,
-    softmax_scale=None,
-    attn_bias=None,
-    key_padding_mask=None,
-    is_causal=False,
-    dropout_p=0.0,
-    training=False,
-    needs_weights=False,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    n_heads: int,
+    kv_n_heads: int,
+    past_key_value: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+    softmax_scale: Optional[float] = None,
+    attn_bias: Optional[torch.Tensor] = None,
+    key_padding_mask: Optional[torch.Tensor] = None,
+    is_causal: bool = False,
+    dropout_p: float = 0.0,
+    training: bool = False,
+    needs_weights: bool = False,
 ):
     q = rearrange(query, 'b s (h d) -> b h s d', h=n_heads)
     k = rearrange(key, 'b s (h d) -> b h d s', h=kv_n_heads)
@@ -142,19 +142,19 @@ def check_valid_inputs(*tensors: torch.Tensor,
 
 
 def flash_attn_fn(
-    query,
-    key,
-    value,
-    n_heads,
-    kv_n_heads,
-    past_key_value=None,
-    softmax_scale=None,
-    attn_bias=None,
-    key_padding_mask=None,
-    is_causal=False,
-    dropout_p=0.0,
-    training=False,
-    needs_weights=False,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    n_heads: int,
+    kv_n_heads: int,
+    past_key_value: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+    softmax_scale: Optional[float] = None,
+    attn_bias: Optional[torch.Tensor] = None,
+    key_padding_mask: Optional[torch.Tensor] = None,
+    is_causal: bool = False,
+    dropout_p: float = 0.0,
+    training: bool = False,
+    needs_weights: bool = False,
 ):
     try:
         from flash_attn import bert_padding, flash_attn_interface  # type: ignore # yapf: disable # isort: skip
@@ -241,19 +241,19 @@ def flash_attn_fn(
 
 
 def triton_flash_attn_fn(
-    query,
-    key,
-    value,
-    n_heads,
-    kv_n_heads,
-    past_key_value=None,
-    softmax_scale=None,
-    attn_bias=None,
-    key_padding_mask=None,
-    is_causal=False,
-    dropout_p=0.0,
-    training=False,
-    needs_weights=False,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    n_heads: int,
+    kv_n_heads: int,
+    past_key_value: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+    softmax_scale: Optional[float] = None,
+    attn_bias: Optional[torch.Tensor] = None,
+    key_padding_mask: Optional[torch.Tensor] = None,
+    is_causal: bool = False,
+    dropout_p: float = 0.0,
+    training: bool = False,
+    needs_weights: bool = False,
 ):
     try:
         from llmfoundry.models.layers.flash_attn_triton import flash_attn_func
@@ -445,12 +445,12 @@ class GeneralizedAttention(nn.Module):
 
     def forward(
         self,
-        x,
-        past_key_value=None,
-        attn_bias=None,
-        attention_mask=None,
-        is_causal=True,
-        needs_weights=False,
+        x: torch.Tensor,
+        past_key_value: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+        attn_bias: Optional[torch.Tensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        is_causal: bool = True,
+        needs_weights: bool = False,
     ):
         qkv = self.Wqkv(x)
 

--- a/llmfoundry/models/layers/attention.py
+++ b/llmfoundry/models/layers/attention.py
@@ -461,11 +461,14 @@ class GroupedQueryAttention(nn.Module):
         if self.clip_qkv:
             qkv = qkv.clamp(min=-self.clip_qkv, max=self.clip_qkv)
 
-        query, key, value = qkv.split([
-            self.d_model, self.kv_n_heads * self.head_dim,
-            self.kv_n_heads * self.head_dim
+        query, key, value = qkv.split(
+        [
+            self.d_model, 
+            self.kv_n_heads * self.head_dim,
+            self.kv_n_heads * self.head_dim,
         ],
-                                      dim=2)
+        dim=2,
+        )
 
         key_padding_mask = attention_mask
 

--- a/llmfoundry/models/layers/attention.py
+++ b/llmfoundry/models/layers/attention.py
@@ -52,7 +52,7 @@ def scaled_multihead_dot_product_attention(
     if multiquery:
         warnings.warn(
             DeprecationWarning(
-                'The direct use of the multiquery arg is deprecated. Set kv_n_heads=1 instead.'
+                'The direct use of the multiquery arg is deprecated. Setting kv_n_heads=1 automatically. Please set kv_n_heads=1 explicitly to remove this warning.'
             ))
         kv_n_heads = 1
 

--- a/llmfoundry/models/layers/attention.py
+++ b/llmfoundry/models/layers/attention.py
@@ -308,7 +308,7 @@ def triton_flash_attn_fn(
     if multiquery:
         warnings.warn(
             DeprecationWarning(
-                'The direct use of the multiquery arg is deprecated. Set kv_n_heads=1 instead.'
+                'The direct use of the multiquery arg is deprecated. Setting kv_n_heads=1 automatically. Please set kv_n_heads=1 explicitly to remove this warning.'
             ))
         kv_n_heads = 1
 

--- a/llmfoundry/models/layers/attention.py
+++ b/llmfoundry/models/layers/attention.py
@@ -420,7 +420,7 @@ class GroupedQueryAttention(nn.Module):
 
         if self.kv_n_heads > self.n_heads:
             raise ValueError(
-                'The number of KV heads should be less than or equal to Q heads'
+                'The number of KV heads should be less than or equal to Q heads.'
             )
 
         if self.n_heads % self.kv_n_heads != 0:

--- a/llmfoundry/models/layers/attention.py
+++ b/llmfoundry/models/layers/attention.py
@@ -379,8 +379,9 @@ def triton_flash_attn_fn(
 
 
 class GroupedQueryAttention(nn.Module):
-    """Grouped Query Attention (GQA) is a generalization of Multi-head (MHA) and
-       Multi-query attention (MQA).
+    """Grouped Query Attention (GQA) is a generalization of Multi-head (MHA).
+
+    and Multi-query attention (MQA).
 
     This allows the user to set a variable of number of kv_n_heads, rather than
     just n_heads or 1, as in MHA and MQA. Using torch or triton attention

--- a/llmfoundry/models/layers/blocks.py
+++ b/llmfoundry/models/layers/blocks.py
@@ -21,7 +21,7 @@ class MPTBlock(nn.Module):
         d_model: int,
         n_heads: int,
         expansion_ratio: int,
-        attn_config: Dict = {
+        attn_config_mutable: Dict = {
             'attn_type': 'multihead_attention',
             'attn_pdrop': 0.0,
             'attn_impl': 'triton',
@@ -46,8 +46,9 @@ class MPTBlock(nn.Module):
         del kwargs  # unused, just to capture any extra args from the config
         super().__init__()
 
+        attn_type = attn_config_mutable.pop('attn_type')
         norm_class = NORM_CLASS_REGISTRY[norm_type.lower()]
-        attn_class = ATTN_CLASS_REGISTRY[attn_config['attn_type']]
+        attn_class = ATTN_CLASS_REGISTRY[attn_type]
 
         self.norm_1 = norm_class(d_model, device=device)
         self.attn = attn_class(d_model=d_model,
@@ -55,7 +56,7 @@ class MPTBlock(nn.Module):
                                fc_type=fc_type,
                                verbose=verbose,
                                device=device,
-                               **attn_config)
+                               **attn_config_mutable)
         self.norm_2 = None
         if not getattr(FFN_CLASS_REGISTRY[ffn_config['ffn_type']], '_has_norm',
                        False):

--- a/llmfoundry/models/layers/blocks.py
+++ b/llmfoundry/models/layers/blocks.py
@@ -52,16 +52,14 @@ class MPTBlock(nn.Module):
         super().__init__()
 
         norm_class = NORM_CLASS_REGISTRY[norm_type.lower()]
-
-        norm_class = NORM_CLASS_REGISTRY[norm_type.lower()]
         assert isinstance(attn_config['attn_type'], str)
         attn_class = ATTN_CLASS_REGISTRY[attn_config['attn_type']]
 
         # necessary to avoid passing extraneous args into attn_class while allowing the use of **kwargs
-        args_to_exclude_in_attn_class = [
+        args_to_exclude_in_attn_class = {
             'attn_type', 'prefix_lm', 'alibi', 'attn_uses_sequence_id',
             'alibi_bias_max'
-        ]
+        }
         attn_config_subset_for_attn_class = {
             k: v
             for k, v in attn_config.items()

--- a/llmfoundry/models/layers/blocks.py
+++ b/llmfoundry/models/layers/blocks.py
@@ -20,21 +20,8 @@ class MPTBlock(nn.Module):
         d_model: int,
         n_heads: int,
         expansion_ratio: int,
-        attn_config_mutable: Dict = {
-            'attn_type': 'multihead_attention',
-            'attn_pdrop': 0.0,
-            'attn_impl': 'triton',
-            'qk_ln': False,
-            'clip_qkv': None,
-            'softmax_scale': None,
-            'prefix_lm': False,
-            'attn_uses_sequence_id': False,
-            'alibi': False,
-            'alibi_bias_max': 8,
-        },
-        ffn_config: Dict = {
-            'ffn_type': 'mptmlp',
-        },
+        attn_config_mutable: Optional[Dict] = None,
+        ffn_config: Optional[Dict] = None,
         resid_pdrop: float = 0.0,
         norm_type: str = 'low_precision_layernorm',
         verbose: int = 0,
@@ -42,8 +29,8 @@ class MPTBlock(nn.Module):
         device: Optional[str] = None,
         **kwargs: Any,
     ):
-        if attn_config is None:
-            attn_config = {
+        if attn_config_mutable is None:
+            attn_config_mutable = {
                 'attn_type': 'multihead_attention',
                 'attn_pdrop': 0.0,
                 'attn_impl': 'triton',
@@ -64,8 +51,10 @@ class MPTBlock(nn.Module):
         del kwargs  # unused, just to capture any extra args from the config
         super().__init__()
 
-        attn_type = attn_config_mutable.pop('attn_type')
         norm_class = NORM_CLASS_REGISTRY[norm_type.lower()]
+
+        attn_type = attn_config_mutable.pop('attn_type')
+        assert isinstance(attn_type, str)
         attn_class = ATTN_CLASS_REGISTRY[attn_type]
 
         self.norm_1 = norm_class(d_model, device=device)

--- a/llmfoundry/models/layers/blocks.py
+++ b/llmfoundry/models/layers/blocks.py
@@ -50,19 +50,12 @@ class MPTBlock(nn.Module):
         attn_class = ATTN_CLASS_REGISTRY[attn_config['attn_type']]
 
         self.norm_1 = norm_class(d_model, device=device)
-        self.attn = attn_class(
-            d_model=d_model,
-            n_heads=n_heads,
-            attn_impl=attn_config['attn_impl'],
-            clip_qkv=attn_config['clip_qkv'],
-            qk_ln=attn_config['qk_ln'],
-            softmax_scale=attn_config['softmax_scale'],
-            attn_pdrop=attn_config['attn_pdrop'],
-            norm_type=norm_type,
-            fc_type=fc_type,
-            verbose=verbose,
-            device=device,
-        )
+        self.attn = attn_class(d_model=d_model,
+                               n_heads=n_heads,
+                               fc_type=fc_type,
+                               verbose=verbose,
+                               device=device,
+                               **attn_config)
         self.norm_2 = None
         if not getattr(FFN_CLASS_REGISTRY[ffn_config['ffn_type']], '_has_norm',
                        False):

--- a/llmfoundry/models/mpt/configuration_mpt.py
+++ b/llmfoundry/models/mpt/configuration_mpt.py
@@ -77,7 +77,7 @@ class MPTConfig(PretrainedConfig):
             emb_pdrop (float): The dropout probability for the embedding layer.
             learned_pos_emb (bool): Whether to use learned positional embeddings
             attn_config (Dict): A dictionary used to configure the model's attention module:
-                attn_type (str): type of attention to use. Options: multihead_attention, multiquery_attention
+                attn_type (str): type of attention to use. Options: multihead_attention, multiquery_attention, grouped_query_attention
                 attn_pdrop (float): The dropout probability for the attention layers.
                 attn_impl (str): The attention implementation to use. One of 'torch', 'flash', or 'triton'.
                 qk_ln (bool): Whether to apply layer normalization to the queries and keys in the attention layer.
@@ -94,6 +94,7 @@ class MPTConfig(PretrainedConfig):
                     Defaults to ``False`` meaning any provided `sequence_id` will be ignored.
                 alibi (bool): Whether to use the alibi bias instead of position embeddings.
                 alibi_bias_max (int): The maximum value of the alibi bias.
+                kv_n_heads (Optional[int]): For grouped_query_attention only, allow user to specify number of kv heads.
             ffn_config (Dict): A dictionary used to configure the model's ffn module:
                 ffn_type (str): type of ffn to use. Options: mptmlp, te_ln_mlp
             init_device (str): The device to use for parameter initialization.
@@ -102,7 +103,6 @@ class MPTConfig(PretrainedConfig):
             verbose (int): The verbosity level. 0 is silent.
             embedding_fraction (float): The fraction to scale the gradients of the embedding layer by.
             norm_type (str): choose type of norm to use
-            multiquery_attention (bool): Whether to use multiquery attention implementation.
             use_cache (bool): Whether or not the model should return the last key/values attentions
             init_config (Dict): A dictionary used to configure the model initialization:
                 init_config.name: The parameter initialization scheme to use. Options: 'default_', 'baseline_',

--- a/llmfoundry/models/mpt/modeling_mpt.py
+++ b/llmfoundry/models/mpt/modeling_mpt.py
@@ -79,7 +79,7 @@ class MPTModel(MPTPreTrainedModel):
 
         # necessary to copy in order to be able to pop arguments so that we can pass in
         # a subset of arguments into the Attention() init function as **kwargs
-        # and remove unnecessary args and still support checkpointing the original att_config
+        # and remove unnecessary args and still support checkpointing the original attn_config
         config.attn_config_mutable = copy.deepcopy(config.attn_config)
 
         # this is an argument into attention init, so should NOT be popped

--- a/llmfoundry/models/mpt/modeling_mpt.py
+++ b/llmfoundry/models/mpt/modeling_mpt.py
@@ -78,11 +78,15 @@ class MPTModel(MPTPreTrainedModel):
         super().__init__(config)
 
         # necessary to copy in order to be able to pop arguments so that we can pass in
-        # a subset of arguments into the Attention() init function and remove unnecessary args
-        # and still support checkpointing
+        # a subset of arguments into the Attention() init function as **kwargs
+        # and remove unnecessary args and still support checkpointing the original att_config
         config.attn_config_mutable = copy.deepcopy(config.attn_config)
 
-        self.attn_impl = config.attn_config_mutable.pop('attn_impl')
+        # this is an argument into attention init, so should NOT be popped
+        self.attn_impl = config.attn_config_mutable['attn_impl']
+
+        # the rest of the arguments must be popped to prevent being popped into the
+        # attention init function
         self.prefix_lm = config.attn_config_mutable.pop('prefix_lm')
         self.attn_uses_sequence_id = config.attn_config_mutable.pop(
             'attn_uses_sequence_id')

--- a/llmfoundry/models/mpt/modeling_mpt.py
+++ b/llmfoundry/models/mpt/modeling_mpt.py
@@ -6,7 +6,6 @@
 Inspired by https://github.com/karpathy/minGPT/blob/master/mingpt/model.py
 """
 
-import copy
 import math
 import warnings
 from typing import Any, List, Mapping, MutableMapping, Optional, Tuple, Union
@@ -77,21 +76,11 @@ class MPTModel(MPTPreTrainedModel):
         config._validate_config()
         super().__init__(config)
 
-        # necessary to copy in order to be able to pop arguments so that we can pass in
-        # a subset of arguments into the Attention() init function as **kwargs
-        # and remove unnecessary args and still support checkpointing the original attn_config
-        config.attn_config_mutable = copy.deepcopy(config.attn_config)
-
-        # this is an argument into attention init, so should NOT be popped
-        self.attn_impl = config.attn_config_mutable['attn_impl']
-
-        # the rest of the arguments must be popped to prevent being popped into the
-        # attention init function
-        self.prefix_lm = config.attn_config_mutable.pop('prefix_lm')
-        self.attn_uses_sequence_id = config.attn_config_mutable.pop(
-            'attn_uses_sequence_id')
-        self.alibi = config.attn_config_mutable.pop('alibi')
-        self.alibi_bias_max = config.attn_config_mutable.pop('alibi_bias_max')
+        self.attn_impl = config.attn_config['attn_impl']
+        self.prefix_lm = config.attn_config['prefix_lm']
+        self.attn_uses_sequence_id = config.attn_config['attn_uses_sequence_id']
+        self.alibi = config.attn_config['alibi']
+        self.alibi_bias_max = config.attn_config['alibi_bias_max']
 
         self.learned_pos_emb = config.learned_pos_emb
 

--- a/tests/test_flash_triton_torch.py
+++ b/tests/test_flash_triton_torch.py
@@ -248,7 +248,7 @@ def test_grouped_attention_heads(attn_impl: str,
 
     n, s, f = 2, 16, cfg.d_model
 
-    mmhsa = attention.GeneralizedAttention(**cfg).to(device)
+    mmhsa = attention.GroupedQueryAttention(**cfg).to(device)
 
     attention_mask = torch.ones(n, s).to(device).bool()
     x0 = torch.randn(n, s, f).to(device)
@@ -288,7 +288,7 @@ def test_grouped_query_invalid_heads(attn_impl: str, device: str = 'cuda'):
     expected_error = 'Each Q head should get the same number of KV heads, so n_heads must be divisible by kv_n_heads'
 
     with pytest.raises(AssertionError, match=expected_error):
-        _ = attention.GeneralizedAttention(**cfg).to(device)
+        _ = attention.GroupedQueryAttention(**cfg).to(device)
 
     cfg = om.create({
         'attn_impl': attn_impl,
@@ -303,7 +303,7 @@ def test_grouped_query_invalid_heads(attn_impl: str, device: str = 'cuda'):
     expected_error = 'The number of KV heads should be less than or equal to Q heads'
 
     with pytest.raises(AssertionError, match=expected_error):
-        _ = attention.GeneralizedAttention(**cfg).to(device)
+        _ = attention.GroupedQueryAttention(**cfg).to(device)
 
     cfg = om.create({
         'attn_impl': attn_impl,
@@ -318,4 +318,4 @@ def test_grouped_query_invalid_heads(attn_impl: str, device: str = 'cuda'):
     expected_error = 'kv_n_heads should be greater than zero'
 
     with pytest.raises(AssertionError, match=expected_error):
-        _ = attention.GeneralizedAttention(**cfg).to(device)
+        _ = attention.GroupedQueryAttention(**cfg).to(device)

--- a/tests/test_flash_triton_torch.py
+++ b/tests/test_flash_triton_torch.py
@@ -23,13 +23,13 @@ def allclose_helper(t0: torch.Tensor,
 @pytest.mark.parametrize(
     'attn_type',
     ['multihead_attention', 'multiquery_attention', 'grouped_query_attention'])
-def test_attn_impl(attn_impl_0,
-                   attn_impl_1,
-                   clip_qkv,
-                   qk_ln,
-                   alibi,
-                   attn_type,
-                   device='cuda'):
+def test_attn_impl(attn_impl_0: str,
+                   attn_impl_1: str,
+                   clip_qkv: bool,
+                   qk_ln: bool,
+                   alibi: bool,
+                   attn_type: str,
+                   device: str = 'cuda'):
     """Compare all attn impl with each other.
 
     Includes testing with and without attn_clip_qkv, attn_qk_ln, and alibi.
@@ -227,7 +227,10 @@ def test_vs_mha(attn_impl: str, device: str = 'cuda'):
 @pytest.mark.parametrize('attn_impl', ['flash', 'triton', 'torch'])
 @pytest.mark.parametrize('n_heads', [32, 16, 8])
 @pytest.mark.parametrize('kv_n_heads', [8, 4, 2, 1])
-def test_grouped_attention_heads(attn_impl, n_heads, kv_n_heads, device='cuda'):
+def test_grouped_attention_heads(attn_impl: str,
+                                 n_heads: int,
+                                 kv_n_heads: int,
+                                 device: str = 'cuda'):
     """Ensure grouped_query_attention runs w/ diff n_heads & kv_n_heads."""
     from llmfoundry.models.layers import attention
 
@@ -266,7 +269,7 @@ def test_grouped_attention_heads(attn_impl, n_heads, kv_n_heads, device='cuda'):
 
 @pytest.mark.gpu
 @pytest.mark.parametrize('attn_impl', ['flash', 'triton', 'torch'])
-def test_grouped_query_invalid_heads(attn_impl, device='cuda'):
+def test_grouped_query_invalid_heads(attn_impl: str, device: str = 'cuda'):
     """Check indivisble combinations of grouped_query_attention."""
     from llmfoundry.models.layers import attention
 
@@ -282,12 +285,10 @@ def test_grouped_query_invalid_heads(attn_impl, device='cuda'):
         'kv_n_heads': 3
     })
 
-    n, s, f = 2, 16, cfg.d_model
-
     expected_error = 'Each Q head should get the same number of KV heads, so n_heads must be divisible by kv_n_heads'
 
     with pytest.raises(AssertionError, match=expected_error):
-        mmhsa = attention.GeneralizedAttention(**cfg).to(device)
+        _ = attention.GeneralizedAttention(**cfg).to(device)
 
     cfg = om.create({
         'attn_impl': attn_impl,
@@ -299,12 +300,10 @@ def test_grouped_query_invalid_heads(attn_impl, device='cuda'):
         'kv_n_heads': 17
     })
 
-    n, s, f = 2, 16, cfg.d_model
-
     expected_error = 'The number of KV heads should be less than or equal to Q heads'
 
     with pytest.raises(AssertionError, match=expected_error):
-        mmhsa = attention.GeneralizedAttention(**cfg).to(device)
+        _ = attention.GeneralizedAttention(**cfg).to(device)
 
     cfg = om.create({
         'attn_impl': attn_impl,
@@ -316,9 +315,7 @@ def test_grouped_query_invalid_heads(attn_impl, device='cuda'):
         'kv_n_heads': 0
     })
 
-    n, s, f = 2, 16, cfg.d_model
-
     expected_error = 'kv_n_heads should be greater than zero'
 
     with pytest.raises(AssertionError, match=expected_error):
-        mmhsa = attention.GeneralizedAttention(**cfg).to(device)
+        _ = attention.GeneralizedAttention(**cfg).to(device)

--- a/tests/test_flash_triton_torch.py
+++ b/tests/test_flash_triton_torch.py
@@ -287,7 +287,7 @@ def test_grouped_query_invalid_heads(attn_impl: str, device: str = 'cuda'):
 
     expected_error = 'Each Q head should get the same number of KV heads, so n_heads must be divisible by kv_n_heads'
 
-    with pytest.raises(AssertionError, match=expected_error):
+    with pytest.raises(ValueError, match=expected_error):
         _ = attention.GroupedQueryAttention(**cfg).to(device)
 
     cfg = om.create({
@@ -302,7 +302,7 @@ def test_grouped_query_invalid_heads(attn_impl: str, device: str = 'cuda'):
 
     expected_error = 'The number of KV heads should be less than or equal to Q heads'
 
-    with pytest.raises(AssertionError, match=expected_error):
+    with pytest.raises(ValueError, match=expected_error):
         _ = attention.GroupedQueryAttention(**cfg).to(device)
 
     cfg = om.create({
@@ -317,5 +317,5 @@ def test_grouped_query_invalid_heads(attn_impl: str, device: str = 'cuda'):
 
     expected_error = 'kv_n_heads should be greater than zero'
 
-    with pytest.raises(AssertionError, match=expected_error):
+    with pytest.raises(ValueError, match=expected_error):
         _ = attention.GroupedQueryAttention(**cfg).to(device)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -370,7 +370,7 @@ def test_loss_fn():
     assert isinstance(test_cfg, DictConfig)
 
     test_cfg.device = 'cuda:0'
-    test_cfg.model.init_device = 'cuda:0'
+    test_cfg.model.init_device = 'cpu'
     test_cfg.model.init_config = {
         'name': 'baseline_',
         'init_std': 0.02,
@@ -383,6 +383,10 @@ def test_loss_fn():
     model_1 = COMPOSER_MODEL_REGISTRY[test_cfg.model.name](test_cfg.model,
                                                            tokenizer)
     model_2 = copy.deepcopy(model_1)
+
+    model_1.to(test_cfg.device)
+    model_2.to(test_cfg.device)
+
     assert isinstance(model_1.loss_fn, torch.nn.CrossEntropyLoss)
     model_2.loss_fn = FusedCrossEntropyLoss(ignore_index=-100)
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -347,80 +347,80 @@ def test_determinism(attn_impl: str, precision):
             optimizer_2.step()
 
 
-# @pytest.mark.gpu
-# def test_loss_fn():
-#     """Tests the Fused CrossEntropy vs torch.nn.CrossEntropy loss function.
+@pytest.mark.gpu
+def test_loss_fn():
+    """Tests the Fused CrossEntropy vs torch.nn.CrossEntropy loss function.
 
-#     We provide non-zero tolerances to account for small numerics differences
-#     between the two loss implementations.
-#     """
-#     try:
-#         from flash_attn.losses.cross_entropy import CrossEntropyLoss as FusedCrossEntropyLoss  # type: ignore # isort: skip
-#     except:
-#         pytest.skip('Fused cross entropy was not installed')
+    We provide non-zero tolerances to account for small numerics differences
+    between the two loss implementations.
+    """
+    try:
+        from flash_attn.losses.cross_entropy import CrossEntropyLoss as FusedCrossEntropyLoss  # type: ignore # isort: skip
+    except:
+        pytest.skip('Fused cross entropy was not installed')
 
-#     # run numerical test in pure fp32
-#     torch.backends.cuda.matmul.allow_tf32 = False  # type: ignore (third-party)
-#     torch.backends.cudnn.allow_tf32 = False  # type: ignore (third-party)
+    # run numerical test in pure fp32
+    torch.backends.cuda.matmul.allow_tf32 = False  # type: ignore (third-party)
+    torch.backends.cudnn.allow_tf32 = False  # type: ignore (third-party)
 
-#     conf_path = 'scripts/train/yamls/pretrain/testing.yaml'
-#     with open(conf_path) as f:
-#         test_cfg = om.load(f)
+    conf_path = 'scripts/train/yamls/pretrain/testing.yaml'
+    with open(conf_path) as f:
+        test_cfg = om.load(f)
 
-#     assert isinstance(test_cfg, DictConfig)
+    assert isinstance(test_cfg, DictConfig)
 
-#     test_cfg.device = 'cuda:0'
-#     test_cfg.model.init_device = 'cpu'
-#     test_cfg.model.init_config = {
-#         'name': 'baseline_',
-#         'init_std': 0.02,
-#     }
+    test_cfg.device = 'cuda:0'
+    test_cfg.model.init_device = 'cpu'
+    test_cfg.model.init_config = {
+        'name': 'baseline_',
+        'init_std': 0.02,
+    }
 
-#     reproducibility.seed_all(test_cfg.get('global_seed', 42))
+    reproducibility.seed_all(test_cfg.get('global_seed', 42))
 
-#     tokenizer = build_tokenizer(test_cfg.tokenizer)
+    tokenizer = build_tokenizer(test_cfg.tokenizer)
 
-#     model_1 = COMPOSER_MODEL_REGISTRY[test_cfg.model.name](test_cfg.model,
-#                                                            tokenizer)
-#     model_2 = copy.deepcopy(model_1)
+    model_1 = COMPOSER_MODEL_REGISTRY[test_cfg.model.name](test_cfg.model,
+                                                           tokenizer)
+    model_2 = copy.deepcopy(model_1)
 
-#     model_1.to(test_cfg.device)
-#     model_2.to(test_cfg.device)
+    model_1.to(test_cfg.device)
+    model_2.to(test_cfg.device)
 
-#     assert isinstance(model_1.loss_fn, torch.nn.CrossEntropyLoss)
-#     model_2.loss_fn = FusedCrossEntropyLoss(ignore_index=-100)
+    assert isinstance(model_1.loss_fn, torch.nn.CrossEntropyLoss)
+    model_2.loss_fn = FusedCrossEntropyLoss(ignore_index=-100)
 
-#     optimizer_1 = DecoupledAdamW(model_1.parameters(),
-#                                  lr=test_cfg.optimizer.lr,
-#                                  betas=test_cfg.optimizer.betas,
-#                                  eps=test_cfg.optimizer.eps,
-#                                  weight_decay=test_cfg.optimizer.weight_decay)
-#     optimizer_2 = DecoupledAdamW(model_2.parameters(),
-#                                  lr=test_cfg.optimizer.lr,
-#                                  betas=test_cfg.optimizer.betas,
-#                                  eps=test_cfg.optimizer.eps,
-#                                  weight_decay=test_cfg.optimizer.weight_decay)
+    optimizer_1 = DecoupledAdamW(model_1.parameters(),
+                                 lr=test_cfg.optimizer.lr,
+                                 betas=test_cfg.optimizer.betas,
+                                 eps=test_cfg.optimizer.eps,
+                                 weight_decay=test_cfg.optimizer.weight_decay)
+    optimizer_2 = DecoupledAdamW(model_2.parameters(),
+                                 lr=test_cfg.optimizer.lr,
+                                 betas=test_cfg.optimizer.betas,
+                                 eps=test_cfg.optimizer.eps,
+                                 weight_decay=test_cfg.optimizer.weight_decay)
 
-#     for i in range(15):
-#         batch = gen_random_batch(2, test_cfg)
-#         output_1 = model_1(batch)
-#         output_2 = model_2(batch)
-#         assert output_1.logits.allclose(output_2.logits, rtol=1e-4,
-#                                         atol=1e-4), f'differed at step {i}'
+    for i in range(15):
+        batch = gen_random_batch(2, test_cfg)
+        output_1 = model_1(batch)
+        output_2 = model_2(batch)
+        assert output_1.logits.allclose(output_2.logits, rtol=1e-4,
+                                        atol=1e-4), f'differed at step {i}'
 
-#         loss_1 = model_1.loss(output_1, batch)
-#         loss_2 = model_2.loss(output_2, batch)
-#         assert loss_1.allclose(loss_2, rtol=1e-3,
-#                                atol=1e-3), f'differed at step {i}'
-#         loss_1.backward()
-#         loss_2.backward()
-#         optimizer_1.step()
-#         optimizer_2.step()
+        loss_1 = model_1.loss(output_1, batch)
+        loss_2 = model_2.loss(output_2, batch)
+        assert loss_1.allclose(loss_2, rtol=1e-3,
+                               atol=1e-3), f'differed at step {i}'
+        loss_1.backward()
+        loss_2.backward()
+        optimizer_1.step()
+        optimizer_2.step()
 
-#         for p1, p2 in zip(model_1.parameters(), model_2.parameters()):
-#             assert p1.data.shape == p2.data.shape
-#             assert p1.data.allclose(p2.data, rtol=1e-5,
-#                                     atol=1e-4), f'differed at step {i}'
+        for p1, p2 in zip(model_1.parameters(), model_2.parameters()):
+            assert p1.data.shape == p2.data.shape
+            assert p1.data.allclose(p2.data, rtol=1e-5,
+                                    atol=1e-4), f'differed at step {i}'
 
 
 @pytest.mark.parametrize('prefixlm', [False, True])


### PR DESCRIPTION
Adding grouped query attention to LLM-foundry, and making the `GQA` class a superclass of MQA and MHA attention, as it is a generalization of those two variants of attention. 
Things to note:
- we currently use `repeat_interleave` to make the grouped query tensor the same dimensions as multi-head attention, which does allocate new memory, compared to using `expand`. This can be updated in the future, but is the safer bet for now, given that we previously saw edge-cases with using `expand` vs `repeat` for particular `head_dim` settings causing NaNs
- Part of this change is also changing how we initialize the QKV matrix, which used to initialize (n_heads * head_dim, d_model), but now is changed to initialize each n_head (head_dim, d_model) matrix separately