### PR TITLE
install xformers for gpu

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ extra_deps['tensorboard'] = [
 ]
 
 extra_deps['gpu'] = [
+    'xformers==0.0.21',
     'flash-attn==v1.0.3.post0',
     # PyPI does not support direct dependencies, so we remove this line before uploading from PyPI
     'xentropy-cuda-lib@git+https://github.com/HazyResearch/flash-attention.git@v1.0.3#subdirectory=csrc/xentropy',


### PR DESCRIPTION
Address following issue:

```
Xformers is not installed correctly. If you want to use memory_efficient_attention to accelerate training use the following command to install Xformers
pip install xformers.
```