### PR TITLE
Monkeypatch flash attention in for llama

### DIFF
--- a/llmfoundry/models/layers/llama_attention_monkeypatch.py
+++ b/llmfoundry/models/layers/llama_attention_monkeypatch.py
@@ -1,0 +1,267 @@
+# Copyright 2022 MosaicML LLM Foundry authors
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+from typing import Callable, Optional, Tuple
+
+import torch
+import torch.functional as F
+
+from llmfoundry.models.layers.attention import (
+    scaled_multihead_dot_product_attention, triton_flash_attn_fn)
+
+log = logging.getLogger(__name__)
+
+
+def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
+    """Equivalent of torch.repeat_interleave(x, dim=1,
+
+    repeats=n_rep).
+
+    The hidden states go from (batch, num_key_value_heads, seqlen, head_dim) to
+    (batch, num_attention_heads, seqlen, head_dim)
+    """
+    batch, num_key_value_heads, slen, head_dim = hidden_states.shape
+    if n_rep == 1:
+        return hidden_states
+    hidden_states = hidden_states[:, :,
+                                  None, :, :].expand(batch, num_key_value_heads,
+                                                     n_rep, slen, head_dim)
+    return hidden_states.reshape(batch, num_key_value_heads * n_rep, slen,
+                                 head_dim)
+
+
+def rotate_half(x: torch.Tensor):
+    """Rotates half the hidden dims of the input."""
+    x1 = x[..., :x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2:]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def apply_rotary_pos_emb(q: torch.Tensor, k: torch.Tensor, cos: torch.Tensor,
+                         sin: torch.Tensor, position_ids: torch.Tensor):
+    # The first two dimensions of cos and sin are always 1, so we can `squeeze` them.
+    cos = cos.squeeze(1).squeeze(0)  # [seq_len, dim]
+    sin = sin.squeeze(1).squeeze(0)  # [seq_len, dim]
+    cos = cos[position_ids].unsqueeze(1)  # [bs, 1, seq_len, dim]
+    sin = sin[position_ids].unsqueeze(1)  # [bs, 1, seq_len, dim]
+    q_embed = (q * cos) + (rotate_half(q) * sin)
+    k_embed = (k * cos) + (rotate_half(k) * sin)
+    return q_embed, k_embed
+
+
+def get_llama_attention_patch_fn(patch_fn_name: str = 'torch') -> Callable:
+    if patch_fn_name == 'torch':
+        return llama_attention_patch_torch
+    elif patch_fn_name == 'triton':
+        return llama_attention_patch_triton
+    else:
+        raise ValueError(
+            f'Unrecognized llama attention patch function: {patch_fn_name}')
+
+
+def llama_attention_patch_torch(
+    self,
+    hidden_states: torch.Tensor,
+    attention_mask: Optional[torch.Tensor] = None,
+    position_ids: Optional[torch.LongTensor] = None,
+    past_key_value: Optional[Tuple[torch.Tensor]] = None,
+    output_attentions: bool = False,
+    use_cache: bool = False,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
+    if use_cache:
+        raise NotImplementedError(
+            'use_cache is not yet supported when patching Llama attention.')
+
+    bsz, q_len, _ = hidden_states.size()
+
+    if self.config.pretraining_tp > 1:
+        key_value_slicing = (self.num_key_value_heads *
+                             self.head_dim) // self.config.pretraining_tp
+        query_slices = self.q_proj.weight.split(
+            (self.num_heads * self.head_dim) // self.config.pretraining_tp,
+            dim=0)
+        key_slices = self.k_proj.weight.split(key_value_slicing, dim=0)
+        value_slices = self.v_proj.weight.split(key_value_slicing, dim=0)
+
+        query_states = [
+            F.linear(hidden_states, query_slices[i])
+            for i in range(self.config.pretraining_tp)
+        ]
+        query_states = torch.cat(query_states, dim=-1)
+
+        key_states = [
+            F.linear(hidden_states, key_slices[i])
+            for i in range(self.config.pretraining_tp)
+        ]
+        key_states = torch.cat(key_states, dim=-1)
+
+        value_states = [
+            F.linear(hidden_states, value_slices[i])
+            for i in range(self.config.pretraining_tp)
+        ]
+        value_states = torch.cat(value_states, dim=-1)
+    else:
+        query_states = self.q_proj(hidden_states)
+        key_states = self.k_proj(hidden_states)
+        value_states = self.v_proj(hidden_states)
+
+    query_states = query_states.view(bsz, q_len, self.num_heads,
+                                     self.head_dim).transpose(1, 2)
+    key_states = key_states.view(bsz, q_len, self.num_key_value_heads,
+                                 self.head_dim).transpose(1, 2)
+    value_states = value_states.view(bsz, q_len, self.num_key_value_heads,
+                                     self.head_dim).transpose(1, 2)
+
+    kv_seq_len = key_states.shape[-2]
+    if past_key_value is not None:
+        kv_seq_len += past_key_value[0].shape[-2]
+    cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)
+    query_states, key_states = apply_rotary_pos_emb(query_states, key_states,
+                                                    cos, sin, position_ids)
+
+    query_states = query_states.transpose(1, 2).view(
+        bsz, q_len, self.num_heads * self.head_dim)
+    key_states = key_states.transpose(1, 2).view(
+        bsz, q_len, self.num_key_value_heads * self.head_dim)
+    value_states = value_states.transpose(1, 2).view(
+        bsz, q_len, self.num_key_value_heads * self.head_dim)
+
+    attn_output, attn_weights, past_key_value = scaled_multihead_dot_product_attention(
+        query=query_states,
+        key=key_states,
+        value=value_states,
+        n_heads=self.num_heads,
+        kv_n_heads=self.num_key_value_heads,
+        past_key_value=past_key_value,
+        softmax_scale=None,
+        attn_bias=attention_mask,
+        key_padding_mask=None,
+        is_causal=False,  # The causal mask is propagated from LLamaForCausalLM
+        dropout_p=0,
+        training=self.training,
+        needs_weights=False,
+    )
+
+    if self.config.pretraining_tp > 1:
+        attn_output = attn_output.split(self.hidden_size //
+                                        self.config.pretraining_tp,
+                                        dim=2)
+        o_proj_slices = self.o_proj.weight.split(self.hidden_size //
+                                                 self.config.pretraining_tp,
+                                                 dim=1)
+        attn_output = sum([
+            F.linear(attn_output[i], o_proj_slices[i])
+            for i in range(self.config.pretraining_tp)
+        ])
+    else:
+        attn_output = self.o_proj(attn_output)
+
+    if not output_attentions:
+        attn_weights = None
+
+    return attn_output, attn_weights, past_key_value
+
+
+def llama_attention_patch_triton(
+    self,
+    hidden_states: torch.Tensor,
+    attention_mask: Optional[torch.Tensor] = None,
+    position_ids: Optional[torch.LongTensor] = None,
+    past_key_value: Optional[Tuple[torch.Tensor]] = None,
+    output_attentions: bool = False,
+    use_cache: bool = False,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
+    if use_cache:
+        raise NotImplementedError(
+            'use_cache is not yet supported when patching Llama attention.')
+    # output_attentions is not support for triton attention
+    if output_attentions:
+        raise NotImplementedError(
+            'output_attentions is not supported when patching Llama attention with triton attention.'
+        )
+    bsz, q_len, _ = hidden_states.size()
+
+    if self.config.pretraining_tp > 1:
+        key_value_slicing = (self.num_key_value_heads *
+                             self.head_dim) // self.config.pretraining_tp
+        query_slices = self.q_proj.weight.split(
+            (self.num_heads * self.head_dim) // self.config.pretraining_tp,
+            dim=0)
+        key_slices = self.k_proj.weight.split(key_value_slicing, dim=0)
+        value_slices = self.v_proj.weight.split(key_value_slicing, dim=0)
+
+        query_states = [
+            F.linear(hidden_states, query_slices[i])
+            for i in range(self.config.pretraining_tp)
+        ]
+        query_states = torch.cat(query_states, dim=-1)
+
+        key_states = [
+            F.linear(hidden_states, key_slices[i])
+            for i in range(self.config.pretraining_tp)
+        ]
+        key_states = torch.cat(key_states, dim=-1)
+
+        value_states = [
+            F.linear(hidden_states, value_slices[i])
+            for i in range(self.config.pretraining_tp)
+        ]
+        value_states = torch.cat(value_states, dim=-1)
+    else:
+        query_states = self.q_proj(hidden_states)
+        key_states = self.k_proj(hidden_states)
+        value_states = self.v_proj(hidden_states)
+
+    query_states = query_states.view(bsz, q_len, self.num_heads,
+                                     self.head_dim).transpose(1, 2)
+    key_states = key_states.view(bsz, q_len, self.num_key_value_heads,
+                                 self.head_dim).transpose(1, 2)
+    value_states = value_states.view(bsz, q_len, self.num_key_value_heads,
+                                     self.head_dim).transpose(1, 2)
+
+    kv_seq_len = key_states.shape[-2]
+    if past_key_value is not None:
+        kv_seq_len += past_key_value[0].shape[-2]
+    cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)
+    query_states, key_states = apply_rotary_pos_emb(query_states, key_states,
+                                                    cos, sin, position_ids)
+
+    query_states = query_states.transpose(1, 2).view(
+        bsz, q_len, self.num_heads * self.head_dim)
+    key_states = key_states.transpose(1, 2).view(
+        bsz, q_len, self.num_key_value_heads * self.head_dim)
+    value_states = value_states.transpose(1, 2).view(
+        bsz, q_len, self.num_key_value_heads * self.head_dim)
+
+    attn_output, _, past_key_value = triton_flash_attn_fn(
+        query=query_states,
+        key=key_states,
+        value=value_states,
+        n_heads=self.num_heads,
+        kv_n_heads=self.num_key_value_heads,
+        past_key_value=past_key_value,
+        softmax_scale=None,
+        attn_bias=attention_mask,
+        key_padding_mask=None,
+        is_causal=False,  # The causal mask is propagated from LLamaForCausalLM
+        dropout_p=0,
+        training=self.training,
+        needs_weights=False,
+    )
+
+    if self.config.pretraining_tp > 1:
+        attn_output = attn_output.split(self.hidden_size //
+                                        self.config.pretraining_tp,
+                                        dim=2)
+        o_proj_slices = self.o_proj.weight.split(self.hidden_size //
+                                                 self.config.pretraining_tp,
+                                                 dim=1)
+        attn_output = sum([
+            F.linear(attn_output[i], o_proj_slices[i])
+            for i in range(self.config.pretraining_tp)
+        ])
+    else:
+        attn_output = self.o_proj(attn_output)
+
+    return attn_output, None, past_key_value

--- a/llmfoundry/models/layers/llama_attention_monkeypatch.py
+++ b/llmfoundry/models/layers/llama_attention_monkeypatch.py
@@ -89,9 +89,9 @@ def llama_attention_patch_torch(
         value_slices = self.v_proj.weight.split(key_value_slicing, dim=0)
 
         query_states = [
-            F.linear( # type: ignore (thirdParty)
-                hidden_states,
-                query_slices[i]) for i in range(self.config.pretraining_tp)
+            F.linear(  # type: ignore (thirdParty)
+                hidden_states, query_slices[i])
+            for i in range(self.config.pretraining_tp)
         ]
         query_states = torch.cat(query_states, dim=-1)
 
@@ -102,9 +102,9 @@ def llama_attention_patch_torch(
         key_states = torch.cat(key_states, dim=-1)
 
         value_states = [
-            F.linear( # type: ignore (thirdParty)
-                hidden_states,
-                value_slices[i]) for i in range(self.config.pretraining_tp)
+            F.linear(  # type: ignore (thirdParty)
+                hidden_states, value_slices[i])
+            for i in range(self.config.pretraining_tp)
         ]
         value_states = torch.cat(value_states, dim=-1)
     else:
@@ -160,9 +160,9 @@ def llama_attention_patch_torch(
                                                  self.config.pretraining_tp,
                                                  dim=1)
         attn_output = sum([
-            F.linear( # type: ignore (thirdParty)
-                attn_output[i],
-                o_proj_slices[i]) for i in range(self.config.pretraining_tp)
+            F.linear(  # type: ignore (thirdParty)
+                attn_output[i], o_proj_slices[i])
+            for i in range(self.config.pretraining_tp)
         ])
     else:
         attn_output = self.o_proj(attn_output)
@@ -170,7 +170,7 @@ def llama_attention_patch_torch(
     if not output_attentions:
         attn_weights = None
 
-    return attn_output, attn_weights, None # type: ignore (thirdParty)
+    return attn_output, attn_weights, None  # type: ignore (thirdParty)
 
 
 def llama_attention_patch_triton(
@@ -202,9 +202,9 @@ def llama_attention_patch_triton(
         value_slices = self.v_proj.weight.split(key_value_slicing, dim=0)
 
         query_states = [
-            F.linear(hidden_states, # type: ignore (thirdParty)
-                     query_slices[i])
-            for i in range(self.config.pretraining_tp)
+            F.linear(  # type: ignore (thirdParty)
+                hidden_states,
+                query_slices[i]) for i in range(self.config.pretraining_tp)
         ]
         query_states = torch.cat(query_states, dim=-1)
 
@@ -215,9 +215,9 @@ def llama_attention_patch_triton(
         key_states = torch.cat(key_states, dim=-1)
 
         value_states = [
-            F.linear(hidden_states, # type: ignore (thirdParty)
-                     value_slices[i])
-            for i in range(self.config.pretraining_tp)
+            F.linear( # type: ignore (thirdParty)
+                hidden_states,
+                value_slices[i]) for i in range(self.config.pretraining_tp)
         ]
         value_states = torch.cat(value_states, dim=-1)
     else:
@@ -273,11 +273,11 @@ def llama_attention_patch_triton(
                                                  self.config.pretraining_tp,
                                                  dim=1)
         attn_output = sum([
-            F.linear(attn_output[i], # type: ignore (thirdParty)
-                     o_proj_slices[i])
-            for i in range(self.config.pretraining_tp)
+            F.linear(  # type: ignore (thirdParty)
+                attn_output[i],
+                o_proj_slices[i]) for i in range(self.config.pretraining_tp)
         ])
     else:
         attn_output = self.o_proj(attn_output)
 
-    return attn_output, None, None # type: ignore (thirdParty)
+    return attn_output, None, None  # type: ignore (thirdParty)

--- a/llmfoundry/models/layers/llama_attention_monkeypatch.py
+++ b/llmfoundry/models/layers/llama_attention_monkeypatch.py
@@ -203,8 +203,8 @@ def llama_attention_patch_triton(
 
         query_states = [
             F.linear(  # type: ignore (thirdParty)
-                hidden_states,
-                query_slices[i]) for i in range(self.config.pretraining_tp)
+                hidden_states, query_slices[i])
+            for i in range(self.config.pretraining_tp)
         ]
         query_states = torch.cat(query_states, dim=-1)
 
@@ -215,9 +215,9 @@ def llama_attention_patch_triton(
         key_states = torch.cat(key_states, dim=-1)
 
         value_states = [
-            F.linear( # type: ignore (thirdParty)
-                hidden_states,
-                value_slices[i]) for i in range(self.config.pretraining_tp)
+            F.linear(  # type: ignore (thirdParty)
+                hidden_states, value_slices[i])
+            for i in range(self.config.pretraining_tp)
         ]
         value_states = torch.cat(value_states, dim=-1)
     else:
@@ -274,8 +274,8 @@ def llama_attention_patch_triton(
                                                  dim=1)
         attn_output = sum([
             F.linear(  # type: ignore (thirdParty)
-                attn_output[i],
-                o_proj_slices[i]) for i in range(self.config.pretraining_tp)
+                attn_output[i], o_proj_slices[i])
+            for i in range(self.config.pretraining_tp)
         ])
     else:
         attn_output = self.o_proj(attn_output)

--- a/llmfoundry/models/layers/llama_attention_monkeypatch.py
+++ b/llmfoundry/models/layers/llama_attention_monkeypatch.py
@@ -89,8 +89,8 @@ def llama_attention_patch_torch(
         value_slices = self.v_proj.weight.split(key_value_slicing, dim=0)
 
         query_states = [
-            F.linear(
-                hidden_states,  # type: ignore (thirdParty)
+            F.linear( # type: ignore (thirdParty)
+                hidden_states,
                 query_slices[i]) for i in range(self.config.pretraining_tp)
         ]
         query_states = torch.cat(query_states, dim=-1)
@@ -102,8 +102,8 @@ def llama_attention_patch_torch(
         key_states = torch.cat(key_states, dim=-1)
 
         value_states = [
-            F.linear(
-                hidden_states,  # type: ignore (thirdParty)
+            F.linear( # type: ignore (thirdParty)
+                hidden_states,
                 value_slices[i]) for i in range(self.config.pretraining_tp)
         ]
         value_states = torch.cat(value_states, dim=-1)
@@ -160,8 +160,8 @@ def llama_attention_patch_torch(
                                                  self.config.pretraining_tp,
                                                  dim=1)
         attn_output = sum([
-            F.linear(
-                attn_output[i],  # type: ignore (thirdParty)
+            F.linear( # type: ignore (thirdParty)
+                attn_output[i],
                 o_proj_slices[i]) for i in range(self.config.pretraining_tp)
         ])
     else:
@@ -170,7 +170,7 @@ def llama_attention_patch_torch(
     if not output_attentions:
         attn_weights = None
 
-    return attn_output, attn_weights, None
+    return attn_output, attn_weights, None # type: ignore (thirdParty)
 
 
 def llama_attention_patch_triton(
@@ -202,8 +202,8 @@ def llama_attention_patch_triton(
         value_slices = self.v_proj.weight.split(key_value_slicing, dim=0)
 
         query_states = [
-            F.linear(hidden_states,
-                     query_slices[i])  # type: ignore (thirdParty)
+            F.linear(hidden_states, # type: ignore (thirdParty)
+                     query_slices[i])
             for i in range(self.config.pretraining_tp)
         ]
         query_states = torch.cat(query_states, dim=-1)
@@ -215,8 +215,8 @@ def llama_attention_patch_triton(
         key_states = torch.cat(key_states, dim=-1)
 
         value_states = [
-            F.linear(hidden_states,
-                     value_slices[i])  # type: ignore (thirdParty)
+            F.linear(hidden_states, # type: ignore (thirdParty)
+                     value_slices[i])
             for i in range(self.config.pretraining_tp)
         ]
         value_states = torch.cat(value_states, dim=-1)
@@ -273,11 +273,11 @@ def llama_attention_patch_triton(
                                                  self.config.pretraining_tp,
                                                  dim=1)
         attn_output = sum([
-            F.linear(attn_output[i],
-                     o_proj_slices[i])  # type: ignore (thirdParty)
+            F.linear(attn_output[i], # type: ignore (thirdParty)
+                     o_proj_slices[i])
             for i in range(self.config.pretraining_tp)
         ])
     else:
         attn_output = self.o_proj(attn_output)
 
-    return attn_output, None, None
+    return attn_output, None, None # type: ignore (thirdParty)

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -328,6 +328,8 @@ def main(cfg: DictConfig):
         dist_timeout=cfg.dist_timeout,
     )
 
+    torch.cuda.empty_cache()
+
     print('Logging config...')
     log_config(cfg)
 

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -173,6 +173,11 @@ def main(cfg: DictConfig):
     # Check for incompatibilities between the model and data loaders
     validate_config(cfg)
 
+    max_split_size_mb = cfg.get('max_split_size_mb', None)
+    if max_split_size_mb is not None:
+        os.environ[
+            'PYTORCH_CUDA_ALLOC_CONF'] = f'max_split_size_mb:{max_split_size_mb}'
+
     # Filter deprecation warning from torch internal usage
     warnings.filterwarnings(
         action='ignore',

--- a/setup.py
+++ b/setup.py
@@ -47,8 +47,9 @@ classifiers = [
 ]
 
 install_requires = [
-    'mosaicml[libcloud,nlp,wandb,mlflow]>=0.15.0,<0.16',
+    'mosaicml[libcloud,wandb,mlflow]>=0.15.0,<0.16',
     'accelerate>=0.20,<0.21',  # for HF inference `device_map`
+    'transformers>=4.31,<4.32',
     'mosaicml-streaming>=0.5.1,<0.6',
     'torch>=1.13.1,<=2.0.1',
     'datasets==2.10.1',

--- a/tests/test_llama_patch.py
+++ b/tests/test_llama_patch.py
@@ -1,0 +1,85 @@
+# Copyright 2022 MosaicML LLM Foundry authors
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import transformers
+from composer.utils import reproducibility
+from transformers.models.llama.modeling_llama import LlamaAttention
+
+from llmfoundry.models.layers.llama_attention_monkeypatch import (
+    llama_attention_patch_torch, llama_attention_patch_triton)
+
+
+@pytest.mark.parametrize('patch_fn_name', ['torch', 'triton'])
+@pytest.mark.parametrize('explicit_mask', [True, False])
+# @pytest.mark.gpu
+def test_patch_equivalence(patch_fn_name: str, explicit_mask: bool):
+    original_forward = LlamaAttention.forward
+
+    device = 'cuda:0'
+    sequence_length = 4096
+    model_dim = 4096
+    batch_size = 2
+    if patch_fn_name == 'torch':
+        patch_fn = llama_attention_patch_torch
+        dtype = torch.float32
+        atol = 0.0
+        rtol = 0.0
+    elif patch_fn_name == 'triton':
+        # the huggingface implementation of llama performs the softmax in fp32
+        # this can result in fairly large differences for the triton implementation
+        # but the torch implementation produces the exact same output so we can confirm
+        # the implementation is correct
+        patch_fn = llama_attention_patch_triton
+        dtype = torch.bfloat16
+        atol = 1e-2
+        rtol = 1e-2
+    else:
+        raise ValueError(f'Unknown patch_fn_name: {patch_fn_name}')
+
+    llama_7b_config = transformers.AutoConfig.from_pretrained(
+        'meta-llama/Llama-2-7b-hf', use_auth_token=True)
+
+    reproducibility.seed_all(42)
+    attention = LlamaAttention(config=llama_7b_config,)
+    attention.to(dtype=dtype, device=device)
+
+    rng = torch.Generator(device=device).manual_seed(42)
+    hidden_states = torch.randn(batch_size,
+                                sequence_length,
+                                model_dim,
+                                generator=rng,
+                                dtype=dtype,
+                                device=device)
+    causal_mask = torch.full((sequence_length, sequence_length),
+                             torch.finfo(torch.float32).min,
+                             device=device)
+    causal_mask = causal_mask.triu(diagonal=1)
+    causal_mask = causal_mask[None,
+                              None, :, :].expand(batch_size, 1, sequence_length,
+                                                 sequence_length)
+    attn_output, _, _ = attention(
+        hidden_states=hidden_states,
+        attention_mask=causal_mask if explicit_mask else None,
+        position_ids=None,
+        past_key_value=None,
+        use_cache=False,
+    )
+
+    reproducibility.seed_all(42)
+    LlamaAttention.forward = patch_fn
+    attention = LlamaAttention(config=llama_7b_config,)
+    attention.to(dtype=dtype, device=device)
+    new_output, _, _ = attention(
+        hidden_states=hidden_states,
+        attention_mask=causal_mask if explicit_mask else None,
+        position_ids=None,
+        past_key_value=None,
+        use_cache=False,
+    )
+
+    # Reset the forward function so patches don't persist
+    LlamaAttention.forward = original_forward
+
+    assert torch.allclose(attn_output, new_output, atol=atol, rtol=rtol)

--- a/tests/test_llama_patch.py
+++ b/tests/test_llama_patch.py
@@ -15,9 +15,11 @@ from llmfoundry.models.layers.llama_attention_monkeypatch import (
 
 @pytest.mark.parametrize('patch_fn_name', ['torch', 'triton'])
 @pytest.mark.parametrize('explicit_mask', [True, False])
-@pytest.mark.parametrize('model_name', ['meta-llama/Llama-2-7b-hf', 'meta-llama/Llama-2-70b-hf'])
-# @pytest.mark.gpu
-def test_patch_equivalence(patch_fn_name: str, explicit_mask: bool, model_name: str):
+@pytest.mark.parametrize(
+    'model_name', ['meta-llama/Llama-2-7b-hf', 'meta-llama/Llama-2-70b-hf'])
+@pytest.mark.gpu
+def test_patch_equivalence(patch_fn_name: str, explicit_mask: bool,
+                           model_name: str):
     if 'HUGGING_FACE_HUB_TOKEN' not in os.environ:
         pytest.skip(
             'The CI cluster does not have access to the Llama models, so skip this test.'

--- a/tests/test_llama_patch.py
+++ b/tests/test_llama_patch.py
@@ -52,7 +52,7 @@ def test_patch_equivalence(patch_fn_name: str, explicit_mask: bool,
         model_name, use_auth_token=True)
 
     reproducibility.seed_all(42)
-    attention = LlamaAttention(config=llama_7b_config,)
+    attention = LlamaAttention(config=llama_config,)
     attention.to(dtype=dtype, device=device)
 
     rng = torch.Generator(device=device).manual_seed(42)

--- a/tests/test_llama_patch.py
+++ b/tests/test_llama_patch.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+
 import pytest
 import torch
 import transformers
@@ -17,7 +18,9 @@ from llmfoundry.models.layers.llama_attention_monkeypatch import (
 @pytest.mark.gpu
 def test_patch_equivalence(patch_fn_name: str, explicit_mask: bool):
     if 'HUGGING_FACE_HUB_TOKEN' not in os.environ:
-        pytest.skip("The CI cluster does not have access to the Llama models, so skip this test.")
+        pytest.skip(
+            'The CI cluster does not have access to the Llama models, so skip this test.'
+        )
 
     original_forward = LlamaAttention.forward
 

--- a/tests/test_llama_patch.py
+++ b/tests/test_llama_patch.py
@@ -79,7 +79,7 @@ def test_patch_equivalence(patch_fn_name: str, explicit_mask: bool,
 
     reproducibility.seed_all(42)
     LlamaAttention.forward = patch_fn
-    attention = LlamaAttention(config=llama_7b_config,)
+    attention = LlamaAttention(config=llama_config,)
     attention.to(dtype=dtype, device=device)
     new_output, _, _ = attention(
         hidden_states=hidden_states,

--- a/tests/test_llama_patch.py
+++ b/tests/test_llama_patch.py
@@ -48,7 +48,7 @@ def test_patch_equivalence(patch_fn_name: str, explicit_mask: bool,
     else:
         raise ValueError(f'Unknown patch_fn_name: {patch_fn_name}')
 
-    llama_7b_config = transformers.AutoConfig.from_pretrained(
+    llama_config = transformers.AutoConfig.from_pretrained(
         model_name, use_auth_token=True)
 
     reproducibility.seed_all(42)

--- a/tests/test_llama_patch.py
+++ b/tests/test_llama_patch.py
@@ -1,6 +1,7 @@
 # Copyright 2022 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import pytest
 import torch
 import transformers
@@ -13,8 +14,11 @@ from llmfoundry.models.layers.llama_attention_monkeypatch import (
 
 @pytest.mark.parametrize('patch_fn_name', ['torch', 'triton'])
 @pytest.mark.parametrize('explicit_mask', [True, False])
-# @pytest.mark.gpu
+@pytest.mark.gpu
 def test_patch_equivalence(patch_fn_name: str, explicit_mask: bool):
+    if 'HUGGING_FACE_HUB_TOKEN' not in os.environ:
+        pytest.skip("The CI cluster does not have access to the Llama models, so skip this test.")
+
     original_forward = LlamaAttention.forward
 
     device = 'cuda:0'

--- a/tests/test_llama_patch.py
+++ b/tests/test_llama_patch.py
@@ -48,8 +48,8 @@ def test_patch_equivalence(patch_fn_name: str, explicit_mask: bool,
     else:
         raise ValueError(f'Unknown patch_fn_name: {patch_fn_name}')
 
-    llama_config = transformers.AutoConfig.from_pretrained(
-        model_name, use_auth_token=True)
+    llama_config = transformers.AutoConfig.from_pretrained(model_name,
+                                                           use_auth_token=True)
 
     reproducibility.seed_all(42)
     attention = LlamaAttention(config=llama_config,)


### PR DESCRIPTION
This PR adds a monkeypatch of triton flash attention for llama2 models. If we start doing this for more models we can try to generalize into an algorithm, but until that time I think this monkeypatch is good enough.

TODO:
- [x] Copy profiling results for 7b
- [x] Copy profiling results for 70b
- [x] Paste in evidence that the test passes

Result for 7b scale to compare implementations:
<img width="433" alt="Screenshot 2023-08-10 at 4 31 57 PM" src="https://github.com/mosaicml/llm-foundry/assets/43149077/b453f0eb-42ae-4669-be52-3e5c72625f90">
<img width="456" alt="Screenshot 2023-08-10 at 4 32 04 PM" src="https://github.com/mosaicml/llm-foundry/assets/43149077/47f5aa13-b61e-48a4-a9ed-cc3833e55517">
<img width="448" alt="Screenshot 2023-08-10 at 4 32 20 PM" src="https://github.com/mosaicml/llm-foundry/assets/43149077/fb16ff2f-3420-445e-ab8f-b9a9166c5acf">

Test results:
```
tests/test_llama_patch.py::test_patch_equivalence[meta-llama/Llama-2-7b-hf-True-torch] 
------------------------------------------------------------------------------------------------------------------- live log call -------------------------------------------------------------------------------------------------------------------
2023-08-11 22:18:17 [    INFO] Setting seed to 42 (reproducibility.py:159)
2023-08-11 22:18:23 [    INFO] Setting seed to 42 (reproducibility.py:159)
PASSED                                                                                                                                                                                                                                        [ 12%]
tests/test_llama_patch.py::test_patch_equivalence[meta-llama/Llama-2-7b-hf-True-triton] 
------------------------------------------------------------------------------------------------------------------- live log call -------------------------------------------------------------------------------------------------------------------
2023-08-11 22:18:23 [    INFO] Setting seed to 42 (reproducibility.py:159)
2023-08-11 22:18:24 [    INFO] Setting seed to 42 (reproducibility.py:159)
PASSED                                                                                                                                                                                                                                        [ 25%]
tests/test_llama_patch.py::test_patch_equivalence[meta-llama/Llama-2-7b-hf-False-torch] 
------------------------------------------------------------------------------------------------------------------- live log call -------------------------------------------------------------------------------------------------------------------
2023-08-11 22:18:25 [    INFO] Setting seed to 42 (reproducibility.py:159)
2023-08-11 22:18:26 [    INFO] Setting seed to 42 (reproducibility.py:159)
PASSED                                                                                                                                                                                                                                        [ 37%]
tests/test_llama_patch.py::test_patch_equivalence[meta-llama/Llama-2-7b-hf-False-triton] 
------------------------------------------------------------------------------------------------------------------- live log call -------------------------------------------------------------------------------------------------------------------
2023-08-11 22:18:27 [    INFO] Setting seed to 42 (reproducibility.py:159)
2023-08-11 22:18:27 [    INFO] Setting seed to 42 (reproducibility.py:159)
PASSED                                                                                                                                                                                                                                        [ 50%]
tests/test_llama_patch.py::test_patch_equivalence[meta-llama/Llama-2-70b-hf-True-torch] 
------------------------------------------------------------------------------------------------------------------- live log call -------------------------------------------------------------------------------------------------------------------
2023-08-11 22:18:28 [    INFO] Setting seed to 42 (reproducibility.py:159)
2023-08-11 22:18:29 [    INFO] Setting seed to 42 (reproducibility.py:159)
PASSED                                                                                                                                                                                                                                        [ 62%]
tests/test_llama_patch.py::test_patch_equivalence[meta-llama/Llama-2-70b-hf-True-triton] 
------------------------------------------------------------------------------------------------------------------- live log call -------------------------------------------------------------------------------------------------------------------
2023-08-11 22:18:30 [    INFO] Setting seed to 42 (reproducibility.py:159)
2023-08-11 22:18:32 [    INFO] Setting seed to 42 (reproducibility.py:159)
PASSED                                                                                                                                                                                                                                        [ 75%]
tests/test_llama_patch.py::test_patch_equivalence[meta-llama/Llama-2-70b-hf-False-torch] 
------------------------------------------------------------------------------------------------------------------- live log call -------------------------------------------------------------------------------------------------------------------
2023-08-11 22:18:33 [    INFO] Setting seed to 42 (reproducibility.py:159)
2023-08-11 22:18:34 [    INFO] Setting seed to 42 (reproducibility.py:159)
PASSED                                                                                                                                                                                                                                        [ 87%]
tests/test_llama_patch.py::test_patch_equivalence[meta-llama/Llama-2-70b-hf-False-triton] 
------------------------------------------------------------------------------------------------------------------- live log call -------------------------------------------------------------------------------------------------------------------
2023-08-11 22:18:36 [    INFO] Setting seed to 42 (reproducibility.py:159)
2023-08-11 22:18:37 [    INFO] Setting seed to 42 (reproducibility.py:159)
PASSED                                                                                                                                                                                                                                        [100%]

================================================================================================================= warnings summary ==================================================================================================================
../../miniconda3/envs/foundry-3.10/lib/python3.10/site-packages/accelerate/utils/dataclasses.py:29
  /mnt/workdisk/danielking/miniconda3/envs/foundry-3.10/lib/python3.10/site-packages/accelerate/utils/dataclasses.py:29: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
    from distutils.util import strtobool

../../miniconda3/envs/foundry-3.10/lib/python3.10/site-packages/deepspeed/ops/op_builder/builder.py:15
  /mnt/workdisk/danielking/miniconda3/envs/foundry-3.10/lib/python3.10/site-packages/deepspeed/ops/op_builder/builder.py:15: DeprecationWarning: The distutils.sysconfig module is deprecated, use sysconfig instead
    import distutils.sysconfig

../../miniconda3/envs/foundry-3.10/lib/python3.10/site-packages/jupyter_client/connect.py:20
  /mnt/workdisk/danielking/miniconda3/envs/foundry-3.10/lib/python3.10/site-packages/jupyter_client/connect.py:20: DeprecationWarning: Jupyter is migrating its paths to use standard platformdirs
  given by the platformdirs library.  To remove this warning and
  see the appropriate new directories, set the environment variable
  `JUPYTER_PLATFORM_DIRS=1` and then run `jupyter --paths`.
  The use of platformdirs will be the default in `jupyter_core` v6
    from jupyter_core.paths import jupyter_data_dir, jupyter_runtime_dir, secure_write

../../miniconda3/envs/foundry-3.10/lib/python3.10/site-packages/comet_ml/monkey_patching.py:19
  /mnt/workdisk/danielking/miniconda3/envs/foundry-3.10/lib/python3.10/site-packages/comet_ml/monkey_patching.py:19: DeprecationWarning: the imp module is deprecated in favour of importlib and slated for removal in Python 3.12; see the module's documentation for alternative uses
    import imp

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================================================================== 8 passed, 4 warnings in 22.00s ===========================================================================================================
```

70b running on 16 and 32 gpus:
<img width="899" alt="Screenshot 2023-08-11 at 2 59 36 PM" src="https://github.com/mosaicml/llm-foundry/assets/43149077/d6ee425d-4d88-44f9-80af-39a0e99934e6">
<img width="443" alt="Screenshot 2023-08-11 at 2 59 45 PM" src="https://github.com/mosaicml/llm-foundry/assets/43149077/26edfb35-e8a9-446c-9c48-528eac5571de">
<img width="464" alt="Screenshot 2023-08-11 at 2 59 50 PM" src="https://github.com/mosaicml/llm-foundry/assets/43149077/797f0319-57a2-4052-8bc0-a37accf2d1cd">
<img width="431" alt="Screenshot 2023-08-11 at 3 00 00 PM" src="https://github.com/mosaicml/llm-foundry/assets/43149077/2f82e12d-b38e-4831-8266-a880b092bcba">
