### PR TITLE
MPT: Change order of operands to enable PT2 compile for inference

### DIFF
--- a/llmfoundry/models/mpt/modeling_mpt.py
+++ b/llmfoundry/models/mpt/modeling_mpt.py
@@ -326,9 +326,9 @@ class MPTModel(MPTPreTrainedModel):
                     'output_attentions is not implemented for MPT when using attn_impl `flash` or `triton`.'
                 )
 
-        if (attention_mask is not None and
-                attention_mask[:, 0].sum() != attention_mask.shape[0] and
-                self.training):
+        if (self.training and
+                attention_mask is not None and
+                attention_mask[:, 0].sum() != attention_mask.shape[0]):
             raise NotImplementedError(
                 'MPT does not support training with left padding.')
 


### PR DESCRIPTION
This is a trivial change, which doesn't actually change any logic, but it very helpful to enable PyTorch 2 compile for inference using mpt-based models. 

During compilation, evaluating `attention_mask[:, 0].sum() != attention_mask.shape[0]` seems to cause a bunch of problems because it compares the shape of the tensor to its actual contents, and leads to graph breaks. By changing the ordering of the operands in this if statement, the problem is resolved since `self.training` gets evaluated first and fails, thus preventing the rest from being evaluated. 