### PR TITLE
Fix init device in conversion script

### DIFF
--- a/scripts/inference/convert_composer_to_hf.py
+++ b/scripts/inference/convert_composer_to_hf.py
@@ -189,6 +189,7 @@ def convert_composer_to_hf(args: Namespace) -> None:
     print(f'Loading model from {local_folder_path}')
     if config.model_type == 'mpt':
         config.attn_config['attn_impl'] = 'torch'
+        config.init_device = 'cpu'
 
     if config.model_type == 'mpt':
         loaded_hf_model = MPTForCausalLM.from_pretrained(local_folder_path,


### PR DESCRIPTION
The previous refactor of the composer to huggingface conversion script accidentally removed the `init_device='cpu'` line, resulting in checkpoints getting converted with meta tensors for the weights. This PR fixes that and adds a test that would've caught it.