### PR TITLE
Bump torch version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,11 +47,11 @@ classifiers = [
 ]
 
 install_requires = [
-    'mosaicml[libcloud,wandb,mlflow]>=0.15.0,<0.16',
+    'mosaicml[libcloud,wandb,mlflow]>=0.15.0,<0.16.2',
     'accelerate>=0.20,<0.21',  # for HF inference `device_map`
     'transformers>=4.31,<4.32',
     'mosaicml-streaming>=0.5.1,<0.6',
-    'torch>=1.13.1,<=2.0.1',
+    'torch>=1.13.1,<=2.1.0',
     'datasets==2.10.1',
     'sentencepiece==0.1.97',
     'einops==0.5.0',
@@ -79,7 +79,7 @@ extra_deps['dev'] = [
 ]
 
 extra_deps['tensorboard'] = [
-    'mosaicml[tensorboard]>=0.15.0,<0.16',
+    'mosaicml[tensorboard]>=0.15.0,<0.16.2',
 ]
 
 extra_deps['gpu'] = [


### PR DESCRIPTION
## Description
Bumps pytorch version to support torch 2.1.0 

## Test 

Install works on cpu:
```
(base) ➜  llm-foundry git:(chuck/bump_torch_version) pip install -e "."     
Obtaining file:///Users/chuck.tang/llm-foundry
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... done
  Installing backend dependencies ... done
  Preparing editable metadata (pyproject.toml) ... done
Collecting triton-pre-mlir@ git+https://github.com/vchiley/triton.git@triton_pre_mlir_sm90#subdirectory=python (from llm-foundry==0.2.0)
  Cloning https://github.com/vchiley/triton.git (to revision triton_pre_mlir_sm90) to /private/var/folders/zz/tvyss5c1723dvpbp7kfc9flh0000gp/T/pip-install-7mick0dc/triton-pre-mlir_1590c310434a4867a62ccc1ca149acb3
  Running command git clone --filter=blob:none --quiet https://github.com/vchiley/triton.git /private/var/folders/zz/tvyss5c1723dvpbp7kfc9flh0000gp/T/pip-install-7mick0dc/triton-pre-mlir_1590c310434a4867a62ccc1ca149acb3
  Running command git checkout -b triton_pre_mlir_sm90 --track origin/triton_pre_mlir_sm90
  Switched to a new branch 'triton_pre_mlir_sm90'
  branch 'triton_pre_mlir_sm90' set up to track 'origin/triton_pre_mlir_sm90'.
  Resolved https://github.com/vchiley/triton.git to commit 86c7fe23397467ade531513291f729c12dd8d15e
  Running command git submodule update --init --recursive -q
  Preparing metadata (setup.py) ... done
Requirement already satisfied: mosaicml[libcloud,mlflow,wandb]<0.16.2,>=0.15.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from llm-foundry==0.2.0) (0.15.1)
Requirement already satisfied: accelerate<0.21,>=0.20 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from llm-foundry==0.2.0) (0.20.3)
Collecting transformers<4.32,>=4.31 (from llm-foundry==0.2.0)
  Obtaining dependency information for transformers<4.32,>=4.31 from https://files.pythonhosted.org/packages/21/02/ae8e595f45b6c8edee07913892b3b41f5f5f273962ad98851dc6a564bbb9/transformers-4.31.0-py3-none-any.whl.metadata
  Using cached transformers-4.31.0-py3-none-any.whl.metadata (116 kB)
Requirement already satisfied: mosaicml-streaming<0.6,>=0.5.1 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from llm-foundry==0.2.0) (0.5.2)
Requirement already satisfied: torch<=2.1.0,>=1.13.1 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from llm-foundry==0.2.0) (2.0.1)
Requirement already satisfied: datasets==2.10.1 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from llm-foundry==0.2.0) (2.10.1)
Requirement already satisfied: sentencepiece==0.1.97 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from llm-foundry==0.2.0) (0.1.97)
Requirement already satisfied: einops==0.5.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from llm-foundry==0.2.0) (0.5.0)
Requirement already satisfied: omegaconf<3,>=2.2.3 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from llm-foundry==0.2.0) (2.3.0)
Requirement already satisfied: slack-sdk<4 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from llm-foundry==0.2.0) (3.21.3)
Requirement already satisfied: mosaicml-cli<1,>=0.3 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from llm-foundry==0.2.0) (0.5.7)
Requirement already satisfied: onnx==1.14.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from llm-foundry==0.2.0) (1.14.0)
Requirement already satisfied: onnxruntime==1.15.1 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from llm-foundry==0.2.0) (1.15.1)
Requirement already satisfied: cmake<=3.26.3,>=3.25.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from llm-foundry==0.2.0) (3.26.3)
Requirement already satisfied: numpy>=1.17 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from datasets==2.10.1->llm-foundry==0.2.0) (1.24.4)
Requirement already satisfied: pyarrow>=6.0.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from datasets==2.10.1->llm-foundry==0.2.0) (12.0.1)
Requirement already satisfied: dill<0.3.7,>=0.3.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from datasets==2.10.1->llm-foundry==0.2.0) (0.3.6)
Requirement already satisfied: pandas in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from datasets==2.10.1->llm-foundry==0.2.0) (2.0.3)
Requirement already satisfied: requests>=2.19.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from datasets==2.10.1->llm-foundry==0.2.0) (2.29.0)
Requirement already satisfied: tqdm>=4.62.1 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from datasets==2.10.1->llm-foundry==0.2.0) (4.65.0)
Requirement already satisfied: xxhash in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from datasets==2.10.1->llm-foundry==0.2.0) (3.3.0)
Requirement already satisfied: multiprocess in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from datasets==2.10.1->llm-foundry==0.2.0) (0.70.14)
Requirement already satisfied: fsspec[http]>=2021.11.1 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from datasets==2.10.1->llm-foundry==0.2.0) (2023.6.0)
Requirement already satisfied: aiohttp in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from datasets==2.10.1->llm-foundry==0.2.0) (3.8.5)
Requirement already satisfied: huggingface-hub<1.0.0,>=0.2.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from datasets==2.10.1->llm-foundry==0.2.0) (0.16.4)
Requirement already satisfied: packaging in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from datasets==2.10.1->llm-foundry==0.2.0) (22.0)
Requirement already satisfied: responses<0.19 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from datasets==2.10.1->llm-foundry==0.2.0) (0.18.0)
Requirement already satisfied: pyyaml>=5.1 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from datasets==2.10.1->llm-foundry==0.2.0) (6.0.1)
Requirement already satisfied: protobuf>=3.20.2 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from onnx==1.14.0->llm-foundry==0.2.0) (4.23.4)
Requirement already satisfied: typing-extensions>=3.6.2.1 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from onnx==1.14.0->llm-foundry==0.2.0) (4.7.1)
Requirement already satisfied: coloredlogs in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from onnxruntime==1.15.1->llm-foundry==0.2.0) (15.0.1)
Requirement already satisfied: flatbuffers in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from onnxruntime==1.15.1->llm-foundry==0.2.0) (23.5.26)
Requirement already satisfied: sympy in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from onnxruntime==1.15.1->llm-foundry==0.2.0) (1.12)
Requirement already satisfied: psutil in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from accelerate<0.21,>=0.20->llm-foundry==0.2.0) (5.9.5)
Requirement already satisfied: argcomplete>=2.0.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from mosaicml-cli<1,>=0.3->llm-foundry==0.2.0) (3.1.1)
Requirement already satisfied: arrow>=1.2.2 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from mosaicml-cli<1,>=0.3->llm-foundry==0.2.0) (1.2.3)
Requirement already satisfied: backoff>=2.2.1 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from mosaicml-cli<1,>=0.3->llm-foundry==0.2.0) (2.2.1)
Requirement already satisfied: gql[websockets]>=3.4.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from mosaicml-cli<1,>=0.3->llm-foundry==0.2.0) (3.4.1)
Requirement already satisfied: prompt-toolkit>=3.0.29 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from mosaicml-cli<1,>=0.3->llm-foundry==0.2.0) (3.0.29)
Requirement already satisfied: questionary>=1.10.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from mosaicml-cli<1,>=0.3->llm-foundry==0.2.0) (1.10.0)
Requirement already satisfied: rich>=12.6.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from mosaicml-cli<1,>=0.3->llm-foundry==0.2.0) (13.5.2)
Requirement already satisfied: ruamel.yaml>=0.17.21 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from mosaicml-cli<1,>=0.3->llm-foundry==0.2.0) (0.17.21)
Requirement already satisfied: validators>=0.20.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from mosaicml-cli<1,>=0.3->llm-foundry==0.2.0) (0.20.0)
Requirement already satisfied: boto3<2,>=1.21.45 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (1.28.20)
Requirement already satisfied: Brotli>=1.0.9 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (1.0.9)
Requirement already satisfied: google-cloud-storage>=2.9.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (2.10.0)
Requirement already satisfied: matplotlib<4,>=3.5.2 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (3.7.2)
Requirement already satisfied: paramiko<4,>=2.11.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (2.12.0)
Requirement already satisfied: python-snappy<1,>=0.6.1 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (0.6.1)
Requirement already satisfied: torchtext>=0.10 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (0.15.2)
Requirement already satisfied: torchvision>=0.10 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (0.15.2)
Requirement already satisfied: zstd<2,>=1.5.2.5 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (1.5.5.1)
Requirement already satisfied: oci<3,>=2.88 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (2.109.0)
Requirement already satisfied: azure-storage-blob<13,>=12.0.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (12.17.0)
Requirement already satisfied: azure-storage-file-datalake<13,>=12.11.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (12.12.0)
Requirement already satisfied: azure-identity>=1.13.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (1.14.0)
Requirement already satisfied: torchmetrics<0.12,>=0.10.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from mosaicml[libcloud,mlflow,wandb]<0.16.2,>=0.15.0->llm-foundry==0.2.0) (0.11.4)
Requirement already satisfied: torch-optimizer<0.4,>=0.3.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from mosaicml[libcloud,mlflow,wandb]<0.16.2,>=0.15.0->llm-foundry==0.2.0) (0.3.0)
Requirement already satisfied: coolname<3,>=1.1.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from mosaicml[libcloud,mlflow,wandb]<0.16.2,>=0.15.0->llm-foundry==0.2.0) (2.2.0)
Requirement already satisfied: tabulate==0.9.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from mosaicml[libcloud,mlflow,wandb]<0.16.2,>=0.15.0->llm-foundry==0.2.0) (0.9.0)
Requirement already satisfied: py-cpuinfo<10,>=8.0.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from mosaicml[libcloud,mlflow,wandb]<0.16.2,>=0.15.0->llm-foundry==0.2.0) (9.0.0)
Requirement already satisfied: importlib-metadata<7,>=5.0.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from mosaicml[libcloud,mlflow,wandb]<0.16.2,>=0.15.0->llm-foundry==0.2.0) (6.8.0)
Collecting mosaicml-cli<1,>=0.3 (from llm-foundry==0.2.0)
  Obtaining dependency information for mosaicml-cli<1,>=0.3 from https://files.pythonhosted.org/packages/cf/25/68f544090f59e94245595a3b3d5e53e06845b53bc03c6ae14bc5a6c358bc/mosaicml_cli-0.4.17-py3-none-any.whl.metadata
  Using cached mosaicml_cli-0.4.17-py3-none-any.whl.metadata (4.9 kB)
Requirement already satisfied: apache-libcloud<4,>=3.3.1 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from mosaicml[libcloud,mlflow,wandb]<0.16.2,>=0.15.0->llm-foundry==0.2.0) (3.7.0)
Collecting mlflow<3.0,>=2.0.1 (from mosaicml[libcloud,mlflow,wandb]<0.16.2,>=0.15.0->llm-foundry==0.2.0)
  Obtaining dependency information for mlflow<3.0,>=2.0.1 from https://files.pythonhosted.org/packages/5d/c8/2ddb5e1d0f75a088b8580868ca439221d3a1d9649a52eb7f940ecc5b5c9f/mlflow-2.6.0-py3-none-any.whl.metadata
  Using cached mlflow-2.6.0-py3-none-any.whl.metadata (12 kB)
Requirement already satisfied: wandb<0.16,>=0.13.2 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from mosaicml[libcloud,mlflow,wandb]<0.16.2,>=0.15.0->llm-foundry==0.2.0) (0.15.8)
Requirement already satisfied: docker>=5.0.3 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from mosaicml-cli<1,>=0.3->llm-foundry==0.2.0) (6.1.3)
Requirement already satisfied: antlr4-python3-runtime==4.9.* in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from omegaconf<3,>=2.2.3->llm-foundry==0.2.0) (4.9.3)
Requirement already satisfied: filelock in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from torch<=2.1.0,>=1.13.1->llm-foundry==0.2.0) (3.12.2)
Requirement already satisfied: networkx in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from torch<=2.1.0,>=1.13.1->llm-foundry==0.2.0) (3.1)
Requirement already satisfied: jinja2 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from torch<=2.1.0,>=1.13.1->llm-foundry==0.2.0) (3.1.2)
Requirement already satisfied: regex!=2019.12.17 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from transformers<4.32,>=4.31->llm-foundry==0.2.0) (2023.8.8)
Requirement already satisfied: tokenizers!=0.11.3,<0.14,>=0.11.1 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from transformers<4.32,>=4.31->llm-foundry==0.2.0) (0.13.3)
Requirement already satisfied: safetensors>=0.3.1 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from transformers<4.32,>=4.31->llm-foundry==0.2.0) (0.3.2)
Requirement already satisfied: python-dateutil>=2.7.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from arrow>=1.2.2->mosaicml-cli<1,>=0.3->llm-foundry==0.2.0) (2.8.2)
Requirement already satisfied: azure-core<2.0.0,>=1.11.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from azure-identity>=1.13.0->mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (1.29.0)
Requirement already satisfied: cryptography>=2.5 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from azure-identity>=1.13.0->mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (39.0.1)
Requirement already satisfied: msal<2.0.0,>=1.20.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from azure-identity>=1.13.0->mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (1.23.0)
Requirement already satisfied: msal-extensions<2.0.0,>=0.3.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from azure-identity>=1.13.0->mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (1.0.0)
Requirement already satisfied: isodate>=0.6.1 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from azure-storage-blob<13,>=12.0.0->mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (0.6.1)
Requirement already satisfied: botocore<1.32.0,>=1.31.20 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from boto3<2,>=1.21.45->mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (1.31.20)
Requirement already satisfied: jmespath<2.0.0,>=0.7.1 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from boto3<2,>=1.21.45->mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (0.10.0)
Requirement already satisfied: s3transfer<0.7.0,>=0.6.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from boto3<2,>=1.21.45->mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (0.6.1)
Requirement already satisfied: urllib3>=1.26.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from docker>=5.0.3->mosaicml-cli<1,>=0.3->llm-foundry==0.2.0) (1.26.16)
Requirement already satisfied: websocket-client>=0.32.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from docker>=5.0.3->mosaicml-cli<1,>=0.3->llm-foundry==0.2.0) (1.6.1)
Requirement already satisfied: attrs>=17.3.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from aiohttp->datasets==2.10.1->llm-foundry==0.2.0) (23.1.0)
Requirement already satisfied: charset-normalizer<4.0,>=2.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from aiohttp->datasets==2.10.1->llm-foundry==0.2.0) (2.0.4)
Requirement already satisfied: multidict<7.0,>=4.5 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from aiohttp->datasets==2.10.1->llm-foundry==0.2.0) (6.0.4)
Requirement already satisfied: async-timeout<5.0,>=4.0.0a3 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from aiohttp->datasets==2.10.1->llm-foundry==0.2.0) (4.0.2)
Requirement already satisfied: yarl<2.0,>=1.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from aiohttp->datasets==2.10.1->llm-foundry==0.2.0) (1.9.2)
Requirement already satisfied: frozenlist>=1.1.1 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from aiohttp->datasets==2.10.1->llm-foundry==0.2.0) (1.4.0)
Requirement already satisfied: aiosignal>=1.1.2 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from aiohttp->datasets==2.10.1->llm-foundry==0.2.0) (1.3.1)
Requirement already satisfied: google-auth<3.0dev,>=1.25.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from google-cloud-storage>=2.9.0->mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (2.22.0)
Requirement already satisfied: google-api-core!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0,<3.0.0dev,>=1.31.5 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from google-cloud-storage>=2.9.0->mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (2.11.1)
Requirement already satisfied: google-cloud-core<3.0dev,>=2.3.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from google-cloud-storage>=2.9.0->mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (2.3.3)
Requirement already satisfied: google-resumable-media>=2.3.2 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from google-cloud-storage>=2.9.0->mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (2.5.0)
Requirement already satisfied: graphql-core<3.3,>=3.2 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from gql[websockets]>=3.4.0->mosaicml-cli<1,>=0.3->llm-foundry==0.2.0) (3.2.3)
Requirement already satisfied: websockets<11,>=10 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from gql[websockets]>=3.4.0->mosaicml-cli<1,>=0.3->llm-foundry==0.2.0) (10.4)
Requirement already satisfied: zipp>=0.5 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from importlib-metadata<7,>=5.0.0->mosaicml[libcloud,mlflow,wandb]<0.16.2,>=0.15.0->llm-foundry==0.2.0) (3.16.2)
Requirement already satisfied: contourpy>=1.0.1 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from matplotlib<4,>=3.5.2->mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (1.1.0)
Requirement already satisfied: cycler>=0.10 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from matplotlib<4,>=3.5.2->mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (0.11.0)
Requirement already satisfied: fonttools>=4.22.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from matplotlib<4,>=3.5.2->mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (4.42.0)
Requirement already satisfied: kiwisolver>=1.0.1 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from matplotlib<4,>=3.5.2->mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (1.4.4)
Requirement already satisfied: pillow>=6.2.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from matplotlib<4,>=3.5.2->mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (10.0.0)
Requirement already satisfied: pyparsing<3.1,>=2.3.1 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from matplotlib<4,>=3.5.2->mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (3.0.9)
Requirement already satisfied: click<9,>=7.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from mlflow<3.0,>=2.0.1->mosaicml[libcloud,mlflow,wandb]<0.16.2,>=0.15.0->llm-foundry==0.2.0) (8.0.4)
Collecting cloudpickle<3 (from mlflow<3.0,>=2.0.1->mosaicml[libcloud,mlflow,wandb]<0.16.2,>=0.15.0->llm-foundry==0.2.0)
  Using cached cloudpickle-2.2.1-py3-none-any.whl (25 kB)
Collecting databricks-cli<1,>=0.8.7 (from mlflow<3.0,>=2.0.1->mosaicml[libcloud,mlflow,wandb]<0.16.2,>=0.15.0->llm-foundry==0.2.0)
  Using cached databricks_cli-0.17.7-py3-none-any.whl
Collecting entrypoints<1 (from mlflow<3.0,>=2.0.1->mosaicml[libcloud,mlflow,wandb]<0.16.2,>=0.15.0->llm-foundry==0.2.0)
  Using cached entrypoints-0.4-py3-none-any.whl (5.3 kB)
Requirement already satisfied: gitpython<4,>=2.1.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from mlflow<3.0,>=2.0.1->mosaicml[libcloud,mlflow,wandb]<0.16.2,>=0.15.0->llm-foundry==0.2.0) (3.1.32)
Requirement already satisfied: pytz<2024 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from mlflow<3.0,>=2.0.1->mosaicml[libcloud,mlflow,wandb]<0.16.2,>=0.15.0->llm-foundry==0.2.0) (2023.3)
Collecting sqlparse<1,>=0.4.0 (from mlflow<3.0,>=2.0.1->mosaicml[libcloud,mlflow,wandb]<0.16.2,>=0.15.0->llm-foundry==0.2.0)
  Using cached sqlparse-0.4.4-py3-none-any.whl (41 kB)
Collecting alembic!=1.10.0,<2 (from mlflow<3.0,>=2.0.1->mosaicml[libcloud,mlflow,wandb]<0.16.2,>=0.15.0->llm-foundry==0.2.0)
  Obtaining dependency information for alembic!=1.10.0,<2 from https://files.pythonhosted.org/packages/ab/7d/b572fc6a51bc430b1fa0ef59591db32b14105093324d472eed8ea296d2df/alembic-1.11.3-py3-none-any.whl.metadata
  Using cached alembic-1.11.3-py3-none-any.whl.metadata (7.2 kB)
Collecting Flask<3 (from mlflow<3.0,>=2.0.1->mosaicml[libcloud,mlflow,wandb]<0.16.2,>=0.15.0->llm-foundry==0.2.0)
  Obtaining dependency information for Flask<3 from https://files.pythonhosted.org/packages/fd/56/26f0be8adc2b4257df20c1c4260ddd0aa396cf8e75d90ab2f7ff99bc34f9/flask-2.3.3-py3-none-any.whl.metadata
  Downloading flask-2.3.3-py3-none-any.whl.metadata (3.6 kB)
Collecting scipy<2 (from mlflow<3.0,>=2.0.1->mosaicml[libcloud,mlflow,wandb]<0.16.2,>=0.15.0->llm-foundry==0.2.0)
  Obtaining dependency information for scipy<2 from https://files.pythonhosted.org/packages/2a/12/62804d63514ecd9d2ecb73497c3e38094f9139bc60b0353b653253d106bb/scipy-1.11.2-cp311-cp311-macosx_12_0_arm64.whl.metadata
  Downloading scipy-1.11.2-cp311-cp311-macosx_12_0_arm64.whl.metadata (146 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 146.5/146.5 kB 8.2 MB/s eta 0:00:00
Collecting querystring-parser<2 (from mlflow<3.0,>=2.0.1->mosaicml[libcloud,mlflow,wandb]<0.16.2,>=0.15.0->llm-foundry==0.2.0)
  Using cached querystring_parser-1.2.4-py2.py3-none-any.whl (7.9 kB)
Collecting sqlalchemy<3,>=1.4.0 (from mlflow<3.0,>=2.0.1->mosaicml[libcloud,mlflow,wandb]<0.16.2,>=0.15.0->llm-foundry==0.2.0)
  Obtaining dependency information for sqlalchemy<3,>=1.4.0 from https://files.pythonhosted.org/packages/cb/a7/3c8c8a36f336880e4dca47bf30d5c723384c40b67e649b35a582d6df45ef/SQLAlchemy-2.0.20-cp311-cp311-macosx_11_0_arm64.whl.metadata
  Downloading SQLAlchemy-2.0.20-cp311-cp311-macosx_11_0_arm64.whl.metadata (9.4 kB)
Collecting scikit-learn<2 (from mlflow<3.0,>=2.0.1->mosaicml[libcloud,mlflow,wandb]<0.16.2,>=0.15.0->llm-foundry==0.2.0)
  Obtaining dependency information for scikit-learn<2 from https://files.pythonhosted.org/packages/18/36/60b58b6199547b7b46be03e05508d053162fbce146639bfc65609fa49b23/scikit_learn-1.3.0-cp311-cp311-macosx_12_0_arm64.whl.metadata
  Using cached scikit_learn-1.3.0-cp311-cp311-macosx_12_0_arm64.whl.metadata (11 kB)
Collecting markdown<4,>=3.3 (from mlflow<3.0,>=2.0.1->mosaicml[libcloud,mlflow,wandb]<0.16.2,>=0.15.0->llm-foundry==0.2.0)
  Obtaining dependency information for markdown<4,>=3.3 from https://files.pythonhosted.org/packages/1a/b5/228c1cdcfe138f1a8e01ab1b54284c8b83735476cb22b6ba251656ed13ad/Markdown-3.4.4-py3-none-any.whl.metadata
  Using cached Markdown-3.4.4-py3-none-any.whl.metadata (6.9 kB)
Collecting gunicorn<22 (from mlflow<3.0,>=2.0.1->mosaicml[libcloud,mlflow,wandb]<0.16.2,>=0.15.0->llm-foundry==0.2.0)
  Obtaining dependency information for gunicorn<22 from https://files.pythonhosted.org/packages/0e/2a/c3a878eccb100ccddf45c50b6b8db8cf3301a6adede6e31d48e8531cab13/gunicorn-21.2.0-py3-none-any.whl.metadata
  Using cached gunicorn-21.2.0-py3-none-any.whl.metadata (4.1 kB)
Requirement already satisfied: MarkupSafe>=2.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from jinja2->torch<=2.1.0,>=1.13.1->llm-foundry==0.2.0) (2.1.3)
Requirement already satisfied: certifi in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from oci<3,>=2.88->mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (2023.7.22)
Requirement already satisfied: pyOpenSSL<24.0.0,>=17.5.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from oci<3,>=2.88->mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (23.2.0)
Requirement already satisfied: circuitbreaker<2.0.0,>=1.3.1 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from oci<3,>=2.88->mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (1.4.0)
Requirement already satisfied: tzdata>=2022.1 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from pandas->datasets==2.10.1->llm-foundry==0.2.0) (2023.3)
Requirement already satisfied: bcrypt>=3.1.3 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from paramiko<4,>=2.11.0->mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (4.0.1)
Requirement already satisfied: pynacl>=1.0.1 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from paramiko<4,>=2.11.0->mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (1.5.0)
Requirement already satisfied: six in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from paramiko<4,>=2.11.0->mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (1.16.0)
Requirement already satisfied: wcwidth in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from prompt-toolkit>=3.0.29->mosaicml-cli<1,>=0.3->llm-foundry==0.2.0) (0.2.6)
Requirement already satisfied: idna<4,>=2.5 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from requests>=2.19.0->datasets==2.10.1->llm-foundry==0.2.0) (3.4)
Requirement already satisfied: markdown-it-py>=2.2.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from rich>=12.6.0->mosaicml-cli<1,>=0.3->llm-foundry==0.2.0) (3.0.0)
Requirement already satisfied: pygments<3.0.0,>=2.13.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from rich>=12.6.0->mosaicml-cli<1,>=0.3->llm-foundry==0.2.0) (2.15.1)
Requirement already satisfied: pytorch-ranger>=0.1.1 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from torch-optimizer<0.4,>=0.3.0->mosaicml[libcloud,mlflow,wandb]<0.16.2,>=0.15.0->llm-foundry==0.2.0) (0.1.1)
Requirement already satisfied: torchdata==0.6.1 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from torchtext>=0.10->mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (0.6.1)
Requirement already satisfied: decorator>=3.4.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from validators>=0.20.0->mosaicml-cli<1,>=0.3->llm-foundry==0.2.0) (5.1.1)
Requirement already satisfied: sentry-sdk>=1.0.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from wandb<0.16,>=0.13.2->mosaicml[libcloud,mlflow,wandb]<0.16.2,>=0.15.0->llm-foundry==0.2.0) (1.29.2)
Requirement already satisfied: docker-pycreds>=0.4.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from wandb<0.16,>=0.13.2->mosaicml[libcloud,mlflow,wandb]<0.16.2,>=0.15.0->llm-foundry==0.2.0) (0.4.0)
Requirement already satisfied: pathtools in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from wandb<0.16,>=0.13.2->mosaicml[libcloud,mlflow,wandb]<0.16.2,>=0.15.0->llm-foundry==0.2.0) (0.1.2)
Requirement already satisfied: setproctitle in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from wandb<0.16,>=0.13.2->mosaicml[libcloud,mlflow,wandb]<0.16.2,>=0.15.0->llm-foundry==0.2.0) (1.3.2)
Requirement already satisfied: setuptools in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from wandb<0.16,>=0.13.2->mosaicml[libcloud,mlflow,wandb]<0.16.2,>=0.15.0->llm-foundry==0.2.0) (67.8.0)
Requirement already satisfied: appdirs>=1.4.3 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from wandb<0.16,>=0.13.2->mosaicml[libcloud,mlflow,wandb]<0.16.2,>=0.15.0->llm-foundry==0.2.0) (1.4.4)
Requirement already satisfied: humanfriendly>=9.1 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from coloredlogs->onnxruntime==1.15.1->llm-foundry==0.2.0) (10.0)
Requirement already satisfied: mpmath>=0.19 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from sympy->onnxruntime==1.15.1->llm-foundry==0.2.0) (1.3.0)
Collecting Mako (from alembic!=1.10.0,<2->mlflow<3.0,>=2.0.1->mosaicml[libcloud,mlflow,wandb]<0.16.2,>=0.15.0->llm-foundry==0.2.0)
  Using cached Mako-1.2.4-py3-none-any.whl (78 kB)
Requirement already satisfied: cffi>=1.12 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from cryptography>=2.5->azure-identity>=1.13.0->mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (1.15.1)
Requirement already satisfied: pyjwt>=1.7.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from databricks-cli<1,>=0.8.7->mlflow<3.0,>=2.0.1->mosaicml[libcloud,mlflow,wandb]<0.16.2,>=0.15.0->llm-foundry==0.2.0) (2.8.0)
Collecting oauthlib>=3.1.0 (from databricks-cli<1,>=0.8.7->mlflow<3.0,>=2.0.1->mosaicml[libcloud,mlflow,wandb]<0.16.2,>=0.15.0->llm-foundry==0.2.0)
  Using cached oauthlib-3.2.2-py3-none-any.whl (151 kB)
Collecting Werkzeug>=2.3.7 (from Flask<3->mlflow<3.0,>=2.0.1->mosaicml[libcloud,mlflow,wandb]<0.16.2,>=0.15.0->llm-foundry==0.2.0)
  Obtaining dependency information for Werkzeug>=2.3.7 from https://files.pythonhosted.org/packages/9b/59/a7c32e3d8d0e546a206e0552a2c04444544f15c1da4a01df8938d20c6ffc/werkzeug-2.3.7-py3-none-any.whl.metadata
  Using cached werkzeug-2.3.7-py3-none-any.whl.metadata (4.1 kB)
Collecting itsdangerous>=2.1.2 (from Flask<3->mlflow<3.0,>=2.0.1->mosaicml[libcloud,mlflow,wandb]<0.16.2,>=0.15.0->llm-foundry==0.2.0)
  Using cached itsdangerous-2.1.2-py3-none-any.whl (15 kB)
Collecting click<9,>=7.0 (from mlflow<3.0,>=2.0.1->mosaicml[libcloud,mlflow,wandb]<0.16.2,>=0.15.0->llm-foundry==0.2.0)
  Obtaining dependency information for click<9,>=7.0 from https://files.pythonhosted.org/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl.metadata
  Using cached click-8.1.7-py3-none-any.whl.metadata (3.0 kB)
Collecting blinker>=1.6.2 (from Flask<3->mlflow<3.0,>=2.0.1->mosaicml[libcloud,mlflow,wandb]<0.16.2,>=0.15.0->llm-foundry==0.2.0)
  Using cached blinker-1.6.2-py3-none-any.whl (13 kB)
Requirement already satisfied: gitdb<5,>=4.0.1 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from gitpython<4,>=2.1.0->mlflow<3.0,>=2.0.1->mosaicml[libcloud,mlflow,wandb]<0.16.2,>=0.15.0->llm-foundry==0.2.0) (4.0.10)
Requirement already satisfied: googleapis-common-protos<2.0.dev0,>=1.56.2 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from google-api-core!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0,<3.0.0dev,>=1.31.5->google-cloud-storage>=2.9.0->mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (1.60.0)
Requirement already satisfied: cachetools<6.0,>=2.0.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from google-auth<3.0dev,>=1.25.0->google-cloud-storage>=2.9.0->mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (5.3.1)
Requirement already satisfied: pyasn1-modules>=0.2.1 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from google-auth<3.0dev,>=1.25.0->google-cloud-storage>=2.9.0->mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (0.3.0)
Requirement already satisfied: rsa<5,>=3.1.4 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from google-auth<3.0dev,>=1.25.0->google-cloud-storage>=2.9.0->mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (4.7.2)
Requirement already satisfied: google-crc32c<2.0dev,>=1.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from google-resumable-media>=2.3.2->google-cloud-storage>=2.9.0->mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (1.5.0)
Requirement already satisfied: mdurl~=0.1 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from markdown-it-py>=2.2.0->rich>=12.6.0->mosaicml-cli<1,>=0.3->llm-foundry==0.2.0) (0.1.2)
Requirement already satisfied: portalocker<3,>=1.0 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from msal-extensions<2.0.0,>=0.3.0->azure-identity>=1.13.0->mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (2.7.0)
Collecting joblib>=1.1.1 (from scikit-learn<2->mlflow<3.0,>=2.0.1->mosaicml[libcloud,mlflow,wandb]<0.16.2,>=0.15.0->llm-foundry==0.2.0)
  Obtaining dependency information for joblib>=1.1.1 from https://files.pythonhosted.org/packages/10/40/d551139c85db202f1f384ba8bcf96aca2f329440a844f924c8a0040b6d02/joblib-1.3.2-py3-none-any.whl.metadata
  Using cached joblib-1.3.2-py3-none-any.whl.metadata (5.4 kB)
Collecting threadpoolctl>=2.0.0 (from scikit-learn<2->mlflow<3.0,>=2.0.1->mosaicml[libcloud,mlflow,wandb]<0.16.2,>=0.15.0->llm-foundry==0.2.0)
  Obtaining dependency information for threadpoolctl>=2.0.0 from https://files.pythonhosted.org/packages/81/12/fd4dea011af9d69e1cad05c75f3f7202cdcbeac9b712eea58ca779a72865/threadpoolctl-3.2.0-py3-none-any.whl.metadata
  Using cached threadpoolctl-3.2.0-py3-none-any.whl.metadata (10.0 kB)
Requirement already satisfied: pycparser in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from cffi>=1.12->cryptography>=2.5->azure-identity>=1.13.0->mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (2.21)
Requirement already satisfied: smmap<6,>=3.0.1 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from gitdb<5,>=4.0.1->gitpython<4,>=2.1.0->mlflow<3.0,>=2.0.1->mosaicml[libcloud,mlflow,wandb]<0.16.2,>=0.15.0->llm-foundry==0.2.0) (5.0.0)
Requirement already satisfied: pyasn1<0.6.0,>=0.4.6 in /Users/chuck.tang/miniconda3/lib/python3.11/site-packages (from pyasn1-modules>=0.2.1->google-auth<3.0dev,>=1.25.0->google-cloud-storage>=2.9.0->mosaicml-streaming<0.6,>=0.5.1->llm-foundry==0.2.0) (0.5.0)
Using cached mosaicml_cli-0.4.17-py3-none-any.whl (197 kB)
Using cached transformers-4.31.0-py3-none-any.whl (7.4 MB)
Using cached mlflow-2.6.0-py3-none-any.whl (18.3 MB)
Using cached alembic-1.11.3-py3-none-any.whl (225 kB)
Downloading flask-2.3.3-py3-none-any.whl (96 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 96.1/96.1 kB 14.5 MB/s eta 0:00:00
Using cached click-8.1.7-py3-none-any.whl (97 kB)
Using cached gunicorn-21.2.0-py3-none-any.whl (80 kB)
Using cached Markdown-3.4.4-py3-none-any.whl (94 kB)
Using cached scikit_learn-1.3.0-cp311-cp311-macosx_12_0_arm64.whl (9.4 MB)
Downloading scipy-1.11.2-cp311-cp311-macosx_12_0_arm64.whl (29.6 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 29.6/29.6 MB 25.2 MB/s eta 0:00:00
Downloading SQLAlchemy-2.0.20-cp311-cp311-macosx_11_0_arm64.whl (2.0 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2.0/2.0 MB 30.3 MB/s eta 0:00:00
Using cached joblib-1.3.2-py3-none-any.whl (302 kB)
Using cached threadpoolctl-3.2.0-py3-none-any.whl (15 kB)
Using cached werkzeug-2.3.7-py3-none-any.whl (242 kB)
Building wheels for collected packages: llm-foundry, triton-pre-mlir
  Building editable for llm-foundry (pyproject.toml) ... done
  Created wheel for llm-foundry: filename=llm_foundry-0.2.0-0.editable-py3-none-any.whl size=12336 sha256=0a8192b39fc7cc72c13aa8ec80ecb5278427869cbec6c27afb96715cddaa9d12
  Stored in directory: /private/var/folders/zz/tvyss5c1723dvpbp7kfc9flh0000gp/T/pip-ephem-wheel-cache-o66hbj_f/wheels/7d/f4/3b/271bd378bd71bda54635a671187bca13c71d90f31b8fe28a82
  Building wheel for triton-pre-mlir (setup.py) ... done
  Created wheel for triton-pre-mlir: filename=triton_pre_mlir-2.0.0-cp311-cp311-macosx_13_0_arm64.whl size=990807 sha256=7bd0eb03e78239d1a6ce47d4cc827531905ae01ef9e4da100e8b26b2737f0ed3
  Stored in directory: /private/var/folders/zz/tvyss5c1723dvpbp7kfc9flh0000gp/T/pip-ephem-wheel-cache-o66hbj_f/wheels/a6/68/1c/05feb60feed1556c1b1cb18f356d71b61b2f25ffdb95bdbe3f
Successfully built llm-foundry triton-pre-mlir
Installing collected packages: Werkzeug, threadpoolctl, sqlparse, sqlalchemy, scipy, querystring-parser, oauthlib, markdown, Mako, joblib, itsdangerous, gunicorn, entrypoints, cloudpickle, click, blinker, scikit-learn, Flask, databricks-cli, alembic, triton-pre-mlir, transformers, mlflow, mosaicml-cli, llm-foundry
  Attempting uninstall: click
    Found existing installation: click 8.0.4
    Uninstalling click-8.0.4:
      Successfully uninstalled click-8.0.4
  Attempting uninstall: transformers
    Found existing installation: transformers 4.30.2
    Uninstalling transformers-4.30.2:
      Successfully uninstalled transformers-4.30.2
  Attempting uninstall: mosaicml-cli
    Found existing installation: mosaicml-cli 0.5.7
    Uninstalling mosaicml-cli-0.5.7:
      Successfully uninstalled mosaicml-cli-0.5.7
  Attempting uninstall: llm-foundry
    Found existing installation: llm-foundry 0.2.0
    Uninstalling llm-foundry-0.2.0:
      Successfully uninstalled llm-foundry-0.2.0
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
oci-cli 3.30.1 requires click==8.0.4, but you have click 8.1.7 which is incompatible.
oci-cli 3.30.1 requires PyYAML<=6,>=5.4, but you have pyyaml 6.0.1 which is incompatible.
Successfully installed Flask-2.3.3 Mako-1.2.4 Werkzeug-2.3.7 alembic-1.11.3 blinker-1.6.2 click-8.1.7 cloudpickle-2.2.1 databricks-cli-0.17.7 entrypoints-0.4 gunicorn-21.2.0 itsdangerous-2.1.2 joblib-1.3.2 llm-foundry-0.2.0 markdown-3.4.4 mlflow-2.6.0 mosaicml-cli-0.4.17 oauthlib-3.2.2 querystring-parser-1.2.4 scikit-learn-1.3.0 scipy-1.11.2 sqlalchemy-2.0.20 sqlparse-0.4.4 threadpoolctl-3.2.0 transformers-4.31.0 triton-pre-mlir-2.0.0
```

Install works on gpu:
```

