### PR TITLE
Updated StreamingTextDataset to pass take in shuffle_block_size

### DIFF
--- a/llmfoundry/data/text_data.py
+++ b/llmfoundry/data/text_data.py
@@ -129,6 +129,7 @@ class StreamingTextDataset(StreamingDataset):
             shuffle=shuffle,
             shuffle_algo=shuffle_algo,
             shuffle_seed=shuffle_seed,
+            shuffle_block_size=shuffle_block_size,
         )
         self.tokenizer = tokenizer
         self.max_seq_len = max_seq_len


### PR DESCRIPTION
makes sure `StreamingTextDataset` takes in `shuffle_block_size` when initialized.