### PR TITLE
Fix ComposerHFCausalLM instantiation with PeftModel

### DIFF
--- a/llmfoundry/models/hf/hf_causal_lm.py
+++ b/llmfoundry/models/hf/hf_causal_lm.py
@@ -179,6 +179,23 @@ class ComposerHFCausalLM(HuggingFaceModelWithZLoss):
 
             z_loss = om_model_config.get('z_loss', 0.0)
 
+            attention_patch_type = om_model_config.get('attention_patch_type',
+                                                       None)
+            if attention_patch_type is not None:
+                if model.config.model_type != 'llama':
+                    raise ValueError(
+                        f'attention_patch_type is only supported for llama models, but got {model.config.model_type}'
+                    )
+
+                print(
+                    f'Patching llama attention with {attention_patch_type} attention'
+                )
+                from transformers.models.llama.modeling_llama import \
+                    LlamaAttention
+                LlamaAttention.forward = get_llama_attention_patch_fn(
+                    attention_patch_type)
+                model.config.use_cache = False
+
         # elif the model is either a PeftModel or a PreTrainedModel
         elif isinstance(om_model_config, model_types):
             model = om_model_config
@@ -190,21 +207,6 @@ class ComposerHFCausalLM(HuggingFaceModelWithZLoss):
             raise ValueError(
                 f'om_model_config must be either a DictConfig, PeftModel, or PreTrainedModel, but got {type(om_model_config)}'
             )
-
-        attention_patch_type = om_model_config.get('attention_patch_type', None)
-        if attention_patch_type is not None:
-            if model.config.model_type != 'llama':
-                raise ValueError(
-                    f'attention_patch_type is only supported for llama models, but got {model.config.model_type}'
-                )
-
-            print(
-                f'Patching llama attention with {attention_patch_type} attention'
-            )
-            from transformers.models.llama.modeling_llama import LlamaAttention
-            LlamaAttention.forward = get_llama_attention_patch_fn(
-                attention_patch_type)
-            model.config.use_cache = False
 
         composer_model = super().__init__(model=model,
                                           shift_labels=True,

--- a/llmfoundry/models/hf/hf_causal_lm.py
+++ b/llmfoundry/models/hf/hf_causal_lm.py
@@ -16,6 +16,7 @@ from composer.metrics.nlp import (InContextLearningLMAccuracy,
                                   LanguageCrossEntropy, LanguagePerplexity)
 from composer.utils import dist
 from omegaconf import DictConfig
+from torch import nn
 from transformers import (AutoConfig, AutoModelForCausalLM,
                           PreTrainedTokenizerBase)
 
@@ -28,12 +29,9 @@ from llmfoundry.models.utils import init_empty_weights
 try:
     from peft.peft_model import PeftModel
     model_types = PeftModel, transformers.PreTrainedModel
-    _om_model_config_type = Union[DictConfig, PeftModel,
-                                  transformers.PreTrainedModel]
 
 except ImportError:
     model_types = transformers.PreTrainedModel
-    _om_model_config_type = Union[DictConfig, transformers.PreTrainedModel]
 
 __all__ = ['ComposerHFCausalLM']
 
@@ -58,10 +56,10 @@ class ComposerHFCausalLM(HuggingFaceModelWithZLoss):
         tokenizer (PreTrainedTokenizer): The tokenizer that the model will use.
     """
 
-    def __init__(
-            self,
-            om_model_config: _om_model_config_type,  # type: ignore
-            tokenizer: PreTrainedTokenizerBase):
+    def __init__(self, om_model_config: Union[DictConfig,
+                                              transformers.PreTrainedModel,
+                                              nn.Module],
+                 tokenizer: PreTrainedTokenizerBase):
         # set up training and eval metrics
         train_metrics = [
             LanguageCrossEntropy(),

--- a/llmfoundry/models/hf/hf_causal_lm.py
+++ b/llmfoundry/models/hf/hf_causal_lm.py
@@ -62,17 +62,6 @@ class ComposerHFCausalLM(HuggingFaceModelWithZLoss):
             self,
             om_model_config: _om_model_config_type,  # type: ignore
             tokenizer: PreTrainedTokenizerBase):
-
-        if not om_model_config.get('trust_remote_code',
-                                   True) and om_model_config.get(
-                                       'pretrained_model_name_or_path',
-                                       None).startswith('mosaicml/mpt'):
-            raise ValueError(
-                'trust_remote_code must be set to True for MPT models. Without this, the MPT model code will come from the transformers library, '
-                +
-                'which is not significantly slower and not compatible with the LLM foundry training code, rather than the code release by MosaicML.'
-            )
-
         # set up training and eval metrics
         train_metrics = [
             LanguageCrossEntropy(),
@@ -90,6 +79,15 @@ class ComposerHFCausalLM(HuggingFaceModelWithZLoss):
 
         # if we are passed a DictConfig, we need to instantiate the model
         if isinstance(om_model_config, DictConfig):
+            if not om_model_config.get('trust_remote_code',
+                                       True) and om_model_config.get(
+                                           'pretrained_model_name_or_path',
+                                           None).startswith('mosaicml/mpt'):
+                raise ValueError(
+                    'trust_remote_code must be set to True for MPT models. Without this, the MPT model code will come from the transformers library, '
+                    +
+                    'which is not significantly slower and not compatible with the LLM foundry training code, rather than the code release by MosaicML.'
+                )
 
             # load the model config
             trust_remote_code = om_model_config.get('trust_remote_code', True)


### PR DESCRIPTION
ComposerHFCausalLM allows a PeftModel as an argument to `__init__`. This fixes that support by moving code the assumes the arg is a DictConfig to under a conditional

Run with fix (hf-lora-eval-JHvNUf)

Run with error (hf-lora-eval-5yaHeD)
```
╭───────────────────── Traceback (most recent call last) ──────────────────────╮
│ /llm-foundry/scripts/eval/eval.py:407 in <module>                            │
│                                                                              │
│   404 │   cli_cfg = om.from_cli(args_list)                                   │
│   405 │   cfg = om.merge(yaml_cfg, cli_cfg)                                  │
│   406 │   assert isinstance(cfg, DictConfig)                                 │
│ ❱ 407 │   main(cfg)                                                          │
│   408                                                                        │
│                                                                              │
│ /llm-foundry/scripts/eval/eval.py:254 in main                                │
│                                                                              │
│   251 │   composite_scores = None                                            │
│   252 │   for model_cfg in model_configs:                                    │
│   253 │   │   (trainer, logger_keys, eval_gauntlet_callback,                 │
│ ❱ 254 │   │    eval_gauntlet_df) = evaluate_model(                           │
│   255 │   │   │    model_cfg=model_cfg,                                      │
│   256 │   │   │    dist_timeout=dist_timeout,                                │
│   257 │   │   │    run_name=run_name,                                        │
│                                                                              │
│ /llm-foundry/scripts/eval/eval.py:129 in evaluate_model                      │
│                                                                              │
│   126 │   │   │   'Hugging Face models in 8bit.')                            │
│   127 │                                                                      │
│   128 │   if hasattr(model_cfg.model, 'pretrained_lora_id_or_path'):         │
│ ❱ 129 │   │   composer_model = load_peft_model(model_cfg.model, tokenizer,   │
│   130 │   │   │   │   │   │   │   │   │   │    num_retries)                  │
│   131 │   else:                                                              │
│   132 │   │   composer_model = load_model(model_cfg.model, tokenizer, fsdp_c │
│                                                                              │
│ /llm-foundry/scripts/eval/eval.py:64 in load_peft_model                      │
│                                                                              │
│    61 │   │   except Exception as e:                                         │
│    62 │   │   │   retries += 1                                               │
│    63 │   │   │   if retries >= num_retries:                                 │
│ ❱  64 │   │   │   │   raise e                                                │
│    65 │   │   │   else:                                                      │
│    66 │   │   │   │   print(                                                 │
│    67 │   │   │   │   │   f'Got exception {str(e)} while loading model {mode │
│                                                                              │
│ /llm-foundry/scripts/eval/eval.py:58 in load_peft_model                      │
│                                                                              │
│    55 │   │   │   peft_model = PeftModel.from_pretrained(                    │
│    56 │   │   │   │   model, model_cfg.pretrained_lora_id_or_path)           │
│    57 │   │   │                                                              │
│ ❱  58 │   │   │   composer_model_wrapper = COMPOSER_MODEL_REGISTRY[model_cfg │
│    59 │   │   │   │   peft_model, tokenizer)                                 │
│    60 │   │   │   return composer_model_wrapper                              │
│    61 │   │   except Exception as e:                                         │
│                                                                              │
│ /llm-foundry/llmfoundry/models/hf/hf_causal_lm.py:66 in __init__             │
│                                                                              │
│    63 │   │   │   om_model_config: _om_model_config_type,  # type: ignore    │
│    64 │   │   │   tokenizer: PreTrainedTokenizerBase):                       │
│    65 │   │                                                                  │
│ ❱  66 │   │   if not om_model_config.get('trust_remote_code',                │
│    67 │   │   │   │   │   │   │   │      True) and om_model_config.get(      │
│    68 │   │   │   │   │   │   │   │   │      'pretrained_model_name_or_path' │
│    69 │   │   │   │   │   │   │   │   │      None).startswith('mosaicml/mpt' │
│                                                                              │
│ /usr/lib/python3/dist-packages/peft/peft_model.py:410 in __getattr__         │
│                                                                              │
│    407 │   │   try:                                                          │
│    408 │   │   │   return super().__getattr__(name)  # defer to nn.Module's  │
│    409 │   │   except AttributeError:                                        │
│ ❱  410 │   │   │   return getattr(self.base_model, name)                     │
│    411 │                                                                     │
│    412 │   def forward(self, *args: Any, **kwargs: Any):                     │
│    413 │   │   """                                                           │
│                                                                              │
│ /usr/lib/python3/dist-packages/peft/tuners/lora.py:384 in __getattr__        │
│                                                                              │
│    381 │   │   try:                                                          │
│    382 │   │   │   return super().__getattr__(name)  # defer to nn.Module's  │
│    383 │   │   except AttributeError:                                        │
│ ❱  384 │   │   │   return getattr(self.model, name)                          │
│    385 │                                                                     │
│    386 │   def get_peft_config_as_dict(self, inference: bool = False):       │
│    387 │   │   config_dict = {}                                              │
│                                                                              │
│ /usr/lib/python3/dist-packages/torch/nn/modules/module.py:1614 in            │
│ __getattr__                                                                  │
│                                                                              │
│   1611 │   │   │   modules = self.__dict__['_modules']                       │
│   1612 │   │   │   if name in modules:                                       │
│   1613 │   │   │   │   return modules[name]                                  │
│ ❱ 1614 │   │   raise AttributeError("'{}' object has no attribute '{}'".form │
│   1615 │   │   │   type(self).__name__, name))                               │
│   1616 │                                                                     │
│   1617 │   def __setattr__(self, name: str, value: Union[Tensor, 'Module'])  │
╰──────────────────────────────────────────────────────────────────────────────╯
AttributeError: 'GPTNeoForCausalLM' object has no attribute 'get'
```