### PR TITLE
Propagate bias through model

### DIFF
--- a/llmfoundry/models/layers/attention.py
+++ b/llmfoundry/models/layers/attention.py
@@ -419,6 +419,7 @@ class GroupedQueryAttention(nn.Module):
         norm_type: str = 'low_precision_layernorm',
         fc_type: str = 'torch',
         device: Optional[str] = None,
+        no_bias: bool = False,
     ):
         super().__init__()
 
@@ -450,7 +451,9 @@ class GroupedQueryAttention(nn.Module):
             self.softmax_scale = 1 / math.sqrt(self.d_model / self.n_heads)
         self.attn_dropout_p = attn_pdrop
 
-        fc_kwargs = {}
+        fc_kwargs = {
+            'bias': not no_bias,
+        }
         if fc_type != 'te':
             fc_kwargs['device'] = device
         self.Wqkv = FC_CLASS_REGISTRY[fc_type](
@@ -557,6 +560,7 @@ class MultiheadAttention(GroupedQueryAttention):
         norm_type: str = 'low_precision_layernorm',
         fc_type: str = 'torch',
         device: Optional[str] = None,
+        no_bias: bool = False
     ):
         super().__init__(
             d_model=d_model,
@@ -569,7 +573,9 @@ class MultiheadAttention(GroupedQueryAttention):
             attn_pdrop=attn_pdrop,
             norm_type=norm_type,
             fc_type=fc_type,
-            device=device)
+            device=device,
+            no_bias=no_bias,
+        )
 
 
 class MultiQueryAttention(GroupedQueryAttention):
@@ -591,6 +597,7 @@ class MultiQueryAttention(GroupedQueryAttention):
         norm_type: str = 'low_precision_layernorm',
         fc_type: str = 'torch',
         device: Optional[str] = None,
+        no_bias: bool = False
     ):
         super().__init__(
             d_model=d_model,
@@ -603,7 +610,9 @@ class MultiQueryAttention(GroupedQueryAttention):
             attn_pdrop=attn_pdrop,
             norm_type=norm_type,
             fc_type=fc_type,
-            device=device)
+            device=device,
+            no_bias=no_bias,
+        )
 
 
 def attn_bias_shape(

--- a/llmfoundry/models/layers/attention.py
+++ b/llmfoundry/models/layers/attention.py
@@ -548,20 +548,18 @@ class MultiheadAttention(GroupedQueryAttention):
     additive bias.
     """
 
-    def __init__(
-        self,
-        d_model: int,
-        n_heads: int,
-        attn_impl: str = 'triton',
-        clip_qkv: Optional[float] = None,
-        qk_ln: bool = False,
-        softmax_scale: Optional[float] = None,
-        attn_pdrop: float = 0.0,
-        norm_type: str = 'low_precision_layernorm',
-        fc_type: str = 'torch',
-        device: Optional[str] = None,
-        bias: bool = True
-    ):
+    def __init__(self,
+                 d_model: int,
+                 n_heads: int,
+                 attn_impl: str = 'triton',
+                 clip_qkv: Optional[float] = None,
+                 qk_ln: bool = False,
+                 softmax_scale: Optional[float] = None,
+                 attn_pdrop: float = 0.0,
+                 norm_type: str = 'low_precision_layernorm',
+                 fc_type: str = 'torch',
+                 device: Optional[str] = None,
+                 bias: bool = True):
         super().__init__(
             d_model=d_model,
             n_heads=n_heads,

--- a/llmfoundry/models/layers/attention.py
+++ b/llmfoundry/models/layers/attention.py
@@ -5,7 +5,7 @@
 
 import math
 import warnings
-from typing import List, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 
 import torch
 import torch.nn as nn
@@ -451,7 +451,7 @@ class GroupedQueryAttention(nn.Module):
             self.softmax_scale = 1 / math.sqrt(self.d_model / self.n_heads)
         self.attn_dropout_p = attn_pdrop
 
-        fc_kwargs = {
+        fc_kwargs: dict[str, Any] = {
             'bias': bias,
         }
         if fc_type != 'te':

--- a/llmfoundry/models/layers/attention.py
+++ b/llmfoundry/models/layers/attention.py
@@ -548,18 +548,20 @@ class MultiheadAttention(GroupedQueryAttention):
     additive bias.
     """
 
-    def __init__(self,
-                 d_model: int,
-                 n_heads: int,
-                 attn_impl: str = 'triton',
-                 clip_qkv: Optional[float] = None,
-                 qk_ln: bool = False,
-                 softmax_scale: Optional[float] = None,
-                 attn_pdrop: float = 0.0,
-                 norm_type: str = 'low_precision_layernorm',
-                 fc_type: str = 'torch',
-                 device: Optional[str] = None,
-                 bias: bool = True):
+    def __init__(
+        self,
+        d_model: int,
+        n_heads: int,
+        attn_impl: str = 'triton',
+        clip_qkv: Optional[float] = None,
+        qk_ln: bool = False,
+        softmax_scale: Optional[float] = None,
+        attn_pdrop: float = 0.0,
+        norm_type: str = 'low_precision_layernorm',
+        fc_type: str = 'torch',
+        device: Optional[str] = None,
+        bias: bool = True,
+    ):
         super().__init__(
             d_model=d_model,
             n_heads=n_heads,

--- a/llmfoundry/models/layers/attention.py
+++ b/llmfoundry/models/layers/attention.py
@@ -419,7 +419,7 @@ class GroupedQueryAttention(nn.Module):
         norm_type: str = 'low_precision_layernorm',
         fc_type: str = 'torch',
         device: Optional[str] = None,
-        no_bias: bool = False,
+        bias: bool = True,
     ):
         super().__init__()
 
@@ -452,7 +452,7 @@ class GroupedQueryAttention(nn.Module):
         self.attn_dropout_p = attn_pdrop
 
         fc_kwargs = {
-            'bias': not no_bias,
+            'bias': bias,
         }
         if fc_type != 'te':
             fc_kwargs['device'] = device
@@ -560,7 +560,7 @@ class MultiheadAttention(GroupedQueryAttention):
         norm_type: str = 'low_precision_layernorm',
         fc_type: str = 'torch',
         device: Optional[str] = None,
-        no_bias: bool = False
+        bias: bool = True
     ):
         super().__init__(
             d_model=d_model,
@@ -574,7 +574,7 @@ class MultiheadAttention(GroupedQueryAttention):
             norm_type=norm_type,
             fc_type=fc_type,
             device=device,
-            no_bias=no_bias,
+            bias=bias,
         )
 
 
@@ -597,7 +597,7 @@ class MultiQueryAttention(GroupedQueryAttention):
         norm_type: str = 'low_precision_layernorm',
         fc_type: str = 'torch',
         device: Optional[str] = None,
-        no_bias: bool = False
+        bias: bool = True,
     ):
         super().__init__(
             d_model=d_model,
@@ -611,7 +611,7 @@ class MultiQueryAttention(GroupedQueryAttention):
             norm_type=norm_type,
             fc_type=fc_type,
             device=device,
-            no_bias=no_bias,
+            bias=bias,
         )
 
 

--- a/llmfoundry/models/layers/blocks.py
+++ b/llmfoundry/models/layers/blocks.py
@@ -73,7 +73,7 @@ class MPTBlock(nn.Module):
             fc_type=fc_type,
             device=device,
             **attn_config_subset_for_attn_class,
-            no_bias=no_bias,
+            bias=not no_bias,
         )
         self.norm_2 = None
         if not getattr(FFN_CLASS_REGISTRY[ffn_config['ffn_type']], '_has_norm',
@@ -83,6 +83,7 @@ class MPTBlock(nn.Module):
             d_model=d_model,
             expansion_ratio=expansion_ratio,
             device=device,
+            bias=not no_bias,
             **ffn_config,
         )
         self.resid_attn_dropout = nn.Dropout(resid_pdrop)

--- a/llmfoundry/models/layers/blocks.py
+++ b/llmfoundry/models/layers/blocks.py
@@ -26,6 +26,7 @@ class MPTBlock(nn.Module):
         norm_type: str = 'low_precision_layernorm',
         fc_type: str = 'torch',
         device: Optional[str] = None,
+        no_bias: bool = False,
         **kwargs: Any,
     ):
         if attn_config is None:
@@ -66,11 +67,14 @@ class MPTBlock(nn.Module):
         }
 
         self.norm_1 = norm_class(d_model, device=device)
-        self.attn = attn_class(d_model=d_model,
-                               n_heads=n_heads,
-                               fc_type=fc_type,
-                               device=device,
-                               **attn_config_subset_for_attn_class)
+        self.attn = attn_class(
+            d_model=d_model,
+            n_heads=n_heads,
+            fc_type=fc_type,
+            device=device,
+            **attn_config_subset_for_attn_class,
+            no_bias=no_bias,
+        )
         self.norm_2 = None
         if not getattr(FFN_CLASS_REGISTRY[ffn_config['ffn_type']], '_has_norm',
                        False):

--- a/llmfoundry/models/layers/ffn.py
+++ b/llmfoundry/models/layers/ffn.py
@@ -24,9 +24,12 @@ class MPTMLP(nn.Module):
         expansion_ratio: int,
         fc_type: str = 'torch',
         device: Optional[str] = None,
+        no_bias: bool = False,
     ):
         super().__init__()
-        fc_kwargs = {}
+        fc_kwargs = {
+            'bias': not no_bias,
+        }
         if fc_type != 'te':
             fc_kwargs['device'] = device
         self.up_proj = FC_CLASS_REGISTRY[fc_type](
@@ -60,6 +63,7 @@ def build_ffn(
     expansion_ratio: int,
     fc_type: str = 'torch',
     device: Optional[str] = None,
+    no_bias: bool = False,
     **kwargs: Any,
 ) -> nn.Module:
     ffn_type = kwargs.pop('ffn_type')
@@ -72,12 +76,14 @@ def build_ffn(
             expansion_ratio=expansion_ratio,
             fc_type=fc_type,
             device=device,
+            no_bias=no_bias,
         )
     elif ffn_type == 'te_ln_mlp':
         assert te is not None
         return te.LayerNormMLP(
             hidden_size=d_model,
             ffn_hidden_size=d_model * expansion_ratio,
+            bias=not no_bias,
             **kwargs,
         )
 

--- a/llmfoundry/models/layers/ffn.py
+++ b/llmfoundry/models/layers/ffn.py
@@ -27,7 +27,7 @@ class MPTMLP(nn.Module):
         bias: bool = True,
     ):
         super().__init__()
-        fc_kwargs = {
+        fc_kwargs: dict[str, Any] = {
             'bias': bias,
         }
         if fc_type != 'te':

--- a/llmfoundry/models/layers/ffn.py
+++ b/llmfoundry/models/layers/ffn.py
@@ -24,11 +24,11 @@ class MPTMLP(nn.Module):
         expansion_ratio: int,
         fc_type: str = 'torch',
         device: Optional[str] = None,
-        no_bias: bool = False,
+        bias: bool = True,
     ):
         super().__init__()
         fc_kwargs = {
-            'bias': not no_bias,
+            'bias': bias,
         }
         if fc_type != 'te':
             fc_kwargs['device'] = device
@@ -63,7 +63,7 @@ def build_ffn(
     expansion_ratio: int,
     fc_type: str = 'torch',
     device: Optional[str] = None,
-    no_bias: bool = False,
+    bias: bool = True,
     **kwargs: Any,
 ) -> nn.Module:
     ffn_type = kwargs.pop('ffn_type')
@@ -76,14 +76,14 @@ def build_ffn(
             expansion_ratio=expansion_ratio,
             fc_type=fc_type,
             device=device,
-            no_bias=no_bias,
+            bias=bias,
         )
     elif ffn_type == 'te_ln_mlp':
         assert te is not None
         return te.LayerNormMLP(
             hidden_size=d_model,
             ffn_hidden_size=d_model * expansion_ratio,
-            bias=not no_bias,
+            bias=bias,
             **kwargs,
         )
 

--- a/llmfoundry/models/mpt/modeling_mpt.py
+++ b/llmfoundry/models/mpt/modeling_mpt.py
@@ -150,6 +150,11 @@ class MPTModel(MPTPreTrainedModel):
                     log.info(f'Removing bias ({module.bias}) from {module}.')
                     module.register_parameter('bias', None)
 
+                # For transformer engine
+                if hasattr(module, 'use_bias'):
+                    log.info(f'Setting use_bias=False for {module}.')
+                    module.use_bias = False
+
         log.debug(self)
         log.debug(f'Using {self.config.init_config["name"]} initialization.')
 

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ extra_deps['gpu'] = [
     'flash-attn==1.0.9',
     'mosaicml-turbo==0.0.4',
     # PyPI does not support direct dependencies, so we remove this line before uploading from PyPI
-    'xentropy-cuda-lib@git+https://github.com/HazyResearch/flash-attention.git@v1.0.3#subdirectory=csrc/xentropy',
+    'xentropy-cuda-lib@git+https://github.com/HazyResearch/flash-attention.git@v1.0.9#subdirectory=csrc/xentropy',
 ]
 
 extra_deps['peft'] = [


### PR DESCRIPTION
Propagate bias through model. This is needed for fp8 and transformer engine as the current implementation errors

Along for ride: bump flash attn xentropy