### PR TITLE
Run CPU tests on a new dep group `all-cpu`

### DIFF
--- a/.github/workflows/pytest-cpu.yaml
+++ b/.github/workflows/pytest-cpu.yaml
@@ -27,7 +27,7 @@ jobs:
         set -ex
         export PATH=/composer-python:$PATH
         python -m pip install --upgrade 'pip<23' wheel
-        python -m pip install --upgrade .[dev]
+        python -m pip install --upgrade .[all-cpu]
     - name: Run Tests
       id: tests
       run: |

--- a/setup.py
+++ b/setup.py
@@ -106,6 +106,7 @@ extra_deps['openai'] = [
     'tiktoken==0.4.0',
 ]
 extra_deps['all'] = set(dep for deps in extra_deps.values() for dep in deps)
+extra_deps['all-cpu'] = set(dep for key, deps in extra_deps.items() for dep in deps if 'gpu' not in key)
 
 setup(
     name=_PACKAGE_NAME,

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,8 @@ extra_deps['openai'] = [
     'tiktoken==0.4.0',
 ]
 extra_deps['all'] = set(dep for deps in extra_deps.values() for dep in deps)
-extra_deps['all-cpu'] = set(dep for key, deps in extra_deps.items() for dep in deps if 'gpu' not in key)
+extra_deps['all-cpu'] = set(
+    dep for key, deps in extra_deps.items() for dep in deps if 'gpu' not in key)
 
 setup(
     name=_PACKAGE_NAME,

--- a/setup.py
+++ b/setup.py
@@ -105,9 +105,9 @@ extra_deps['openai'] = [
     'openai==0.27.8',
     'tiktoken==0.4.0',
 ]
-extra_deps['all'] = set(dep for deps in extra_deps.values() for dep in deps)
 extra_deps['all-cpu'] = set(
     dep for key, deps in extra_deps.items() for dep in deps if 'gpu' not in key)
+extra_deps['all'] = set(dep for deps in extra_deps.values() for dep in deps)
 
 setup(
     name=_PACKAGE_NAME,


### PR DESCRIPTION
Previously they were running on the `dev` dep group which might skip tests for optional dependencies.