### PR TITLE
Add tmp path retention policy

### DIFF
--- a/.github/mcp/mcp_pytest.py
+++ b/.github/mcp/mcp_pytest.py
@@ -86,11 +86,12 @@ if __name__ == '__main__':
     if len(name) > 56:
         name = name[:56]
 
+    clear_tmp_path_flag = '-o tmp_path_retention_policy=none'
     command += f'''
 
     pip install --upgrade --user .[all]
 
-    export COMMON_ARGS="-v --durations=20 -m '{args.pytest_markers}'"
+    export COMMON_ARGS="-v --durations=20 -m '{args.pytest_markers}' {clear_tmp_path_flag}"
 
     make test PYTEST='{args.pytest_command}' EXTRA_ARGS="$COMMON_ARGS --codeblocks"
 

--- a/.github/workflows/pytest-cpu.yaml
+++ b/.github/workflows/pytest-cpu.yaml
@@ -33,7 +33,7 @@ jobs:
       run: |
         set -ex
         export PATH=/composer-python:$PATH
-        export COMMON_ARGS="-v --durations=20 -m '${{ inputs.pytest-markers }}'"
+        export COMMON_ARGS="-v --durations=20 -m '${{ inputs.pytest-markers }}' -o tmp_path_retention_policy=none"
 
         # Necessary to run git diff for doctests
         git config --global --add safe.directory /__w/llm-foundry/llm-foundry


### PR DESCRIPTION
Add tmp path retention policy to none for llm foundry to avoid future pytests from overloading the test runners disk space. 