### PR TITLE
Add runtime error in eval.py if yaml config is improperly formatted with extraneous or missing values

### DIFF
--- a/scripts/eval/eval.py
+++ b/scripts/eval/eval.py
@@ -142,7 +142,7 @@ def main(cfg: DictConfig):
     default_run_name: str = os.environ.get('RUN_NAME', 'llm')
     run_name: str = cfg.pop('run_name', default_run_name)
     num_retries: int = cfg.pop('num_retries', 3)
-    loggers_cfg: Dict[str, Any] = cfg.pop('loggers', {}) or {}
+    loggers_cfg: Dict[str, Any] = cfg.pop('loggers', {})
     cfg.pop('model_name_or_path', None)
 
     # Warn for unused parameters

--- a/scripts/eval/eval.py
+++ b/scripts/eval/eval.py
@@ -122,11 +122,12 @@ def evaluate_model(model_cfg: DictConfig, dist_timeout: Union[float, int],
                                                 model_gauntlet)  # type: ignore
 
     if hasattr(model_cfg.model, 'pretrained_lora_id_or_path'):
-        composer_model = load_peft_model(model_cfg.model, tokenizer, num_retries)
+        composer_model = load_peft_model(model_cfg.model, tokenizer,
+                                         num_retries)
     else:
         composer_model = load_model(model_cfg.model, tokenizer, fsdp_config,
-                                num_retries)
-      
+                                    num_retries)
+
     if model_gauntlet_df is None and model_gauntlet is not None:
         model_gauntlet_df = pd.DataFrame(
             columns=['model_name', 'average'] +
@@ -170,27 +171,46 @@ def evaluate_model(model_cfg: DictConfig, dist_timeout: Union[float, int],
 def main(cfg: DictConfig):
     om.resolve(cfg)
     model_configs: ListConfig = pop_config(cfg, 'models', must_exist=True)
-    model_gauntlet_config: Optional[Union[str, DictConfig]] = pop_config(cfg, 
-        'model_gauntlet', must_exist=False, default_value=None)
-    fsdp_dict_cfg: Optional[DictConfig] = pop_config(cfg, 'fsdp_config', must_exist=False, default_value=None)
+    model_gauntlet_config: Optional[Union[str, DictConfig]] = pop_config(
+        cfg, 'model_gauntlet', must_exist=False, default_value=None)
+    fsdp_dict_cfg: Optional[DictConfig] = pop_config(cfg,
+                                                     'fsdp_config',
+                                                     must_exist=False,
+                                                     default_value=None)
     fsdp_config: Optional[Dict] = om.to_container(
         fsdp_dict_cfg,
         resolve=True) if fsdp_dict_cfg is not None else None  # type: ignore
     assert isinstance(fsdp_config, Dict) or fsdp_config is None
 
     # Mandatory Evaluation Parameters
-    icl_tasks: Union[str, ListConfig] = pop_config(cfg, 'icl_tasks', must_exist=True)
+    icl_tasks: Union[str, ListConfig] = pop_config(cfg,
+                                                   'icl_tasks',
+                                                   must_exist=True)
     max_seq_len: int = pop_config(cfg, 'max_seq_len', must_exist=True)
-    device_eval_batch_size: int = pop_config(cfg, 'device_eval_batch_size', must_exist=True)
+    device_eval_batch_size: int = pop_config(cfg,
+                                             'device_eval_batch_size',
+                                             must_exist=True)
     precision: str = pop_config(cfg, 'precision', must_exist=True)
 
     # Optional Evaluation Parameters with default values
     seed: int = pop_config(cfg, 'seed', must_exist=False, default_value=17)
-    dist_timeout: Union[float, int] = pop_config(cfg, 'dist_timeout', must_exist=False, default_value=600.0)
+    dist_timeout: Union[float, int] = pop_config(cfg,
+                                                 'dist_timeout',
+                                                 must_exist=False,
+                                                 default_value=600.0)
     default_run_name: str = os.environ.get('RUN_NAME', 'llm')
-    run_name: str = pop_config(cfg, 'run_name', must_exist=False, default_value=default_run_name)
-    num_retries: int = pop_config(cfg, 'num_retries', must_exist=False, default_value=3)
-    loggers_cfg: Dict[str, Any] = pop_config(cfg, 'loggers', must_exist=False, default_value={})
+    run_name: str = pop_config(cfg,
+                               'run_name',
+                               must_exist=False,
+                               default_value=default_run_name)
+    num_retries: int = pop_config(cfg,
+                                  'num_retries',
+                                  must_exist=False,
+                                  default_value=3)
+    loggers_cfg: Dict[str, Any] = pop_config(cfg,
+                                             'loggers',
+                                             must_exist=False,
+                                             default_value={})
 
     # Pop out interpolation variables.
     pop_config(cfg, 'model_name_or_path', must_exist=False, default_value=None)

--- a/scripts/eval/eval.py
+++ b/scripts/eval/eval.py
@@ -242,7 +242,7 @@ def main(cfg: DictConfig):
         else:
             models_df = pd.concat([models_df, model_results], ignore_index=True)
 
-        if model_gauntlet_df is not None and model_gauntlet is not None and model_gauntlet_df is not None:
+        if model_gauntlet_df is not None and model_gauntlet is not None:
             assert composite_scores is not None
             row = {'model_name': model_cfg['model_name']}
             row.update({

--- a/scripts/eval/eval.py
+++ b/scripts/eval/eval.py
@@ -5,8 +5,8 @@ import os
 import re
 import sys
 import time
-from typing import Any, Dict, List, Optional, Union
 import warnings
+from typing import Any, Dict, List, Optional, Union
 
 import pandas as pd
 import torch
@@ -47,17 +47,12 @@ def load_model(model_cfg: DictConfig, tokenizer: PreTrainedTokenizerBase,
                     )
 
 
-def evaluate_model(model_cfg: DictConfig,
-                   dist_timeout: Union[float, int], 
-                   run_name: str,
-                   icl_tasks: Union[str, ListConfig],
-                   max_seq_len: int,
-                   device_eval_batch_size: int,
-                   model_gauntlet_config: Optional[Union[str, DictConfig]], 
-                   fsdp_config: Optional[Dict], 
-                   num_retries: int, 
-                   loggers_cfg: Dict[str, Any],
-                   precision: str,
+def evaluate_model(model_cfg: DictConfig, dist_timeout: Union[float, int],
+                   run_name: str, icl_tasks: Union[str, ListConfig],
+                   max_seq_len: int, device_eval_batch_size: int,
+                   model_gauntlet_config: Optional[Union[str, DictConfig]],
+                   fsdp_config: Optional[Dict], num_retries: int,
+                   loggers_cfg: Dict[str, Any], precision: str,
                    model_gauntlet_df: Optional[pd.DataFrame]):
     print(f'Evaluating model: {model_cfg.model_name}', flush=True)
     # Build tokenizer and model
@@ -74,11 +69,12 @@ def evaluate_model(model_cfg: DictConfig,
             model_gauntlet = loaded_model_gauntlet_config.model_gauntlet
         else:
             model_gauntlet = model_gauntlet_config
-        model_gauntlet.logger_keys = logger_keys
-        model_gauntlet.benchmark_sizes = {
+        model_gauntlet.logger_keys = logger_keys  # type: ignore
+        model_gauntlet.benchmark_sizes = {  # type: ignore
             e.label: e.dataloader.num_samples for e in evaluators
         }
-        model_gauntlet_callback = ModelGauntlet(**model_gauntlet)  # type: ignore
+        model_gauntlet_callback = ModelGauntlet(**
+                                                model_gauntlet)  # type: ignore
 
     composer_model = load_model(model_cfg.model, tokenizer, fsdp_config,
                                 num_retries)
@@ -154,7 +150,7 @@ def main(cfg: DictConfig):
         warnings.warn(
             f'Unused parameter {key} found in cfg. Please check your yaml to ensure this parameter is necessary.'
         )
-    
+
     reproducibility.seed_all(seed)
     dist.initialize_dist(get_device(None), timeout=dist_timeout)
 
@@ -164,19 +160,18 @@ def main(cfg: DictConfig):
     for model_cfg in model_configs:
         (in_memory_logger, logger_keys, model_gauntlet_callback, model_gauntlet,
          model_gauntlet_df) = evaluate_model(
-            model_cfg = model_cfg,
-            dist_timeout = dist_timeout,
-            run_name = run_name,
-            icl_tasks = icl_tasks,
-            max_seq_len = max_seq_len,
-            device_eval_batch_size = device_eval_batch_size,
-            model_gauntlet_config = model_gauntlet_config, 
-            fsdp_config = fsdp_config,
-            num_retries = num_retries, 
-            loggers_cfg = loggers_cfg,
-            precision = precision,
-            model_gauntlet_df = model_gauntlet_df
-        )
+             model_cfg=model_cfg,
+             dist_timeout=dist_timeout,
+             run_name=run_name,
+             icl_tasks=icl_tasks,
+             max_seq_len=max_seq_len,
+             device_eval_batch_size=device_eval_batch_size,
+             model_gauntlet_config=model_gauntlet_config,
+             fsdp_config=fsdp_config,
+             num_retries=num_retries,
+             loggers_cfg=loggers_cfg,
+             precision=precision,
+             model_gauntlet_df=model_gauntlet_df)
 
         if model_gauntlet_callback is not None:
             # TODO(bmosaicml) This needs to be refactored to fix the typing issue

--- a/scripts/eval/eval.py
+++ b/scripts/eval/eval.py
@@ -191,6 +191,8 @@ def main(cfg: DictConfig):
     run_name: str = cfg.pop('run_name', default_run_name)
     num_retries: int = cfg.pop('num_retries', 3)
     loggers_cfg: Dict[str, Any] = cfg.pop('loggers', {})
+
+    # Pop out interpolation variables.
     cfg.pop('model_name_or_path', None)
 
     # Warn for unused parameters

--- a/tests/test_eval_inputs.py
+++ b/tests/test_eval_inputs.py
@@ -23,8 +23,8 @@ class TestEvalYAMLInputs:
     @pytest.fixture
     def cfg(self) -> DictConfig:
         """Create YAML cfg fixture for testing purposes."""
-        conf_path: str = os.path.join(
-            repo_dir, 'scripts/eval/yamls/hf_eval.yaml')
+        conf_path: str = os.path.join(repo_dir,
+                                      'scripts/eval/yamls/hf_eval.yaml')
         with open(conf_path, 'r', encoding='utf-8') as config:
             test_cfg = om.load(config)
         assert isinstance(test_cfg, DictConfig)
@@ -35,16 +35,16 @@ class TestEvalYAMLInputs:
         mandatory_params = [
             'max_seq_len',
             'device_eval_batch_size',
-            'precision', 
+            'precision',
             'model_configs',
         ]
         mandatory_configs = ['models', 'icl_tasks']
         for p in mandatory_params + mandatory_configs:
-            with pytest.raises((omegaconf.errors.ConfigKeyError, omegaconf.errors.InterpolationKeyError)):
-                cfg[p + "-mispelled"] = cfg.pop(p)
+            with pytest.raises((omegaconf.errors.ConfigKeyError,
+                                omegaconf.errors.InterpolationKeyError)):
+                cfg[p + '-mispelled'] = cfg.pop(p)
                 main(cfg)
-                cfg[p] = cfg.pop(p + "-mispelled")
-
+                cfg[p] = cfg.pop(p + '-mispelled')
 
     def test_optional_mispelled_params_raise_warning(self,
                                                      cfg: DictConfig) -> None:
@@ -55,7 +55,7 @@ class TestEvalYAMLInputs:
             'run_name',
             'num_retries',
             'loggers',
-            'model_gauntlet', 
+            'model_gauntlet',
             'fsdp_config',
         ]
         old_cfg = copy.deepcopy(cfg)

--- a/tests/test_eval_inputs.py
+++ b/tests/test_eval_inputs.py
@@ -1,0 +1,74 @@
+# Copyright 2022 MosaicML LLM Foundry authors
+# SPDX-License-Identifier: Apache-2.0
+import copy
+import os
+import sys
+import warnings
+
+import omegaconf
+import pytest
+from omegaconf import DictConfig
+from omegaconf import OmegaConf as om
+
+# Add repo root to path so we can import scripts and test it
+repo_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.append(repo_dir)
+
+from scripts.eval.eval import main  # noqa: E402
+
+
+class TestEvalYAMLInputs:
+    """Validate and tests error handling for the input YAML file."""
+
+    @pytest.fixture
+    def cfg(self) -> DictConfig:
+        """Create YAML cfg fixture for testing purposes."""
+        conf_path: str = os.path.join(
+            repo_dir, 'scripts/eval/yamls/hf_eval.yaml')
+        with open(conf_path, 'r', encoding='utf-8') as config:
+            test_cfg = om.load(config)
+        assert isinstance(test_cfg, DictConfig)
+        return test_cfg
+
+    def test_mispelled_mandatory_params_fail(self, cfg: DictConfig) -> None:
+        """Check that mandatory mispelled inputs fail to train."""
+        mandatory_params = [
+            'max_seq_len',
+            'device_eval_batch_size',
+            'precision', 
+            'model_configs',
+        ]
+        mandatory_configs = ['models', 'icl_tasks']
+        for p in mandatory_params + mandatory_configs:
+            with pytest.raises((omegaconf.errors.ConfigKeyError, omegaconf.errors.InterpolationKeyError)):
+                cfg[p + "-mispelled"] = cfg.pop(p)
+                main(cfg)
+                cfg[p] = cfg.pop(p + "-mispelled")
+
+
+    def test_optional_mispelled_params_raise_warning(self,
+                                                     cfg: DictConfig) -> None:
+        """Check that warnings are raised for optional mispelled parameters."""
+        optional_params = [
+            'seed',
+            'dist_timeout',
+            'run_name',
+            'num_retries',
+            'loggers',
+            'model_gauntlet', 
+            'fsdp_config',
+        ]
+        old_cfg = copy.deepcopy(cfg)
+        for param in optional_params:
+            orig_value = cfg.pop(param, None)
+            updated_param = param + '-mispelling'
+            cfg[updated_param] = orig_value
+            with warnings.catch_warnings(record=True) as warning_list:
+                try:
+                    main(cfg)
+                except:
+                    pass
+                assert any(f'Unused parameter {updated_param} found in cfg.' in
+                           str(warning.message) for warning in warning_list)
+            # restore configs.
+            cfg = copy.deepcopy(old_cfg)


### PR DESCRIPTION
## Description
This PR enables us to sanity check our eval yaml configuration files before we run the full eval pipeline. This enables us to catch errors in the YAML config prior to an eval run starting. If a yaml config is improperly formatted with extraneous or missing values, a runtime error will be thrown. 

## Unit Test:
Added unit tests to make sure we raise `omegaconf.errors` and/or warn users if the yaml is incorrectly formatted. Warnings are used if the parameter has an optional default value. 

## Integration Test:
**Test 1**: Model reaches 0.56 COPA accuracy before and after refactor (1 GPU) 
``` python 
  composer eval/eval.py \
  eval/yamls/hf_eval.yaml \
  icl_tasks=eval/yamls/copa.yaml \
  model_name_or_path=mpt-125m-hf
```

**Test 2**: Model gauntlet runs: `mcli run -f mcli/mcli-hf-eval.yaml --follow`

Main branch: `mcli logs -f all-eval-main-nphii5`
```
Ran mosaicml/mpt-7b-instruct eval in: 5852.91842341423 seconds
Printing gauntlet results for all models
| model_name               |   average |   world_knowledge |   commonsense_reasoning |   language_understanding |   symbolic_problem_solving |   reading_comprehension |
|:-------------------------|----------:|------------------:|------------------------:|-------------------------:|---------------------------:|------------------------:|
| mosaicml/mpt-7b-instruct |  0.354255 |          0.398764 |                0.415097 |                 0.371509 |                   0.171216 |                0.414691 |
Printing complete results for all models
| Category                 | Benchmark
```

chuck/add_yaml_check_eval branch: `mcli logs -f all-eval-chuck-branch-UqSCPR`
```
Ran mosaicml/mpt-7b-instruct eval in: 5858.392446279526 seconds
Printing gauntlet results for all models
| model_name               |   average |   world_knowledge |   commonsense_reasoning |   language_understanding |   symbolic_problem_solving |   reading_comprehension |
|:-------------------------|----------:|------------------:|------------------------:|-------------------------:|---------------------------:|------------------------:|
| mosaicml/mpt-7b-instruct |  0.354255 |          0.398764 |                0.415097 |                 0.371509 |                   0.171216 |                0.414691 |
Printing complete results for all models
| Category                 | Benchmark
```

## Issues Addressed
This PR chips away at this tech debt [issue](https://mosaicml.atlassian.net/browse/RESEARCH-717).
