### PR TITLE
Refactor build optimizer and peft models to use kwargs syntax

### DIFF
--- a/llmfoundry/utils/builders.py
+++ b/llmfoundry/utils/builders.py
@@ -106,17 +106,15 @@ def build_optimizer(model: torch.nn.Module,
         raise ValueError(f'Not sure how to build optimizer: {name}')
 
 
-def build_scheduler(cfg: DictConfig):
-    if cfg.name == 'constant_with_warmup':
-        return ConstantWithWarmupScheduler(t_warmup=cfg.t_warmup)
-    elif cfg.name == 'cosine_with_warmup':
-        return CosineAnnealingWithWarmupScheduler(t_warmup=cfg.t_warmup,
-                                                  alpha_f=cfg.alpha_f)
-    elif cfg.name == 'linear_decay_with_warmup':
-        return LinearWithWarmupScheduler(t_warmup=cfg.t_warmup,
-                                         alpha_f=cfg.alpha_f)
+def build_scheduler(name: str, scheduler_config: Dict[str, Any]):
+    if name == 'constant_with_warmup':
+        return ConstantWithWarmupScheduler(**scheduler_config)
+    elif name == 'cosine_with_warmup':
+        return CosineAnnealingWithWarmupScheduler(**scheduler_config)
+    elif name == 'linear_decay_with_warmup':
+        return LinearWithWarmupScheduler(**scheduler_config)
     else:
-        raise ValueError(f'Not sure how to build scheduler: {cfg.name}')
+        raise ValueError(f'Not sure how to build scheduler: {name}')
 
 
 def build_tokenizer(om_tokenizer_config: DictConfig) -> PreTrainedTokenizerBase:

--- a/llmfoundry/utils/builders.py
+++ b/llmfoundry/utils/builders.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Union
 
 import torch
 from composer import algorithms
@@ -88,18 +88,14 @@ def build_algorithm(name: str, kwargs: Dict[str, Any]):
         raise ValueError(f'Not sure how to build algorithm: {name}')
 
 
-def build_optimizer(model: torch.nn.Module, 
-                    name: str,
+def build_optimizer(model: torch.nn.Module, name: str,
                     optimizer_config: Dict[str, Any]):
     if name == 'decoupled_adamw':
-        return DecoupledAdamW(model.parameters(),
-                              **optimizer_config)
+        return DecoupledAdamW(model.parameters(), **optimizer_config)
     elif name == 'decoupled_lionw':
-        return DecoupledLionW(model.parameters(),
-                               **optimizer_config)
+        return DecoupledLionW(model.parameters(), **optimizer_config)
     elif name == 'clip_lion':
-        return DecoupledClipLion(model.parameters(),
-                                  **optimizer_config)
+        return DecoupledClipLion(model.parameters(), **optimizer_config)
     elif name == 'adalr_lion':
         return DecoupledAdaLRLion(model.parameters(), **optimizer_config)
     else:

--- a/llmfoundry/utils/builders.py
+++ b/llmfoundry/utils/builders.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional, Tuple, Union
 
 import torch
 from composer import algorithms
@@ -88,35 +88,22 @@ def build_algorithm(name: str, kwargs: Dict[str, Any]):
         raise ValueError(f'Not sure how to build algorithm: {name}')
 
 
-def build_optimizer(cfg: DictConfig, model: torch.nn.Module):
-    if cfg.name == 'decoupled_adamw':
+def build_optimizer(model: torch.nn.Module, 
+                    name: str,
+                    optimizer_config: Dict[str, Any]):
+    if name == 'decoupled_adamw':
         return DecoupledAdamW(model.parameters(),
-                              lr=cfg.lr,
-                              betas=cfg.betas,
-                              eps=cfg.eps,
-                              weight_decay=cfg.weight_decay)
-    elif cfg.name == 'decoupled_lionw':
+                              **optimizer_config)
+    elif name == 'decoupled_lionw':
         return DecoupledLionW(model.parameters(),
-                              lr=cfg.lr,
-                              betas=cfg.betas,
-                              weight_decay=cfg.weight_decay)
-    elif cfg.name == 'clip_lion':
+                               **optimizer_config)
+    elif name == 'clip_lion':
         return DecoupledClipLion(model.parameters(),
-                                 lr=cfg.lr,
-                                 betas=cfg.betas,
-                                 weight_decay=cfg.weight_decay,
-                                 outlier_threshold=cfg.outlier_threshold)
-    elif cfg.name == 'adalr_lion':
-        return DecoupledAdaLRLion(model.parameters(),
-                                  lr=cfg.lr,
-                                  betas=cfg.betas,
-                                  weight_decay=cfg.weight_decay,
-                                  outlier_threshold=cfg.outlier_threshold,
-                                  timeout=cfg.timeout,
-                                  lr_penalty=cfg.lr_penalty,
-                                  min_scale=cfg.min_scale)
+                                  **optimizer_config)
+    elif name == 'adalr_lion':
+        return DecoupledAdaLRLion(model.parameters(), **optimizer_config)
     else:
-        raise ValueError(f'Not sure how to build optimizer: {cfg.name}')
+        raise ValueError(f'Not sure how to build optimizer: {name}')
 
 
 def build_scheduler(cfg: DictConfig):

--- a/llmfoundry/utils/config_utils.py
+++ b/llmfoundry/utils/config_utils.py
@@ -29,7 +29,7 @@ def pop_config(cfg: DictConfig,
         if not isinstance(value, DictConfig) and not isinstance(
                 value, ListConfig):
             raise ValueError(
-                'The key: {key} has a value: {value} that cannot be \
+                f'The key: {key} has a value: {value} that cannot be \
                             converted to a dict or list. Please check your yaml.'
             )
         return om.to_container(value)

--- a/llmfoundry/utils/config_utils.py
+++ b/llmfoundry/utils/config_utils.py
@@ -26,9 +26,11 @@ def pop_config(cfg: DictConfig,
     """
     value = cfg.pop(key, None)
     if value is not None and convert:
-        assert isinstance(value, DictConfig) or isinstance(value, ListConfig)
+        if not isinstance(value, DictConfig) and not isinstance(value, ListConfig): 
+            raise ValueError("The key: {key} has a value: {value} that cannot be \
+                            converted to a dict or list. Please check your yaml.")
         return om.to_container(value)
-    elif value is not None and not convert:
+    elif value is not None:
         return value
     elif must_exist:
         raise NameError(

--- a/llmfoundry/utils/config_utils.py
+++ b/llmfoundry/utils/config_utils.py
@@ -16,7 +16,7 @@ from llmfoundry.models.utils import init_empty_weights
 def pop_config(cfg: DictConfig,
                key: str,
                must_exist: bool = True,
-               default_value: Any = None, 
+               default_value: Any = None,
                convert: bool = False) -> Any:
     """Pop a value from the main config file and return it.
 

--- a/llmfoundry/utils/config_utils.py
+++ b/llmfoundry/utils/config_utils.py
@@ -26,9 +26,12 @@ def pop_config(cfg: DictConfig,
     """
     value = cfg.pop(key, None)
     if value is not None and convert:
-        if not isinstance(value, DictConfig) and not isinstance(value, ListConfig): 
-            raise ValueError("The key: {key} has a value: {value} that cannot be \
-                            converted to a dict or list. Please check your yaml.")
+        if not isinstance(value, DictConfig) and not isinstance(
+                value, ListConfig):
+            raise ValueError(
+                'The key: {key} has a value: {value} that cannot be \
+                            converted to a dict or list. Please check your yaml.'
+            )
         return om.to_container(value)
     elif value is not None:
         return value

--- a/llmfoundry/utils/config_utils.py
+++ b/llmfoundry/utils/config_utils.py
@@ -12,6 +12,7 @@ from omegaconf import OmegaConf as om
 
 from llmfoundry.models.utils import init_empty_weights
 
+
 def pop_config(cfg: DictConfig,
                key: str,
                must_exist: bool = True,

--- a/llmfoundry/utils/config_utils.py
+++ b/llmfoundry/utils/config_utils.py
@@ -7,7 +7,7 @@ import warnings
 from typing import Any, Dict, Optional, Union
 
 from composer.utils import dist
-from omegaconf import DictConfig
+from omegaconf import DictConfig, ListConfig
 from omegaconf import OmegaConf as om
 
 from llmfoundry.models.utils import init_empty_weights
@@ -16,14 +16,19 @@ from llmfoundry.models.utils import init_empty_weights
 def pop_config(cfg: DictConfig,
                key: str,
                must_exist: bool = True,
-               default_value: Any = None) -> Any:
+               default_value: Any = None, 
+               convert: bool = False) -> Any:
     """Pop a value from the main config file and return it.
 
     If the key does not exist, return the default_value or raise a RuntimeError
-    depending on the must_exist flag.
+    depending on the must_exist flag. If the convert flag is set to True, then
+    we will convert the value to a python object using OmegaConf.to_container.
     """
     value = cfg.pop(key, None)
-    if value is not None:
+    if value is not None and convert:
+        assert isinstance(value, DictConfig) or isinstance(value, ListConfig)
+        return om.to_container(value)
+    elif value is not None and not convert:
         return value
     elif must_exist:
         raise NameError(

--- a/llmfoundry/utils/config_utils.py
+++ b/llmfoundry/utils/config_utils.py
@@ -26,7 +26,7 @@ def pop_config(cfg: DictConfig,
     if value is not None:
         return value
     elif must_exist:
-        raise RuntimeError(
+        raise NameError(
             f'The {key} parameter is missing and must exist for execution. Please check your yaml.'
         )
     else:
@@ -112,8 +112,8 @@ def process_init_device(model_cfg: DictConfig, fsdp_config: Optional[Dict]):
 def log_config(cfg: DictConfig):
     """Logs the current config and updates the wandb and mlflow configs.
 
-    This function can be called multiple times to update the wandb config with
-    different variables.
+    This function can be called multiple times to update the wandb and MLflow
+    config with different variables.
     """
     print(om.to_yaml(cfg))
     if 'wandb' in cfg.get('loggers', {}):

--- a/llmfoundry/utils/config_utils.py
+++ b/llmfoundry/utils/config_utils.py
@@ -90,6 +90,11 @@ def process_init_device(model_cfg: DictConfig, fsdp_config: Optional[Dict]):
 
 
 def log_config(cfg: DictConfig):
+    """Logs the current config and updates the wandb config if available.
+
+    This function can be called multiple times to update the wandb config with
+    different variables.
+    """
     print(om.to_yaml(cfg))
     if 'wandb' in cfg.get('loggers', {}):
         try:

--- a/llmfoundry/utils/config_utils.py
+++ b/llmfoundry/utils/config_utils.py
@@ -4,13 +4,32 @@
 import contextlib
 import math
 import warnings
-from typing import Dict, Optional, Union
+from typing import Any, Dict, Optional, Union
 
 from composer.utils import dist
 from omegaconf import DictConfig
 from omegaconf import OmegaConf as om
 
 from llmfoundry.models.utils import init_empty_weights
+
+def pop_config(cfg: DictConfig,
+               key: str,
+               must_exist: bool = True,
+               default_value: Any = None) -> Any:
+    """Pop a value from the main config file and return it.
+
+    If the key does not exist, return the default_value or raise a RuntimeError
+    depending on the must_exist flag.
+    """
+    value = cfg.pop(key, None)
+    if value is not None:
+        return value
+    elif must_exist:
+        raise RuntimeError(
+            f'The {key} parameter is missing and must exist for execution. Please check your yaml.'
+        )
+    else:
+        return default_value
 
 
 def calculate_batch_size_info(global_batch_size: int,
@@ -90,7 +109,7 @@ def process_init_device(model_cfg: DictConfig, fsdp_config: Optional[Dict]):
 
 
 def log_config(cfg: DictConfig):
-    """Logs the current config and updates the wandb config if available.
+    """Logs the current config and updates the wandb and mlflow configs.
 
     This function can be called multiple times to update the wandb config with
     different variables.

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -184,11 +184,11 @@ def main(cfg: DictConfig):
     om.resolve(cfg)
 
     # Set seed first
-    seed: int = cfg.pop('seed')
+    seed: int = pop_config(cfg, 'seed', must_exist=True)
     reproducibility.seed_all(seed)
 
     # Initialize distributed setting with seed
-    dist_timeout: Union[int, float] = cfg.pop('dist_timeout', 600.0)
+    dist_timeout: Union[int, float] = pop_config(cfg, 'dist_timeout', must_exist=False, default_value=600.0)
     dist.initialize_dist(get_device(None), timeout=dist_timeout)
 
     # Get global and device batch size information from distributed/single node setting
@@ -279,12 +279,12 @@ def main(cfg: DictConfig):
     autoresume = pop_config(cfg,'autoresume', must_exist=False, default_value=autoresume_default)
 
     # Pop known unused parameters.
-    cfg.pop('data_local', None)
-    cfg.pop('data_remote', None)
-    cfg.pop('global_seed')
-    cfg.pop('global_train_batch_size')
-    cfg.pop('n_gpus')
-    cfg.pop('device_train_grad_accum')
+    pop_config(cfg, 'data_local', must_exist=False)
+    pop_config(cfg, 'data_remote', must_exist=False)
+    pop_config(cfg, 'global_seed', must_exist=False)
+    pop_config(cfg, 'global_train_batch_size', must_exist=False)
+    pop_config(cfg, 'n_gpus', must_exist=False)
+    pop_config(cfg, 'device_train_grad_accum', must_exist=False)
 
     # Warn users for unused parameters
     for key in cfg:

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -104,8 +104,8 @@ def build_composer_model(model_cfg: DictConfig,
 
 
 def build_composer_peft_model(
-    pretrained_model_name_or_path: str, lora_args: Dict[str, Any],
-    tokenizer: PreTrainedTokenizerBase) -> ComposerHFCausalLM:
+        pretrained_model_name_or_path: str, lora_args: Dict[str, Any],
+        tokenizer: PreTrainedTokenizerBase) -> ComposerHFCausalLM:
     try:
         from peft import LoraConfig, get_peft_model
     except ImportError as e:
@@ -120,8 +120,8 @@ def build_composer_peft_model(
     lora_cfg = LoraConfig(**lora_args)
 
     print('Building model from HuggingFace checkpoint...')
-    model = MPTForCausalLM.from_pretrained(
-        pretrained_model_name_or_path, trust_remote_code=True)
+    model = MPTForCausalLM.from_pretrained(pretrained_model_name_or_path,
+                                           trust_remote_code=True)
     print('Model built!')
 
     print('Adding Lora modules...')
@@ -212,23 +212,29 @@ def main(cfg: DictConfig):
     # Mandatory model training configs
     model_config: DictConfig = pop_config(cfg, 'model', must_exist=True)
     tokenizer_config: DictConfig = pop_config(cfg, 'tokenizer', must_exist=True)
-    optimizer_config: Dict[str, Any] = pop_config(cfg, 'optimizer', must_exist=True, convert=True)
-    scheduler_config: Dict[str, Any] = pop_config(cfg, 'scheduler', must_exist=True, convert=True)
+    optimizer_config: Dict[str, Any] = pop_config(cfg,
+                                                  'optimizer',
+                                                  must_exist=True,
+                                                  convert=True)
+    scheduler_config: Dict[str, Any] = pop_config(cfg,
+                                                  'scheduler',
+                                                  must_exist=True,
+                                                  convert=True)
     train_loader_config: DictConfig = pop_config(cfg,
                                                  'train_loader',
                                                  must_exist=True)
 
     # Optional fsdp data, fine-tuning, and eval configs
     fsdp_config: Optional[Dict] = pop_config(cfg,
-                                                'fsdp_config',
-                                                must_exist=False,
-                                                default_value=None, 
-                                                convert=True)
+                                             'fsdp_config',
+                                             must_exist=False,
+                                             default_value=None,
+                                             convert=True)
     lora_config: Optional[Dict[str, Any]] = pop_config(cfg,
-                                            'lora',
-                                            must_exist=False,
-                                            default_value=None,
-                                            convert=True)
+                                                       'lora',
+                                                       must_exist=False,
+                                                       default_value=None,
+                                                       convert=True)
     eval_loader_config: Optional[DictConfig] = pop_config(cfg,
                                                           'eval_loader',
                                                           must_exist=False,
@@ -389,7 +395,8 @@ def main(cfg: DictConfig):
     with init_context:
         if lora_config is not None:  # frozen model + trainable lora modules
             model: ComposerHFCausalLM = build_composer_peft_model(
-                model_config.pretrained_model_name_or_path, lora_config['args'], tokenizer)
+                model_config.pretrained_model_name_or_path, lora_config['args'],
+                tokenizer)
             print_trainable_parameters(model)  # should not be 100%
         else:  # standard model
             model = build_composer_model(model_config, tokenizer)

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -300,7 +300,8 @@ def main(cfg: DictConfig):
 
     # Initialize context
     init_context = process_init_device(model_config, fsdp_config)
-    log_config(om.create(fsdp_config))
+    if fsdp_config:
+        log_config(om.create(fsdp_config))
 
     # Build tokenizer
     tokenizer = build_tokenizer(tokenizer_config)

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -398,6 +398,32 @@ def main(cfg: DictConfig):
     n_params = sum(p.numel() for p in model.parameters())
     logged_cfg.update({'n_params': n_params})
 
+
+    # Optimizer
+    optimizer_name: str = optimizer_config.pop('name')
+    optimizer = build_optimizer(model, optimizer_name, optimizer_config)
+
+    # Scheduler
+    scheduler = build_scheduler(scheduler_config)
+
+    # Loggers
+    loggers = [
+        build_logger(str(name), logger_cfg)
+        for name, logger_cfg in logger_configs.items()
+    ] if logger_configs else None
+
+    # Callbacks
+    callbacks = [
+        build_callback(str(name), callback_cfg)
+        for name, callback_cfg in callback_configs.items()
+    ] if callback_configs else None
+
+    # Algorithms
+    algorithms = [
+        build_algorithm(str(name), algorithm_cfg)
+        for name, algorithm_cfg in algorithm_configs.items()
+    ] if algorithm_configs else None
+
     # Dataloaders
     print('Building train loader...')
     train_loader = build_dataloader(
@@ -424,31 +450,6 @@ def main(cfg: DictConfig):
                                                  max_seq_len,
                                                  device_eval_batch_size)
         evaluators.extend(icl_evaluators)
-
-    # Optimizer
-    optimizer_name: str = optimizer_config.pop('name')
-    optimizer = build_optimizer(model, optimizer_name, optimizer_config)
-
-    # Scheduler
-    scheduler = build_scheduler(scheduler_config)
-
-    # Loggers
-    loggers = [
-        build_logger(str(name), logger_cfg)
-        for name, logger_cfg in logger_configs.items()
-    ] if logger_configs else None
-
-    # Callbacks
-    callbacks = [
-        build_callback(str(name), callback_cfg)
-        for name, callback_cfg in callback_configs.items()
-    ] if callback_configs else None
-
-    # Algorithms
-    algorithms = [
-        build_algorithm(str(name), algorithm_cfg)
-        for name, algorithm_cfg in algorithm_configs.items()
-    ] if algorithm_configs else None
 
     # Build the Trainer
     print('Building trainer...')

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -213,7 +213,7 @@ def main(cfg: DictConfig):
     model_config: DictConfig = pop_config(cfg, 'model', must_exist=True)
     tokenizer_config: DictConfig = pop_config(cfg, 'tokenizer', must_exist=True)
     optimizer_config: Dict[str, Any] = pop_config(cfg, 'optimizer', must_exist=True, convert=True)
-    scheduler_config: DictConfig = pop_config(cfg, 'scheduler', must_exist=True)
+    scheduler_config: Dict[str, Any] = pop_config(cfg, 'scheduler', must_exist=True, convert=True)
     train_loader_config: DictConfig = pop_config(cfg,
                                                  'train_loader',
                                                  must_exist=True)
@@ -398,13 +398,13 @@ def main(cfg: DictConfig):
     n_params = sum(p.numel() for p in model.parameters())
     logged_cfg.update({'n_params': n_params})
 
-
     # Optimizer
     optimizer_name: str = optimizer_config.pop('name')
     optimizer = build_optimizer(model, optimizer_name, optimizer_config)
 
     # Scheduler
-    scheduler = build_scheduler(scheduler_config)
+    scheduler_name: str = scheduler_config.pop('name')
+    scheduler = build_scheduler(scheduler_name, scheduler_config)
 
     # Loggers
     loggers = [

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -225,11 +225,11 @@ def main(cfg: DictConfig):
                                                  must_exist=True)
 
     # Optional fsdp data, fine-tuning, and eval configs
-    fsdp_config: Optional[Dict] = pop_config(cfg,
-                                             'fsdp_config',
-                                             must_exist=False,
-                                             default_value=None,
-                                             convert=True)
+    fsdp_config: Optional[Dict[str, Any]] = pop_config(cfg,
+                                                       'fsdp_config',
+                                                       must_exist=False,
+                                                       default_value=None,
+                                                       convert=True)
     lora_config: Optional[Dict[str, Any]] = pop_config(cfg,
                                                        'lora',
                                                        must_exist=False,

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -189,7 +189,7 @@ def main(cfg: DictConfig):
     logged_cfg: DictConfig = copy.deepcopy(cfg)
 
     # Get max split size mb
-    max_split_size_mb: int = cfg.pop('max_split_size_mb', None)
+    max_split_size_mb: Optional[int] = cfg.pop('max_split_size_mb', None)
     if max_split_size_mb is not None:
         os.environ[
             'PYTORCH_CUDA_ALLOC_CONF'] = f'max_split_size_mb:{max_split_size_mb}'

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -178,10 +178,10 @@ def main(cfg: DictConfig):
         message=
         'torch.distributed.*_base is a private function and will be deprecated.*'
     )
-    
+
     # Check for incompatibilities between the model and data loaders
     validate_config(cfg)
-    
+
     # Resolve all interpolation variables as early as possible
     om.resolve(cfg)
 
@@ -189,7 +189,7 @@ def main(cfg: DictConfig):
     logged_cfg: DictConfig = copy.deepcopy(cfg)
 
     # Get max split size mb
-    max_split_size_mb: int  = cfg.pop('max_split_size_mb', None)
+    max_split_size_mb: int = cfg.pop('max_split_size_mb', None)
     if max_split_size_mb is not None:
         os.environ[
             'PYTORCH_CUDA_ALLOC_CONF'] = f'max_split_size_mb:{max_split_size_mb}'
@@ -204,7 +204,7 @@ def main(cfg: DictConfig):
                                                  must_exist=False,
                                                  default_value=600.0)
     dist.initialize_dist(get_device(None), timeout=dist_timeout)
-    
+
     # Get global and device batch size information from distributed/single node setting
     cfg = update_batch_size_info(cfg)
     logged_cfg.update(cfg, merge=True)

--- a/tests/test_train_inputs.py
+++ b/tests/test_train_inputs.py
@@ -98,3 +98,14 @@ class TestTrainingYAMLInputs:
         with pytest.raises(ValueError) as exception_info:
             main(cfg)
         assert str(exception_info.value) == "Not sure how to build optimizer: invalid-optimizer"
+
+    def test_extra_params_in_scheduler_cfg_errors(self, cfg: DictConfig) -> None:
+        cfg.scheduler.t_warmup_extra = 'extra-parameter'
+        with pytest.raises(TypeError):
+            main(cfg)
+    
+    def test_invalid_name_in_scheduler_cfg_errors(self, cfg: DictConfig) -> None:
+        cfg.scheduler.name = 'invalid-scheduler'
+        with pytest.raises(ValueError) as exception_info:
+            main(cfg)
+        assert str(exception_info.value) == "Not sure how to build scheduler: invalid-scheduler"

--- a/tests/test_train_inputs.py
+++ b/tests/test_train_inputs.py
@@ -88,24 +88,30 @@ class TestTrainingYAMLInputs:
             # restore configs.
             cfg = copy.deepcopy(old_cfg)
 
-    def test_extra_params_in_optimizer_cfg_errors(self, cfg: DictConfig) -> None:
+    def test_extra_params_in_optimizer_cfg_errors(self,
+                                                  cfg: DictConfig) -> None:
         cfg.optimizer.beta2 = 'extra-parameter'
         with pytest.raises(TypeError):
             main(cfg)
 
-    def test_invalid_name_in_optimizer_cfg_errors(self, cfg: DictConfig) -> None:
+    def test_invalid_name_in_optimizer_cfg_errors(self,
+                                                  cfg: DictConfig) -> None:
         cfg.optimizer.name = 'invalid-optimizer'
         with pytest.raises(ValueError) as exception_info:
             main(cfg)
-        assert str(exception_info.value) == "Not sure how to build optimizer: invalid-optimizer"
+        assert str(exception_info.value
+                  ) == 'Not sure how to build optimizer: invalid-optimizer'
 
-    def test_extra_params_in_scheduler_cfg_errors(self, cfg: DictConfig) -> None:
+    def test_extra_params_in_scheduler_cfg_errors(self,
+                                                  cfg: DictConfig) -> None:
         cfg.scheduler.t_warmup_extra = 'extra-parameter'
         with pytest.raises(TypeError):
             main(cfg)
-    
-    def test_invalid_name_in_scheduler_cfg_errors(self, cfg: DictConfig) -> None:
+
+    def test_invalid_name_in_scheduler_cfg_errors(self,
+                                                  cfg: DictConfig) -> None:
         cfg.scheduler.name = 'invalid-scheduler'
         with pytest.raises(ValueError) as exception_info:
             main(cfg)
-        assert str(exception_info.value) == "Not sure how to build scheduler: invalid-scheduler"
+        assert str(exception_info.value
+                  ) == 'Not sure how to build scheduler: invalid-scheduler'

--- a/tests/test_train_inputs.py
+++ b/tests/test_train_inputs.py
@@ -87,3 +87,14 @@ class TestTrainingYAMLInputs:
                            str(warning.message) for warning in warning_list)
             # restore configs.
             cfg = copy.deepcopy(old_cfg)
+
+    def test_extra_params_in_optimizer_cfg_errors(self, cfg: DictConfig) -> None:
+        cfg.optimizer.beta2 = 'extra-parameter'
+        with pytest.raises(TypeError):
+            main(cfg)
+
+    def test_invalid_name_in_optimizer_cfg_errors(self, cfg: DictConfig) -> None:
+        cfg.optimizer.name = 'invalid-optimizer'
+        with pytest.raises(ValueError) as exception_info:
+            main(cfg)
+        assert str(exception_info.value) == "Not sure how to build optimizer: invalid-optimizer"

--- a/tests/test_train_inputs.py
+++ b/tests/test_train_inputs.py
@@ -52,7 +52,7 @@ class TestTrainingYAMLInputs:
         for param in mandatory_params:
             orig_param = cfg.pop(param)
             with pytest.raises(
-                (omegaconf.errors.ConfigAttributeError, RuntimeError)):
+                (omegaconf.errors.ConfigAttributeError, NameError)):
                 main(cfg)
             cfg[param] = orig_param
 

--- a/tests/test_yaml_inputs.py
+++ b/tests/test_yaml_inputs.py
@@ -19,11 +19,11 @@ from scripts.train.train import main  # noqa: E402
 
 class TestTrainingInputs:
     """
-    This class contains unit tests for validating the input YAML files used for training.
+    This class validates and tests error handling for the input YAML files used for training.
     """
     @pytest.fixture
     def cfg(self) -> DictConfig:
-        """This fixture will only be available within the scope of TestTrainingInputs"""
+        """Create YAML cfg fixture for testing purposes."""
         conf_path: str = os.path.join(repo_dir,
                                   'scripts/train/yamls/pretrain/mpt-125m.yaml')
         with open(conf_path, 'r', encoding='utf-8') as config:
@@ -57,7 +57,7 @@ class TestTrainingInputs:
 
     def test_optional_mispelled_params_raise_warning(self, cfg: DictConfig) -> None: 
         """
-        Check that a mispellings warnings are raised for optional parameters.
+        Check that warnings are raised for optional parameters that are mispelled.
         """
         optional_params = [
             'save_weights_only',
@@ -80,11 +80,10 @@ class TestTrainingInputs:
             updated_param = param + '-mispelling'
             cfg[updated_param] = orig_value
             with warnings.catch_warnings(record=True) as warning_list:
-                # ideally we should be able to run without try catch but there is no lightweight training run just yet. 
                 try:
                     main(cfg)
                 except:
                     pass
                 assert any(f"Unused parameter {updated_param} found in cfg." in str(warning.message) for warning in warning_list)
-            # restore param
+            # restore configs.
             cfg = copy.deepcopy(old_cfg)

--- a/tests/test_yaml_inputs.py
+++ b/tests/test_yaml_inputs.py
@@ -1,0 +1,90 @@
+# Copyright 2022 MosaicML LLM Foundry authors
+# SPDX-License-Identifier: Apache-2.0
+import copy
+import os
+import sys
+import pytest 
+import omegaconf
+import warnings 
+
+from omegaconf import DictConfig
+from omegaconf import OmegaConf as om
+
+# Add repo root to path so we can import scripts and test it
+repo_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.append(repo_dir)
+
+from scripts.train.train import main  # noqa: E402
+
+
+class TestTrainingInputs:
+    """
+    This class contains unit tests for validating the input YAML files used for training.
+    """
+    @pytest.fixture
+    def cfg(self) -> DictConfig:
+        """This fixture will only be available within the scope of TestTrainingInputs"""
+        conf_path: str = os.path.join(repo_dir,
+                                  'scripts/train/yamls/pretrain/mpt-125m.yaml')
+        with open(conf_path, 'r', encoding='utf-8') as config:
+            test_cfg = om.load(config)
+        assert isinstance(test_cfg, DictConfig)
+        return test_cfg
+
+
+    def test_mispelled_mandatory_params_fail(self, cfg: DictConfig) -> None:
+        """ Check that mandatory mispelled inputs fail to train. """
+        cfg.trai_loader = cfg.pop('train_loader')
+        with pytest.raises(omegaconf.errors.ConfigAttributeError):
+            main(cfg)
+
+
+    def test_missing_mandatory_parameters_fail(self, cfg: DictConfig) -> None:
+        """
+        Check that missing mandatory parameters fail to train. 
+        """
+        mandatory_params = ['train_loader', 'model',  'tokenizer', 'optimizer', 'scheduler', 'max_duration',
+            'eval_interval',
+            'precision',
+            'max_seq_len',
+        ] 
+        for param in mandatory_params:
+            orig_param = cfg.pop(param)
+            with pytest.raises((omegaconf.errors.ConfigAttributeError, RuntimeError)):
+                main(cfg)
+            cfg[param] = orig_param
+
+
+    def test_optional_mispelled_params_raise_warning(self, cfg: DictConfig) -> None: 
+        """
+        Check that a mispellings warnings are raised for optional parameters.
+        """
+        optional_params = [
+            'save_weights_only',
+            'save_filename',
+            'run_name'
+            'progress_bar',
+            'python_log_level',
+            'eval_first',
+            'autoresume', 
+            'fsdp_dict_config', 
+            'fsdp_config', 
+            'lora_config', 
+            'eval_loader_config',
+            'icl_tasks_config',
+            'save_folder', 
+        ] 
+        old_cfg = copy.deepcopy(cfg)
+        for param in optional_params:
+            orig_value = cfg.pop(param, None)
+            updated_param = param + '-mispelling'
+            cfg[updated_param] = orig_value
+            with warnings.catch_warnings(record=True) as warning_list:
+                # ideally we should be able to run without try catch but there is no lightweight training run just yet. 
+                try:
+                    main(cfg)
+                except:
+                    pass
+                assert any(f"Unused parameter {updated_param} found in cfg." in str(warning.message) for warning in warning_list)
+            # restore param
+            cfg = copy.deepcopy(old_cfg)

--- a/tests/test_yaml_inputs.py
+++ b/tests/test_yaml_inputs.py
@@ -17,7 +17,7 @@ sys.path.append(repo_dir)
 from scripts.train.train import main  # noqa: E402
 
 
-class TestTrainingInputs:
+class TestTrainingYAMLInputs:
     """
     This class validates and tests error handling for the input YAML files used for training.
     """

--- a/tests/test_yaml_inputs.py
+++ b/tests/test_yaml_inputs.py
@@ -3,10 +3,10 @@
 import copy
 import os
 import sys
-import pytest 
-import omegaconf
-import warnings 
+import warnings
 
+import omegaconf
+import pytest
 from omegaconf import DictConfig
 from omegaconf import OmegaConf as om
 
@@ -18,62 +18,61 @@ from scripts.train.train import main  # noqa: E402
 
 
 class TestTrainingYAMLInputs:
-    """
-    This class validates and tests error handling for the input YAML files used for training.
-    """
+    """Validate and tests error handling for the input YAML file."""
+
     @pytest.fixture
     def cfg(self) -> DictConfig:
         """Create YAML cfg fixture for testing purposes."""
-        conf_path: str = os.path.join(repo_dir,
-                                  'scripts/train/yamls/pretrain/mpt-125m.yaml')
+        conf_path: str = os.path.join(
+            repo_dir, 'scripts/train/yamls/pretrain/mpt-125m.yaml')
         with open(conf_path, 'r', encoding='utf-8') as config:
             test_cfg = om.load(config)
         assert isinstance(test_cfg, DictConfig)
         return test_cfg
 
-
     def test_mispelled_mandatory_params_fail(self, cfg: DictConfig) -> None:
-        """ Check that mandatory mispelled inputs fail to train. """
+        """Check that mandatory mispelled inputs fail to train."""
         cfg.trai_loader = cfg.pop('train_loader')
         with pytest.raises(omegaconf.errors.ConfigAttributeError):
             main(cfg)
 
-
     def test_missing_mandatory_parameters_fail(self, cfg: DictConfig) -> None:
-        """
-        Check that missing mandatory parameters fail to train. 
-        """
-        mandatory_params = ['train_loader', 'model',  'tokenizer', 'optimizer', 'scheduler', 'max_duration',
+        """Check that missing mandatory parameters fail to train."""
+        mandatory_params = [
+            'train_loader',
+            'model',
+            'tokenizer',
+            'optimizer',
+            'scheduler',
+            'max_duration',
             'eval_interval',
             'precision',
             'max_seq_len',
-        ] 
+        ]
         for param in mandatory_params:
             orig_param = cfg.pop(param)
-            with pytest.raises((omegaconf.errors.ConfigAttributeError, RuntimeError)):
+            with pytest.raises(
+                (omegaconf.errors.ConfigAttributeError, RuntimeError)):
                 main(cfg)
             cfg[param] = orig_param
 
-
-    def test_optional_mispelled_params_raise_warning(self, cfg: DictConfig) -> None: 
-        """
-        Check that warnings are raised for optional parameters that are mispelled.
-        """
+    def test_optional_mispelled_params_raise_warning(self,
+                                                     cfg: DictConfig) -> None:
+        """Check that warnings are raised for optional mispelled parameters."""
         optional_params = [
             'save_weights_only',
             'save_filename',
-            'run_name'
+            'run_name',
             'progress_bar',
             'python_log_level',
             'eval_first',
-            'autoresume', 
-            'fsdp_dict_config', 
-            'fsdp_config', 
-            'lora_config', 
+            'autoresume',
+            'save_folder',
+            'fsdp_config',
+            'lora_config',
             'eval_loader_config',
             'icl_tasks_config',
-            'save_folder', 
-        ] 
+        ]
         old_cfg = copy.deepcopy(cfg)
         for param in optional_params:
             orig_value = cfg.pop(param, None)
@@ -84,6 +83,7 @@ class TestTrainingYAMLInputs:
                     main(cfg)
                 except:
                     pass
-                assert any(f"Unused parameter {updated_param} found in cfg." in str(warning.message) for warning in warning_list)
+                assert any(f'Unused parameter {updated_param} found in cfg.' in
+                           str(warning.message) for warning in warning_list)
             # restore configs.
             cfg = copy.deepcopy(old_cfg)

--- a/tests/test_yaml_inputs.py
+++ b/tests/test_yaml_inputs.py
@@ -24,7 +24,7 @@ class TestTrainingYAMLInputs:
     def cfg(self) -> DictConfig:
         """Create YAML cfg fixture for testing purposes."""
         conf_path: str = os.path.join(
-            repo_dir, 'scripts/train/yamls/pretrain/mpt-125m.yaml')
+            repo_dir, 'scripts/train/yamls/pretrain/testing.yaml')
         with open(conf_path, 'r', encoding='utf-8') as config:
             test_cfg = om.load(config)
         assert isinstance(test_cfg, DictConfig)


### PR DESCRIPTION
Refactor build optimizer and peft models in `train/train.py` to use  `**kwargs` syntax so that config's are dictionaries, classes/functions have arguments explicitly stated in their signature, and `build_***` uses **kwargs for initializing classes. 

Changes:
- `build_optimizer`
- `build_scheduler`
- `build_composer_peft_model`

Additionally, moved `build_dataloader` right before `Trainer` is initialized to make it faster to catch non-data related issues in the yaml. 

## Unit Tests 
- Added unit tests for optimizer states and build_scheduler. 

## Integration Tests
- Trained PEFT model, got same fine tuning scores: 
<img width="1635" alt="Screenshot 2023-08-16 at 5 39 17 PM" src="https://github.com/mosaicml/llm-foundry/assets/13524881/57226d52-a35e-4229-8e01-4ff3e7d51d29">

- [Before change LORA run](https://wandb.ai/mosaic-ml/chuck-runs/runs/ckod4o5r/logs?workspace=user-chuck-tang98)
- [After change LORA run](https://wandb.ai/mosaic-ml/chuck-runs/runs/69aiy9uk?workspace=user-chuck-tang98)

## Issues Closed
Chipping away at tech [debt](https://id.atlassian.com/login/authorize?continue=https%3A%2F%2Fmosaicml.atlassian.net%2Fbrowse%2FRESEARCH-717&token=eyJraWQiOiJtaWNyb3Mvc2lnbi1pbi1zZXJ2aWNlL2FlN21rM2I2cGxzOWhtaDkiLCJhbGciOiJSUzI1NiJ9.eyJtYXJrZWRWZXJpZmllZCI6ImZhbHNlIiwibG9naW5UeXBlIjoic2Vzc2lvblJlZnJlc2giLCJpc3MiOiJtaWNyb3Mvc2lnbi1pbi1zZXJ2aWNlIiwidXNlcklkIjoiNzEyMDIwOjVkY2IyNmIzLWYzNjctNDc2Yy1hYTJlLTNjNzg3NDhiZjgyNiIsImlzU2xhY2tBcHBTb3VyY2UiOiJmYWxzZSIsImF1ZCI6Imxpbmstc2lnbmF0dXJlLXZhbGlkYXRvciIsIm5iZiI6MTY5MjEzNTk3MCwic2NvcGUiOiJMb2dpbiIsImV4cCI6MTY5MjEzNjA5MCwiaWF0IjoxNjkyMTM1OTcwLCJqdGkiOiJmNTA2MjY1My05YTZmLTRjNTQtOWViMC0yYjhiOWQ4MjQ2ODMiLCJoYXNoZWRDc3JmVG9rZW4iOiIxMDYzYTZkYjY2NTVmZDMyZGYwMjQ5N2FmZjllZWFmYmFhOTU5NzA4ZDA4ZjdmMzg4MDk4YjBjMGJlNWU3Yjg2In0.abK8iEzpDsAT9ca3zLtWLCgkEiYyz0Byng6_Zl68jhrMkR0_w-EXp8MEkWVrWXQWEdpNVRjyb9rxq32VN-STEdR3Y1wXYRI6-7z-V7Uwpk0ZxRNproba8kthUFtu22atf-II_P_zjvE4abkVaeENXCq3i9v5jX1MDgYlF_9t72BnQ_-rFpOYDGhme8NXu5w2Z2G_M3AhTzGSSxi52_0JcCAHwMN39RWQKQR3gsHPFDPC6MGdjnN_dnNB18iYNLzp2BGGBBobCPgruuvMsu9r2wDOC0W34pdFnBkXvTnoCtVp-3jIKPvVDphkuSYl28Y6-rvck86bq_Skwz76zg6DQg&state=eyJoYXNoZWRDc3JmVG9rZW4iOiJhNDAxMTdhYWZmMjkzOWNjNWI5YTE0ZDRjOTMyN2ZlYjAxNGUyNjg4ZWNhMTkzYzhhZDcyNzA5YzJlMWIzNTExIn0%3D)