### PR TITLE
Add python log level in llm foundry eval script 

### DIFF
--- a/scripts/eval/eval.py
+++ b/scripts/eval/eval.py
@@ -97,9 +97,8 @@ def evaluate_model(model_cfg: DictConfig, dist_timeout: Union[float, int],
                    max_seq_len: int, device_eval_batch_size: int,
                    model_gauntlet_config: Optional[Union[str, DictConfig]],
                    fsdp_config: Optional[Dict], num_retries: int,
-                   loggers_cfg: Dict[str, Any], python_log_level: str, 
-                   precision: str, 
-                   model_gauntlet_df: Optional[pd.DataFrame]):
+                   loggers_cfg: Dict[str, Any], python_log_level: str,
+                   precision: str, model_gauntlet_df: Optional[pd.DataFrame]):
     print(f'Evaluating model: {model_cfg.model_name}', flush=True)
     # Build tokenizer and model
     tokenizer = build_tokenizer(model_cfg.tokenizer)
@@ -248,8 +247,8 @@ def main(cfg: DictConfig):
              loggers_cfg=loggers_cfg,
              python_log_level=python_log_level,
              precision=precision,
-             model_gauntlet_df=model_gauntlet_df, 
-        )
+             model_gauntlet_df=model_gauntlet_df,
+         )
 
         if model_gauntlet_callback is not None:
             # TODO(bmosaicml) This needs to be refactored to fix the typing issue

--- a/scripts/eval/eval.py
+++ b/scripts/eval/eval.py
@@ -97,7 +97,8 @@ def evaluate_model(model_cfg: DictConfig, dist_timeout: Union[float, int],
                    max_seq_len: int, device_eval_batch_size: int,
                    model_gauntlet_config: Optional[Union[str, DictConfig]],
                    fsdp_config: Optional[Dict], num_retries: int,
-                   loggers_cfg: Dict[str, Any], precision: str,
+                   loggers_cfg: Dict[str, Any], python_log_level: str, 
+                   precision: str, 
                    model_gauntlet_df: Optional[pd.DataFrame]):
     print(f'Evaluating model: {model_cfg.model_name}', flush=True)
     # Build tokenizer and model
@@ -154,6 +155,7 @@ def evaluate_model(model_cfg: DictConfig, dist_timeout: Union[float, int],
         progress_bar=False,
         log_to_console=True,
         dist_timeout=dist_timeout,
+        python_log_level=python_log_level,
     )
 
     if torch.cuda.is_available():
@@ -191,6 +193,10 @@ def main(cfg: DictConfig):
                                              'device_eval_batch_size',
                                              must_exist=True)
     precision: str = pop_config(cfg, 'precision', must_exist=True)
+    python_log_level: str = pop_config(cfg,
+                                       'python_log_level',
+                                       must_exist=False,
+                                       default_value='debug')
 
     # Optional Evaluation Parameters with default values
     seed: int = pop_config(cfg, 'seed', must_exist=False, default_value=17)
@@ -240,8 +246,10 @@ def main(cfg: DictConfig):
              fsdp_config=fsdp_config,
              num_retries=num_retries,
              loggers_cfg=loggers_cfg,
+             python_log_level=python_log_level,
              precision=precision,
-             model_gauntlet_df=model_gauntlet_df)
+             model_gauntlet_df=model_gauntlet_df, 
+        )
 
         if model_gauntlet_callback is not None:
             # TODO(bmosaicml) This needs to be refactored to fix the typing issue


### PR DESCRIPTION
Add python log level in llm foundry eval script 

## Test

**Before commit**
```
python eval/eval.py \
  eval/yamls/hf_eval.yaml \
  icl_tasks=eval/yamls/copa.yaml \
  model_name_or_path=mpt-125m-hf

Evaluating model: mpt-125m-hf
Extracting ICL task config from path: eval/yamls/copa.yaml
Found cached dataset json (/root/.cache/huggingface/datasets/json/default-dab79150852c1071/0.0.0/0f7e3662623656454fcd2b650f34e886a7db4b9104504885bd462096cc7a9f51)
Loading cached processed dataset at /root/.cache/huggingface/datasets/json/default-dab79150852c1071/0.0.0/0f7e3662623656454fcd2b650f34e886a7db4b9104504885bd462096cc7a9f51/cache-cd52fb08eb73c6e5.arrow
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100/100 [00:00<00:00, 6093.45it/s]
Instantiating an MPTForCausalLM model from /root/.cache/huggingface/modules/transformers_modules/mpt-125m-hf/modeling_mpt.py
You are using config.init_device='cpu', but you can also use config.init_device="meta" with Composer + FSDP for fast initialization.
Xformers is not installed correctly. If you want to use memory_efficient_attention to accelerate training use the following command to install Xformers
pip install xformers.
/mnt/workdisk/chuck/conda/envs/llm-foundry/lib/python3.10/site-packages/composer/trainer/trainer.py:975: UserWarning: No optimizer was specified. Defaulting to DecoupledSGDW(lr=0.1)
  warnings.warn(('No optimizer was specified. Defaulting to '
******************************
Config:
node_name: a100-40sxm-h14-02
num_gpus_per_node: 1
num_nodes: 1
rank_zero_seed: 3017306518

******************************
[Eval batch=1/50] Eval on copa/0-shot data
[Eval batch=6/50] Eval on copa/0-shot data
[Eval batch=11/50] Eval on copa/0-shot data
[Eval batch=16/50] Eval on copa/0-shot data
[Eval batch=21/50] Eval on copa/0-shot data
[Eval batch=26/50] Eval on copa/0-shot data
[Eval batch=30/50] Eval on copa/0-shot data
[Eval batch=35/50] Eval on copa/0-shot data
[Eval batch=40/50] Eval on copa/0-shot data
[Eval batch=45/50] Eval on copa/0-shot data
[Eval batch=50/50] Eval on copa/0-shot data:
         Eval metrics/copa/0-shot/InContextLearningMultipleChoiceAccuracy: 0.5600
Ran mpt-125m-hf eval in: 6.88492226600647 seconds
Warning: couldn't find results for benchmark: {'name': 'jeopardy', 'num_fewshot': 10, 'random_baseline': 0, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'bigbench_qa_wikidata', 'num_fewshot': 10, 'random_baseline': 0, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'arc_easy', 'num_fewshot': 10, 'random_baseline': 0.25, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'arc_challenge', 'num_fewshot': 10, 'random_baseline': 0.25, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'mmlu', 'num_fewshot': 10, 'random_baseline': 0.25, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'bigbench_misconceptions', 'num_fewshot': 10, 'random_baseline': 0.5, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'piqa', 'num_fewshot': 10, 'random_baseline': 0.5, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'openbook_qa', 'num_fewshot': 0, 'random_baseline': 0.25, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'bigbench_novel_concepts', 'num_fewshot': 10, 'random_baseline': 0.25, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'bigbench_strange_stories', 'num_fewshot': 10, 'random_baseline': 0.5, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'bigbench_strategy_qa', 'num_fewshot': 10, 'random_baseline': 0.5, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'lambada_openai', 'num_fewshot': 0, 'random_baseline': 0.0, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'hellaswag', 'num_fewshot': 10, 'random_baseline': 0.25, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'winograd', 'num_fewshot': 0, 'random_baseline': 0.5, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'winogrande', 'num_fewshot': 0, 'random_baseline': 0.5, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'bigbench_conlang_translation', 'num_fewshot': 0, 'random_baseline': 0.0, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'bigbench_language_identification', 'num_fewshot': 10, 'random_baseline': 0.25, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'bigbench_conceptual_combinations', 'num_fewshot': 10, 'random_baseline': 0.25, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'bigbench_elementary_math_qa', 'num_fewshot': 10, 'random_baseline': 0.25, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'bigbench_dyck_languages', 'num_fewshot': 10, 'random_baseline': 0, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'bigbench_cs_algorithms', 'num_fewshot': 10, 'random_baseline': 0, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'bigbench_logical_deduction', 'num_fewshot': 10, 'random_baseline': 0.25, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'bigbench_operators', 'num_fewshot': 10, 'random_baseline': 0.0, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'bigbench_repeat_copy_logic', 'num_fewshot': 10, 'random_baseline': 0.0, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'simple_arithmetic_withspaces', 'num_fewshot': 10, 'random_baseline': 0.0, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'simple_arithmetic_nospaces', 'num_fewshot': 10, 'random_baseline': 0.0, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'math_qa', 'num_fewshot': 10, 'random_baseline': 0.25, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'logi_qa', 'num_fewshot': 10, 'random_baseline': 0.25, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'pubmed_qa_labeled', 'num_fewshot': 10, 'random_baseline': 0.0, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'squad', 'num_fewshot': 10, 'random_baseline': 0, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'bigbench_understanding_fables', 'num_fewshot': 10, 'random_baseline': 0.25, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'boolq', 'num_fewshot': 10, 'random_baseline': 0.5, 'weighting': 1}
Printing gauntlet results for all models
| model_name   |   average |   world_knowledge |   commonsense_reasoning |   language_understanding |   symbolic_problem_solving |   reading_comprehension |
|:-------------|----------:|------------------:|------------------------:|-------------------------:|---------------------------:|------------------------:|
| mpt-125m-hf  |     0.024 |                 0 |                    0.12 |                        0 |                          0 |                       0 |
Printing complete results for all models
| Category              | Benchmark   | Subtask   |   Accuracy |   Number few shot | Model       |
|:----------------------|:------------|:----------|-----------:|------------------:|:------------|
| commonsense_reasoning | copa        |           |       0.56 |                 0 | mpt-125m-hf |
```

**After commit**
```
python eval/eval.py \
  eval/yamls/hf_eval.yaml \
  icl_tasks=eval/yamls/copa.yaml \
  model_name_or_path=mpt-125m-hf

Evaluating model: mpt-125m-hf
Extracting ICL task config from path: eval/yamls/copa.yaml
Found cached dataset json (/root/.cache/huggingface/datasets/json/default-dab79150852c1071/0.0.0/0f7e3662623656454fcd2b650f34e886a7db4b9104504885bd462096cc7a9f51)
Loading cached processed dataset at /root/.cache/huggingface/datasets/json/default-dab79150852c1071/0.0.0/0f7e3662623656454fcd2b650f34e886a7db4b9104504885bd462096cc7a9f51/cache-cd52fb08eb73c6e5.arrow
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100/100 [00:00<00:00, 6229.20it/s]
Instantiating an MPTForCausalLM model from /root/.cache/huggingface/modules/transformers_modules/mpt-125m-hf/modeling_mpt.py
You are using config.init_device='cpu', but you can also use config.init_device="meta" with Composer + FSDP for fast initialization.
Xformers is not installed correctly. If you want to use memory_efficient_attention to accelerate training use the following command to install Xformers
pip install xformers.
2023-08-23 19:25:07,352: rank0[106264][MainThread]: INFO: composer.utils.reproducibility: Setting seed to 2442873400
/mnt/workdisk/chuck/conda/envs/llm-foundry/lib/python3.10/site-packages/composer/trainer/trainer.py:975: UserWarning: No optimizer was specified. Defaulting to DecoupledSGDW(lr=0.1)
  warnings.warn(('No optimizer was specified. Defaulting to '
2023-08-23 19:25:07,353: rank0[106264][MainThread]: INFO: composer.trainer.trainer: Run name: llm-foundry-quickstart-qH0dyf
2023-08-23 19:25:07,406: rank0[106264][MainThread]: INFO: composer.trainer.trainer: Stepping schedulers every batch. To step schedulers every epoch, set `step_schedulers_every_batch=False`.
2023-08-23 19:25:07,631: rank0[106264][MainThread]: INFO: composer.trainer.trainer: Setting seed to 2442873400
2023-08-23 19:25:07,631: rank0[106264][MainThread]: INFO: composer.utils.reproducibility: Setting seed to 2442873400
2023-08-23 19:25:07,633: rank0[106264][MainThread]: INFO: composer.trainer.trainer: Added ['copa/0-shot'] to eval_metrics.
******************************
Config:
node_name: a100-40sxm-h14-02
num_gpus_per_node: 1
num_nodes: 1
rank_zero_seed: 2442873400

******************************
[Eval batch=1/50] Eval on copa/0-shot data
[Eval batch=6/50] Eval on copa/0-shot data
[Eval batch=11/50] Eval on copa/0-shot data
[Eval batch=16/50] Eval on copa/0-shot data
[Eval batch=21/50] Eval on copa/0-shot data
[Eval batch=26/50] Eval on copa/0-shot data
[Eval batch=30/50] Eval on copa/0-shot data
[Eval batch=35/50] Eval on copa/0-shot data
[Eval batch=40/50] Eval on copa/0-shot data
[Eval batch=45/50] Eval on copa/0-shot data
[Eval batch=50/50] Eval on copa/0-shot data:
         Eval metrics/copa/0-shot/InContextLearningMultipleChoiceAccuracy: 0.5600
Ran mpt-125m-hf eval in: 6.326979398727417 seconds
2023-08-23 19:25:13,958: rank0[106264][MainThread]: DEBUG: composer.core.engine: Closing the engine
2023-08-23 19:25:13,959: rank0[106264][MainThread]: DEBUG: composer.core.engine: Closing callback InMemoryLogger
2023-08-23 19:25:13,959: rank0[106264][MainThread]: DEBUG: composer.core.engine: Closing callback ConsoleLogger
2023-08-23 19:25:13,959: rank0[106264][MainThread]: DEBUG: composer.core.engine: Post-closing callback InMemoryLogger
2023-08-23 19:25:13,959: rank0[106264][MainThread]: DEBUG: composer.core.engine: Post-closing callback ConsoleLogger
Warning: couldn't find results for benchmark: {'name': 'jeopardy', 'num_fewshot': 10, 'random_baseline': 0, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'bigbench_qa_wikidata', 'num_fewshot': 10, 'random_baseline': 0, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'arc_easy', 'num_fewshot': 10, 'random_baseline': 0.25, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'arc_challenge', 'num_fewshot': 10, 'random_baseline': 0.25, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'mmlu', 'num_fewshot': 10, 'random_baseline': 0.25, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'bigbench_misconceptions', 'num_fewshot': 10, 'random_baseline': 0.5, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'piqa', 'num_fewshot': 10, 'random_baseline': 0.5, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'openbook_qa', 'num_fewshot': 0, 'random_baseline': 0.25, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'bigbench_novel_concepts', 'num_fewshot': 10, 'random_baseline': 0.25, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'bigbench_strange_stories', 'num_fewshot': 10, 'random_baseline': 0.5, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'bigbench_strategy_qa', 'num_fewshot': 10, 'random_baseline': 0.5, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'lambada_openai', 'num_fewshot': 0, 'random_baseline': 0.0, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'hellaswag', 'num_fewshot': 10, 'random_baseline': 0.25, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'winograd', 'num_fewshot': 0, 'random_baseline': 0.5, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'winogrande', 'num_fewshot': 0, 'random_baseline': 0.5, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'bigbench_conlang_translation', 'num_fewshot': 0, 'random_baseline': 0.0, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'bigbench_language_identification', 'num_fewshot': 10, 'random_baseline': 0.25, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'bigbench_conceptual_combinations', 'num_fewshot': 10, 'random_baseline': 0.25, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'bigbench_elementary_math_qa', 'num_fewshot': 10, 'random_baseline': 0.25, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'bigbench_dyck_languages', 'num_fewshot': 10, 'random_baseline': 0, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'bigbench_cs_algorithms', 'num_fewshot': 10, 'random_baseline': 0, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'bigbench_logical_deduction', 'num_fewshot': 10, 'random_baseline': 0.25, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'bigbench_operators', 'num_fewshot': 10, 'random_baseline': 0.0, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'bigbench_repeat_copy_logic', 'num_fewshot': 10, 'random_baseline': 0.0, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'simple_arithmetic_withspaces', 'num_fewshot': 10, 'random_baseline': 0.0, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'simple_arithmetic_nospaces', 'num_fewshot': 10, 'random_baseline': 0.0, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'math_qa', 'num_fewshot': 10, 'random_baseline': 0.25, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'logi_qa', 'num_fewshot': 10, 'random_baseline': 0.25, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'pubmed_qa_labeled', 'num_fewshot': 10, 'random_baseline': 0.0, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'squad', 'num_fewshot': 10, 'random_baseline': 0, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'bigbench_understanding_fables', 'num_fewshot': 10, 'random_baseline': 0.25, 'weighting': 1}
Warning: couldn't find results for benchmark: {'name': 'boolq', 'num_fewshot': 10, 'random_baseline': 0.5, 'weighting': 1}
Printing gauntlet results for all models
| model_name   |   average |   world_knowledge |   commonsense_reasoning |   language_understanding |   symbolic_problem_solving |   reading_comprehension |
|:-------------|----------:|------------------:|------------------------:|-------------------------:|---------------------------:|------------------------:|
| mpt-125m-hf  |     0.024 |                 0 |                    0.12 |                        0 |                          0 |                       0 |
Printing complete results for all models
| Category              | Benchmark   | Subtask   |   Accuracy |   Number few shot | Model       |
|:----------------------|:------------|:----------|-----------:|------------------:|:------------|
| commonsense_reasoning | copa        |           |       0.56 |                 0 | mpt-125m-hf |
```
