### PR TITLE
Move the model creation to the last step before trainer creation

### DIFF
--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -464,8 +464,7 @@ def main(cfg: DictConfig):
         assert model.train_metrics is not None
         eval_metric_names = list(model.train_metrics.keys())
         eval_loader.metric_names = eval_metric_names
-        evaluators = [eval_loader
-                     ] + evaluators  # Put the base eval_loader first
+        evaluators.insert(0, eval_loader)  # Put the base eval_loader first
 
     # Build the Trainer
     print('Building trainer...')

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -423,13 +423,15 @@ def main(cfg: DictConfig):
     ## Evaluation
     print('Building eval loader...')
     evaluators = []
+    eval_loader = None
     if eval_loader_config is not None:
         eval_dataloader = build_dataloader(eval_loader_config, tokenizer,
                                            device_eval_batch_size)
-        eval_loader = Evaluator(label='eval',
-                                dataloader=eval_dataloader,
-                                metric_names=[], # we will add these after model is created
-                        )
+        eval_loader = Evaluator(
+            label='eval',
+            dataloader=eval_dataloader,
+            metric_names=[],  # we will add these after model is created
+        )
 
     if icl_tasks_config is not None:
         icl_evaluators, _ = build_icl_evaluators(icl_tasks_config, tokenizer,
@@ -458,10 +460,12 @@ def main(cfg: DictConfig):
 
     # Now add the eval metrics
     if eval_loader_config is not None:
+        assert eval_loader is not None
         assert model.train_metrics is not None
         eval_metric_names = list(model.train_metrics.keys())
         eval_loader.metric_names = eval_metric_names
-        evaluators = [eval_loader] + evaluators # Put the base eval_loader first
+        evaluators = [eval_loader
+                     ] + evaluators  # Put the base eval_loader first
 
     # Build the Trainer
     print('Building trainer...')

--- a/tests/test_train_inputs.py
+++ b/tests/test_train_inputs.py
@@ -123,17 +123,21 @@ class TestTrainingYAMLInputs:
 
     def test_extra_params_in_optimizer_cfg_errors(self,
                                                   cfg: DictConfig) -> None:
-        make_fake_index_file('./my-copy-c4/train/index.json')
-        make_fake_index_file('./my-copy-c4/val/index.json')
+        data_local = './my-copy-c4-opt1'
+        make_fake_index_file(f'{data_local}/train/index.json')
+        make_fake_index_file(f'{data_local}/val/index.json')
+        cfg.train_loader.dataset.local = data_local
         cfg.optimizer.beta2 = 'extra-parameter'
         with pytest.raises(TypeError):
             main(cfg)
 
     def test_invalid_name_in_optimizer_cfg_errors(self,
                                                   cfg: DictConfig) -> None:
-        make_fake_index_file('./my-copy-c4/train/index.json')
-        make_fake_index_file('./my-copy-c4/val/index.json')
+        data_local = './my-copy-c4-opt2'
+        make_fake_index_file(f'{data_local}/train/index.json')
+        make_fake_index_file(f'{data_local}/val/index.json')
         cfg.optimizer.name = 'invalid-optimizer'
+        cfg.train_loader.dataset.local = data_local
         with pytest.raises(ValueError) as exception_info:
             main(cfg)
         assert str(exception_info.value

--- a/tests/test_train_inputs.py
+++ b/tests/test_train_inputs.py
@@ -17,38 +17,38 @@ sys.path.append(repo_dir)
 
 from scripts.train.train import main  # noqa: E402
 
+
 def make_fake_index_file(path: str) -> None:
     """Create a fake index file in the path."""
     fake_index = {
-        "shards": [
-            {
-                "column_encodings": ["bytes"],
-                "column_names": ["tokens"],
-                "column_sizes": [None],
-                "compression": "zstd",
-                "format": "mds",
-                "hashes": [],
-                "raw_data": {
-                    "basename": "shard.00000.mds",
-                    "bytes": 5376759,
-                    "hashes": {},
-                },
-                "samples": 328,
-                "size_limit": 67108864,
-                "version": 2,
-                "zip_data": {
-                    "basename": "shard.00000.mds.zstd",
-                    "bytes": 564224,
-                    "hashes": {},
-                }
+        'shards': [{
+            'column_encodings': ['bytes'],
+            'column_names': ['tokens'],
+            'column_sizes': [None],
+            'compression': 'zstd',
+            'format': 'mds',
+            'hashes': [],
+            'raw_data': {
+                'basename': 'shard.00000.mds',
+                'bytes': 5376759,
+                'hashes': {},
+            },
+            'samples': 328,
+            'size_limit': 67108864,
+            'version': 2,
+            'zip_data': {
+                'basename': 'shard.00000.mds.zstd',
+                'bytes': 564224,
+                'hashes': {},
             }
-        ],
-        "version": 2
+        }],
+        'version': 2
     }
     if not os.path.exists(path):
         os.makedirs(os.path.dirname(path), exist_ok=True)
         with open(path, 'w') as f:
             json.dump(fake_index, f)
+
 
 class TestTrainingYAMLInputs:
     """Validate and tests error handling for the input YAML file."""

--- a/tests/test_train_inputs.py
+++ b/tests/test_train_inputs.py
@@ -1,6 +1,7 @@
 # Copyright 2022 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 import copy
+import json
 import os
 import sys
 import warnings
@@ -16,6 +17,38 @@ sys.path.append(repo_dir)
 
 from scripts.train.train import main  # noqa: E402
 
+def make_fake_index_file(path: str) -> None:
+    """Create a fake index file in the path."""
+    fake_index = {
+        "shards": [
+            {
+                "column_encodings": ["bytes"],
+                "column_names": ["tokens"],
+                "column_sizes": [None],
+                "compression": "zstd",
+                "format": "mds",
+                "hashes": [],
+                "raw_data": {
+                    "basename": "shard.00000.mds",
+                    "bytes": 5376759,
+                    "hashes": {},
+                },
+                "samples": 328,
+                "size_limit": 67108864,
+                "version": 2,
+                "zip_data": {
+                    "basename": "shard.00000.mds.zstd",
+                    "bytes": 564224,
+                    "hashes": {},
+                }
+            }
+        ],
+        "version": 2
+    }
+    if not os.path.exists(path):
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, 'w') as f:
+            json.dump(fake_index, f)
 
 class TestTrainingYAMLInputs:
     """Validate and tests error handling for the input YAML file."""
@@ -90,12 +123,16 @@ class TestTrainingYAMLInputs:
 
     def test_extra_params_in_optimizer_cfg_errors(self,
                                                   cfg: DictConfig) -> None:
+        make_fake_index_file('./my-copy-c4/train/index.json')
+        make_fake_index_file('./my-copy-c4/val/index.json')
         cfg.optimizer.beta2 = 'extra-parameter'
         with pytest.raises(TypeError):
             main(cfg)
 
     def test_invalid_name_in_optimizer_cfg_errors(self,
                                                   cfg: DictConfig) -> None:
+        make_fake_index_file('./my-copy-c4/train/index.json')
+        make_fake_index_file('./my-copy-c4/val/index.json')
         cfg.optimizer.name = 'invalid-optimizer'
         with pytest.raises(ValueError) as exception_info:
             main(cfg)

--- a/tests/test_train_inputs.py
+++ b/tests/test_train_inputs.py
@@ -127,6 +127,7 @@ class TestTrainingYAMLInputs:
         make_fake_index_file(f'{data_local}/train/index.json')
         make_fake_index_file(f'{data_local}/val/index.json')
         cfg.train_loader.dataset.local = data_local
+        cfg.eval_loader.dataset.local = data_local
         cfg.optimizer.beta2 = 'extra-parameter'
         with pytest.raises(TypeError):
             main(cfg)
@@ -138,6 +139,7 @@ class TestTrainingYAMLInputs:
         make_fake_index_file(f'{data_local}/val/index.json')
         cfg.optimizer.name = 'invalid-optimizer'
         cfg.train_loader.dataset.local = data_local
+        cfg.eval_loader.dataset.local = data_local
         with pytest.raises(ValueError) as exception_info:
             main(cfg)
         assert str(exception_info.value


### PR DESCRIPTION
The model download from huggingface is often quite slow, so this PR moves the model creation to the last step before the trainer creation. This way any other misconfigurations or dataset init validation will fail faster without having to wait for the model download from huggingface.

Before with bad data path: `fast-fail-data-before-1-5KeAKO` (fails after model download)
After with bad data path: `fast-fail-data-after-1-HMYrlQ` (fails before model download)
After with normal data path: `fast-fail-data-normal-3-5YV31Z` (trains and evals as normal)

Closes [GRT-2320](https://mosaicml.atlassian.net/browse/GRT-2320)