### PR TITLE
Fix conversion script to work with checkpoints from composer dev

### DIFF
--- a/llmfoundry/utils/checkpoint_conversion_helpers.py
+++ b/llmfoundry/utils/checkpoint_conversion_helpers.py
@@ -56,11 +56,17 @@ def get_hf_tokenizer_from_composer_state_dict(
         os.makedirs(tokenizer_save_dir, exist_ok=True)
 
         for filename, saved_content in hf_tokenizer_state.items():
+            # For backwards compatibility, check if the filename already has the file extension
+            if filename.endswith(saved_content['file_extension']):
+                tokenizer_file_name = filename
+            else:
+                tokenizer_file_name = filename + saved_content['file_extension']
+
             # This cannot be a temporary directory because huggingface relies on the slow tokenizer file
             # being persistent on disk
             tokenizer_file_path = Path(
                 tokenizer_save_dir
-            ) / f'{filename}{saved_content["file_extension"]}'
+            ) / tokenizer_file_name
             if saved_content['file_extension'] == '.json':
                 with open(tokenizer_file_path, 'w') as _tmp_file:
                     json.dump(saved_content['content'], _tmp_file)

--- a/llmfoundry/utils/checkpoint_conversion_helpers.py
+++ b/llmfoundry/utils/checkpoint_conversion_helpers.py
@@ -64,9 +64,7 @@ def get_hf_tokenizer_from_composer_state_dict(
 
             # This cannot be a temporary directory because huggingface relies on the slow tokenizer file
             # being persistent on disk
-            tokenizer_file_path = Path(
-                tokenizer_save_dir
-            ) / tokenizer_file_name
+            tokenizer_file_path = Path(tokenizer_save_dir) / tokenizer_file_name
             if saved_content['file_extension'] == '.json':
                 with open(tokenizer_file_path, 'w') as _tmp_file:
                     json.dump(saved_content['content'], _tmp_file)


### PR DESCRIPTION
Composer dev changed the HF info in the checkpoint a bit. The composer utility has backwards compat support, but the foundry utility did not (it would've gotten added when we upgraded foundry to the next composer version, but researchers are already training off of dev).

Test on composer dev with change:
`=========================================================================================================== 1 passed, 6 warnings in 4.40s ===========================================================================================================`

Test on composer dev without change:
`FAILED tests/test_hf_conversion_script.py::test_convert_and_generate[mpt] - OSError: /mnt/workdisk/danielking/github/llm-foundry/tokenizer-save-dir-bcv7MW does not appear to have a file named config.json. Checkout 'https://huggingface.co//mnt/workdisk/danielking/github/llm-foundry/tokenizer-save-dir-bcv7MW/None' fo...
=========================================================================================================== 1 failed, 7 warnings in 3.41s ===========================================================================================================`

The unit tests in foundry cover testing on the latest supported composer release.