### PR TITLE
Add runtime error in train.py if yaml config is improperly formatted with extraneous or missing values

### DIFF
--- a/llmfoundry/utils/config_utils.py
+++ b/llmfoundry/utils/config_utils.py
@@ -12,6 +12,7 @@ from omegaconf import OmegaConf as om
 
 from llmfoundry.models.utils import init_empty_weights
 
+
 def pop_config(cfg: DictConfig,
                key: str,
                must_exist: bool = True,

--- a/llmfoundry/utils/config_utils.py
+++ b/llmfoundry/utils/config_utils.py
@@ -26,7 +26,7 @@ def pop_config(cfg: DictConfig,
     if value is not None:
         return value
     elif must_exist:
-        raise RuntimeError(
+        raise NameError(
             f'The {key} parameter is missing and must exist for execution. Please check your yaml.'
         )
     else:
@@ -112,8 +112,8 @@ def process_init_device(model_cfg: DictConfig, fsdp_config: Optional[Dict]):
 def log_config(cfg: DictConfig):
     """Logs the current config and updates the wandb and mlflow configs.
 
-    This function can be called multiple times to update the wandb config with
-    different variables.
+    This function can be called multiple times to update the wandb and MLflow
+    config with different variables.
     """
     print(om.to_yaml(cfg))
     if 'wandb' in cfg.get('loggers', {}):

--- a/llmfoundry/utils/config_utils.py
+++ b/llmfoundry/utils/config_utils.py
@@ -90,6 +90,11 @@ def process_init_device(model_cfg: DictConfig, fsdp_config: Optional[Dict]):
 
 
 def log_config(cfg: DictConfig):
+    """Logs the current config and updates the wandb config if available.
+
+    This function can be called multiple times to update the wandb config with
+    different variables.
+    """
     print(om.to_yaml(cfg))
     if 'wandb' in cfg.get('loggers', {}):
         try:

--- a/llmfoundry/utils/config_utils.py
+++ b/llmfoundry/utils/config_utils.py
@@ -4,13 +4,32 @@
 import contextlib
 import math
 import warnings
-from typing import Dict, Optional, Union
+from typing import Any, Dict, Optional, Union
 
 from composer.utils import dist
 from omegaconf import DictConfig
 from omegaconf import OmegaConf as om
 
 from llmfoundry.models.utils import init_empty_weights
+
+def pop_config(cfg: DictConfig,
+               key: str,
+               must_exist: bool = True,
+               default_value: Any = None) -> Any:
+    """Pop a value from the main config file and return it.
+
+    If the key does not exist, return the default_value or raise a RuntimeError
+    depending on the must_exist flag.
+    """
+    value = cfg.pop(key, None)
+    if value is not None:
+        return value
+    elif must_exist:
+        raise RuntimeError(
+            f'The {key} parameter is missing and must exist for execution. Please check your yaml.'
+        )
+    else:
+        return default_value
 
 
 def calculate_batch_size_info(global_batch_size: int,
@@ -90,7 +109,7 @@ def process_init_device(model_cfg: DictConfig, fsdp_config: Optional[Dict]):
 
 
 def log_config(cfg: DictConfig):
-    """Logs the current config and updates the wandb config if available.
+    """Logs the current config and updates the wandb and mlflow configs.
 
     This function can be called multiple times to update the wandb config with
     different variables.

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -184,11 +184,11 @@ def main(cfg: DictConfig):
     om.resolve(cfg)
 
     # Set seed first
-    seed: int = cfg.pop('seed')
+    seed: int = pop_config(cfg, 'seed', must_exist=True)
     reproducibility.seed_all(seed)
 
     # Initialize distributed setting with seed
-    dist_timeout: Union[int, float] = cfg.pop('dist_timeout', 600.0)
+    dist_timeout: Union[int, float] = pop_config(cfg, 'dist_timeout', must_exist=False, default_value=600.0)
     dist.initialize_dist(get_device(None), timeout=dist_timeout)
 
     # Get global and device batch size information from distributed/single node setting
@@ -279,12 +279,12 @@ def main(cfg: DictConfig):
     autoresume = pop_config(cfg,'autoresume', must_exist=False, default_value=autoresume_default)
 
     # Pop known unused parameters.
-    cfg.pop('data_local', None)
-    cfg.pop('data_remote', None)
-    cfg.pop('global_seed')
-    cfg.pop('global_train_batch_size')
-    cfg.pop('n_gpus')
-    cfg.pop('device_train_grad_accum')
+    pop_config(cfg, 'data_local', must_exist=False)
+    pop_config(cfg, 'data_remote', must_exist=False)
+    pop_config(cfg, 'global_seed', must_exist=False)
+    pop_config(cfg, 'global_train_batch_size', must_exist=False)
+    pop_config(cfg, 'n_gpus', must_exist=False)
+    pop_config(cfg, 'device_train_grad_accum', must_exist=False)
 
     # Warn users for unused parameters
     for key in cfg:

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -300,7 +300,8 @@ def main(cfg: DictConfig):
 
     # Initialize context
     init_context = process_init_device(model_config, fsdp_config)
-    log_config(om.create(fsdp_config))
+    if fsdp_config:
+        log_config(om.create(fsdp_config))
 
     # Build tokenizer
     tokenizer = build_tokenizer(tokenizer_config)

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -189,7 +189,7 @@ def main(cfg: DictConfig):
     logged_cfg: DictConfig = copy.deepcopy(cfg)
 
     # Get max split size mb
-    max_split_size_mb: int = cfg.pop('max_split_size_mb', None)
+    max_split_size_mb: Optional[int] = cfg.pop('max_split_size_mb', None)
     if max_split_size_mb is not None:
         os.environ[
             'PYTORCH_CUDA_ALLOC_CONF'] = f'max_split_size_mb:{max_split_size_mb}'

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -178,10 +178,10 @@ def main(cfg: DictConfig):
         message=
         'torch.distributed.*_base is a private function and will be deprecated.*'
     )
-    
+
     # Check for incompatibilities between the model and data loaders
     validate_config(cfg)
-    
+
     # Resolve all interpolation variables as early as possible
     om.resolve(cfg)
 
@@ -189,7 +189,7 @@ def main(cfg: DictConfig):
     logged_cfg: DictConfig = copy.deepcopy(cfg)
 
     # Get max split size mb
-    max_split_size_mb: int  = cfg.pop('max_split_size_mb', None)
+    max_split_size_mb: int = cfg.pop('max_split_size_mb', None)
     if max_split_size_mb is not None:
         os.environ[
             'PYTORCH_CUDA_ALLOC_CONF'] = f'max_split_size_mb:{max_split_size_mb}'
@@ -204,7 +204,7 @@ def main(cfg: DictConfig):
                                                  must_exist=False,
                                                  default_value=600.0)
     dist.initialize_dist(get_device(None), timeout=dist_timeout)
-    
+
     # Get global and device batch size information from distributed/single node setting
     cfg = update_batch_size_info(cfg)
     logged_cfg.update(cfg, merge=True)

--- a/tests/test_train_inputs.py
+++ b/tests/test_train_inputs.py
@@ -52,7 +52,7 @@ class TestTrainingYAMLInputs:
         for param in mandatory_params:
             orig_param = cfg.pop(param)
             with pytest.raises(
-                (omegaconf.errors.ConfigAttributeError, RuntimeError)):
+                (omegaconf.errors.ConfigAttributeError, NameError)):
                 main(cfg)
             cfg[param] = orig_param
 

--- a/tests/test_yaml_inputs.py
+++ b/tests/test_yaml_inputs.py
@@ -19,11 +19,11 @@ from scripts.train.train import main  # noqa: E402
 
 class TestTrainingInputs:
     """
-    This class contains unit tests for validating the input YAML files used for training.
+    This class validates and tests error handling for the input YAML files used for training.
     """
     @pytest.fixture
     def cfg(self) -> DictConfig:
-        """This fixture will only be available within the scope of TestTrainingInputs"""
+        """Create YAML cfg fixture for testing purposes."""
         conf_path: str = os.path.join(repo_dir,
                                   'scripts/train/yamls/pretrain/mpt-125m.yaml')
         with open(conf_path, 'r', encoding='utf-8') as config:
@@ -57,7 +57,7 @@ class TestTrainingInputs:
 
     def test_optional_mispelled_params_raise_warning(self, cfg: DictConfig) -> None: 
         """
-        Check that a mispellings warnings are raised for optional parameters.
+        Check that warnings are raised for optional parameters that are mispelled.
         """
         optional_params = [
             'save_weights_only',
@@ -80,11 +80,10 @@ class TestTrainingInputs:
             updated_param = param + '-mispelling'
             cfg[updated_param] = orig_value
             with warnings.catch_warnings(record=True) as warning_list:
-                # ideally we should be able to run without try catch but there is no lightweight training run just yet. 
                 try:
                     main(cfg)
                 except:
                     pass
                 assert any(f"Unused parameter {updated_param} found in cfg." in str(warning.message) for warning in warning_list)
-            # restore param
+            # restore configs.
             cfg = copy.deepcopy(old_cfg)

--- a/tests/test_yaml_inputs.py
+++ b/tests/test_yaml_inputs.py
@@ -1,0 +1,90 @@
+# Copyright 2022 MosaicML LLM Foundry authors
+# SPDX-License-Identifier: Apache-2.0
+import copy
+import os
+import sys
+import pytest 
+import omegaconf
+import warnings 
+
+from omegaconf import DictConfig
+from omegaconf import OmegaConf as om
+
+# Add repo root to path so we can import scripts and test it
+repo_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.append(repo_dir)
+
+from scripts.train.train import main  # noqa: E402
+
+
+class TestTrainingInputs:
+    """
+    This class contains unit tests for validating the input YAML files used for training.
+    """
+    @pytest.fixture
+    def cfg(self) -> DictConfig:
+        """This fixture will only be available within the scope of TestTrainingInputs"""
+        conf_path: str = os.path.join(repo_dir,
+                                  'scripts/train/yamls/pretrain/mpt-125m.yaml')
+        with open(conf_path, 'r', encoding='utf-8') as config:
+            test_cfg = om.load(config)
+        assert isinstance(test_cfg, DictConfig)
+        return test_cfg
+
+
+    def test_mispelled_mandatory_params_fail(self, cfg: DictConfig) -> None:
+        """ Check that mandatory mispelled inputs fail to train. """
+        cfg.trai_loader = cfg.pop('train_loader')
+        with pytest.raises(omegaconf.errors.ConfigAttributeError):
+            main(cfg)
+
+
+    def test_missing_mandatory_parameters_fail(self, cfg: DictConfig) -> None:
+        """
+        Check that missing mandatory parameters fail to train. 
+        """
+        mandatory_params = ['train_loader', 'model',  'tokenizer', 'optimizer', 'scheduler', 'max_duration',
+            'eval_interval',
+            'precision',
+            'max_seq_len',
+        ] 
+        for param in mandatory_params:
+            orig_param = cfg.pop(param)
+            with pytest.raises((omegaconf.errors.ConfigAttributeError, RuntimeError)):
+                main(cfg)
+            cfg[param] = orig_param
+
+
+    def test_optional_mispelled_params_raise_warning(self, cfg: DictConfig) -> None: 
+        """
+        Check that a mispellings warnings are raised for optional parameters.
+        """
+        optional_params = [
+            'save_weights_only',
+            'save_filename',
+            'run_name'
+            'progress_bar',
+            'python_log_level',
+            'eval_first',
+            'autoresume', 
+            'fsdp_dict_config', 
+            'fsdp_config', 
+            'lora_config', 
+            'eval_loader_config',
+            'icl_tasks_config',
+            'save_folder', 
+        ] 
+        old_cfg = copy.deepcopy(cfg)
+        for param in optional_params:
+            orig_value = cfg.pop(param, None)
+            updated_param = param + '-mispelling'
+            cfg[updated_param] = orig_value
+            with warnings.catch_warnings(record=True) as warning_list:
+                # ideally we should be able to run without try catch but there is no lightweight training run just yet. 
+                try:
+                    main(cfg)
+                except:
+                    pass
+                assert any(f"Unused parameter {updated_param} found in cfg." in str(warning.message) for warning in warning_list)
+            # restore param
+            cfg = copy.deepcopy(old_cfg)

--- a/tests/test_yaml_inputs.py
+++ b/tests/test_yaml_inputs.py
@@ -17,7 +17,7 @@ sys.path.append(repo_dir)
 from scripts.train.train import main  # noqa: E402
 
 
-class TestTrainingInputs:
+class TestTrainingYAMLInputs:
     """
     This class validates and tests error handling for the input YAML files used for training.
     """

--- a/tests/test_yaml_inputs.py
+++ b/tests/test_yaml_inputs.py
@@ -3,10 +3,10 @@
 import copy
 import os
 import sys
-import pytest 
-import omegaconf
-import warnings 
+import warnings
 
+import omegaconf
+import pytest
 from omegaconf import DictConfig
 from omegaconf import OmegaConf as om
 
@@ -18,62 +18,61 @@ from scripts.train.train import main  # noqa: E402
 
 
 class TestTrainingYAMLInputs:
-    """
-    This class validates and tests error handling for the input YAML files used for training.
-    """
+    """Validate and tests error handling for the input YAML file."""
+
     @pytest.fixture
     def cfg(self) -> DictConfig:
         """Create YAML cfg fixture for testing purposes."""
-        conf_path: str = os.path.join(repo_dir,
-                                  'scripts/train/yamls/pretrain/mpt-125m.yaml')
+        conf_path: str = os.path.join(
+            repo_dir, 'scripts/train/yamls/pretrain/mpt-125m.yaml')
         with open(conf_path, 'r', encoding='utf-8') as config:
             test_cfg = om.load(config)
         assert isinstance(test_cfg, DictConfig)
         return test_cfg
 
-
     def test_mispelled_mandatory_params_fail(self, cfg: DictConfig) -> None:
-        """ Check that mandatory mispelled inputs fail to train. """
+        """Check that mandatory mispelled inputs fail to train."""
         cfg.trai_loader = cfg.pop('train_loader')
         with pytest.raises(omegaconf.errors.ConfigAttributeError):
             main(cfg)
 
-
     def test_missing_mandatory_parameters_fail(self, cfg: DictConfig) -> None:
-        """
-        Check that missing mandatory parameters fail to train. 
-        """
-        mandatory_params = ['train_loader', 'model',  'tokenizer', 'optimizer', 'scheduler', 'max_duration',
+        """Check that missing mandatory parameters fail to train."""
+        mandatory_params = [
+            'train_loader',
+            'model',
+            'tokenizer',
+            'optimizer',
+            'scheduler',
+            'max_duration',
             'eval_interval',
             'precision',
             'max_seq_len',
-        ] 
+        ]
         for param in mandatory_params:
             orig_param = cfg.pop(param)
-            with pytest.raises((omegaconf.errors.ConfigAttributeError, RuntimeError)):
+            with pytest.raises(
+                (omegaconf.errors.ConfigAttributeError, RuntimeError)):
                 main(cfg)
             cfg[param] = orig_param
 
-
-    def test_optional_mispelled_params_raise_warning(self, cfg: DictConfig) -> None: 
-        """
-        Check that warnings are raised for optional parameters that are mispelled.
-        """
+    def test_optional_mispelled_params_raise_warning(self,
+                                                     cfg: DictConfig) -> None:
+        """Check that warnings are raised for optional mispelled parameters."""
         optional_params = [
             'save_weights_only',
             'save_filename',
-            'run_name'
+            'run_name',
             'progress_bar',
             'python_log_level',
             'eval_first',
-            'autoresume', 
-            'fsdp_dict_config', 
-            'fsdp_config', 
-            'lora_config', 
+            'autoresume',
+            'save_folder',
+            'fsdp_config',
+            'lora_config',
             'eval_loader_config',
             'icl_tasks_config',
-            'save_folder', 
-        ] 
+        ]
         old_cfg = copy.deepcopy(cfg)
         for param in optional_params:
             orig_value = cfg.pop(param, None)
@@ -84,6 +83,7 @@ class TestTrainingYAMLInputs:
                     main(cfg)
                 except:
                     pass
-                assert any(f"Unused parameter {updated_param} found in cfg." in str(warning.message) for warning in warning_list)
+                assert any(f'Unused parameter {updated_param} found in cfg.' in
+                           str(warning.message) for warning in warning_list)
             # restore configs.
             cfg = copy.deepcopy(old_cfg)

--- a/tests/test_yaml_inputs.py
+++ b/tests/test_yaml_inputs.py
@@ -24,7 +24,7 @@ class TestTrainingYAMLInputs:
     def cfg(self) -> DictConfig:
         """Create YAML cfg fixture for testing purposes."""
         conf_path: str = os.path.join(
-            repo_dir, 'scripts/train/yamls/pretrain/mpt-125m.yaml')
+            repo_dir, 'scripts/train/yamls/pretrain/testing.yaml')
         with open(conf_path, 'r', encoding='utf-8') as config:
             test_cfg = om.load(config)
         assert isinstance(test_cfg, DictConfig)


### PR DESCRIPTION
## Description
This PR enables us to sanity check our train yaml configuration files before we run the full training pipeline. This enables us to catch errors in the YAML config before a training run starts. If a yaml config is improperly formatted with extraneous or missing values, a `NameError` will be thrown. 

## Unit Test: 
Added unit tests to make sure we raise a `NameError` and/or warn the user if the yaml is incorrectly formatted. Warnings are used if the parameter has an optional default value. 

## Integration Test:
Before and after training runs show the same loss curves throughout training. 
<img width="333" alt="Screenshot 2023-08-15 at 10 57 55 AM" src="https://github.com/mosaicml/llm-foundry/assets/13524881/a0329a77-c54b-4d0b-961b-058e35021664">


**mpt-125m training branch master**: https://wandb.ai/mosaic-ml/chuck-runs/runs/2jq1uy86
**mpt-125m training branch chuck/add_yaml_sanity_check_train**: https://wandb.ai/mosaic-ml/chuck-runs/runs/n8wlqwec

All runs at: https://wandb.ai/mosaic-ml/chuck-runs?workspace=user-chuck-tang98 