### PR TITLE
Update datasets version to latest

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ install_requires = [
     'transformers>=4.32,<4.33',
     'mosaicml-streaming>=0.5.1,<0.6',
     'torch>=1.13.1,<2.1.1',
-    'datasets==2.10.1',
+    'datasets>=2.14.5,<2.15',
     'fsspec==2023.6.0',  # newer version results in a bug in datasets that duplicates data
     'sentencepiece==0.1.97',
     'einops==0.5.0',


### PR DESCRIPTION
Resolves DatasetGenerationError on csv files

Manual test
Run demonstrating error without datasets update: finetune-mpt-7b-oD6fWG
Run with fix: run-finetune-mpt-7b-uhyogq-mrFqql

Regression testing looks good: https://wandb.ai/mosaic-ml/llm-foundry-regressions/groups/09-11-2023%3A%3A12%3A28%3A53%3A%3A6ac78e6b512751611e31a852da42865bf0755f7d

But does not include the llama reg test bc I don't have permission yet