### PR TITLE
Remove old optimizer logs

### DIFF
--- a/llmfoundry/optim/adaptive_lion.py
+++ b/llmfoundry/optim/adaptive_lion.py
@@ -48,14 +48,6 @@ class DecoupledAdaLRLion(Optimizer):
         'l2_norm/grad':
             lambda param, optim_state, step_tensor: torch.linalg.vector_norm(
                 param.grad),
-        'cosine/update_grad':
-            lambda param, optim_state, step_tensor: torch.nn.functional.
-            cosine_similarity(
-                param.grad.flatten(), step_tensor.flatten(), dim=0),
-        'cosine/moment_grad':
-            lambda param, optim_state, step_tensor: torch.nn.functional.
-            cosine_similarity(
-                param.grad.flatten(), optim_state['exp_avg'].flatten(), dim=0),
     }
 
     def __init__(self,

--- a/llmfoundry/optim/lion.py
+++ b/llmfoundry/optim/lion.py
@@ -26,14 +26,6 @@ class DecoupledLionW(Optimizer):
         'l2_norm/grad':
             lambda param, optim_state, step_tensor: torch.linalg.vector_norm(
                 param.grad),
-        'cosine/update_grad':
-            lambda param, optim_state, step_tensor: torch.nn.functional.
-            cosine_similarity(
-                param.grad.flatten(), step_tensor.flatten(), dim=0),
-        'cosine/moment_grad':
-            lambda param, optim_state, step_tensor: torch.nn.functional.
-            cosine_similarity(
-                param.grad.flatten(), optim_state['exp_avg'].flatten(), dim=0),
     }
 
     def __init__(


### PR DESCRIPTION
The optimizer monitor logs very aggressively. This PR changes removes some logging which is not useful per @bmosaicml's recommendation