### PR TITLE
Remove non existent named arguments to StreamingDataset

### DIFF
--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -176,8 +176,6 @@ class StreamingFinetuningDataset(StreamingDataset):
             shuffle_seed=shuffle_seed,
             shuffle_block_size=shuffle_block_size,
             sampling_method=sampling_method,
-            sampling_granularity=sampling_granularity,
-            batching_method=batching_method,
         )
 
         self.tokenizer = tokenizer

--- a/llmfoundry/data/text_data.py
+++ b/llmfoundry/data/text_data.py
@@ -147,8 +147,6 @@ class StreamingTextDataset(StreamingDataset):
             shuffle_seed=shuffle_seed,
             shuffle_block_size=shuffle_block_size,
             sampling_method=sampling_method,
-            sampling_granularity=sampling_granularity,
-            batching_method=batching_method,
         )
         self.tokenizer = tokenizer
         self.max_seq_len = max_seq_len


### PR DESCRIPTION
Fixes the following pyright failures:
```
  /Users/irene.dea/llm-foundry/llmfoundry/data/text_data.py:150:13 - error: No parameter named "sampling_granularity" (reportGeneralTypeIssues)
  /Users/irene.dea/llm-foundry/llmfoundry/data/text_data.py:151:13 - error: No parameter named "batching_method" (reportGeneralTypeIssues)
/Users/irene.dea/llm-foundry/llmfoundry/data/finetuning/tasks.py
  /Users/irene.dea/llm-foundry/llmfoundry/data/finetuning/tasks.py:179:13 - error: No parameter named "sampling_granularity" (reportGeneralTypeIssues)
  /Users/irene.dea/llm-foundry/llmfoundry/data/finetuning/tasks.py:180:13 - error: No parameter named "batching_method" (reportGeneralTypeIssues)
```