### PR TITLE
Update max duration due to mcli api change

### DIFF
--- a/.github/mcp/mcp_pytest.py
+++ b/.github/mcp/mcp_pytest.py
@@ -109,7 +109,7 @@ if __name__ == '__main__':
         image=args.image,
         integrations=[git_integration],
         command=command,
-        scheduling={'max_duration_seconds:': args.timeout},
+        scheduling={'max_duration:': args.timeout / 60 / 60},
     )
 
     # Create run


### PR DESCRIPTION
Update max duration due to mcli api change in pytest. API now accepts hours instead of seconds