### PR TITLE
Add comment indicating tokenizer API wrapper is experimental

### DIFF
--- a/llmfoundry/models/inference_api_wrapper/openai_causal_lm.py
+++ b/llmfoundry/models/inference_api_wrapper/openai_causal_lm.py
@@ -30,7 +30,7 @@ MAX_RETRIES = 10
 
 
 class OpenAITokenizerWrapper(AutoTokenizer):
-
+    # this API is experimental and for evaluation only. It is subject to change as we add support for training
     def __init__(self, name: str) -> None:
         try:
             import tiktoken


### PR DESCRIPTION
Per @dakinggg request, clarifying the current version of OpenAI's tokenizer wrapper is experimental and soon to change as we add training support.