### PR TITLE
Add init syntax for scripts directory

### DIFF
--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2022 MosaicML LLM Foundry authors
+# SPDX-License-Identifier: Apache-2.0
+

--- a/scripts/data_prep/__init__.py
+++ b/scripts/data_prep/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2022 MosaicML LLM Foundry authors
+# SPDX-License-Identifier: Apache-2.0
+

--- a/scripts/eval/__init__.py
+++ b/scripts/eval/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2022 MosaicML LLM Foundry authors
+# SPDX-License-Identifier: Apache-2.0
+

--- a/scripts/misc/__init__.py
+++ b/scripts/misc/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2022 MosaicML LLM Foundry authors
+# SPDX-License-Identifier: Apache-2.0
+

--- a/scripts/train/__init__.py
+++ b/scripts/train/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2022 MosaicML LLM Foundry authors
+# SPDX-License-Identifier: Apache-2.0
+


### PR DESCRIPTION
Add init syntax for scripts directory. 

@bmosaicml was running into issues importing the `scripts.data_prep.convert_dataset_hf` file in the `test_training.py` test but `import scripts` was working. This PR should fix these import errors. 

```
_______________________________ ERROR collecting tests/test_training.py ________________________________
ImportError while importing test module '/Users/jeremy.dohmann/LLMWork/llm-foundry/tests/test_training.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/test_training.py:17: in <module>
    from scripts.data_prep.convert_dataset_hf import main as main_hf  # noqa: E402
E   ModuleNotFoundError: No module named 'scripts.data_prep'
```