### PR TITLE
typecast shuffle_block_size because of issue

### DIFF
--- a/llmfoundry/data/text_data.py
+++ b/llmfoundry/data/text_data.py
@@ -112,6 +112,10 @@ class StreamingTextDataset(StreamingDataset):
                         f'local directory {local} does not contain split {split}'
                     )
 
+        # TODO: discover where yamls are being converted incorrect, but temporary workaround
+        if isinstance(shuffle_block_size, float):
+            shuffle_block_size = int(shuffle_block_size)
+
         # Build Dataset
         super().__init__(
             streams=streams,


### PR DESCRIPTION
There is an issue where yamls sometimes interpret shuffle_block_size as a float. Its not clear why this happens and in what cases but this should at least allow working from fresh branches. 