### PR TITLE
Handle flash_attn version update in transformers main

### DIFF
--- a/llmfoundry/models/layers/llama_attention_monkeypatch.py
+++ b/llmfoundry/models/layers/llama_attention_monkeypatch.py
@@ -186,6 +186,7 @@ def llama_attention_patch_triton(
     past_key_value: Optional[Tuple[torch.Tensor]] = None,
     output_attentions: bool = False,
     use_cache: bool = False,
+    padding_mask: Optional[torch.LongTensor] = None,
 ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
     if use_cache:
         raise NotImplementedError(

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -28,7 +28,6 @@ from llmfoundry.utils.config_utils import (log_config, pop_config,
                                            process_init_device,
                                            update_batch_size_info)
 
-
 def validate_config(cfg: DictConfig):
     """Validates compatible model and dataloader selection."""
     loaders = [cfg.train_loader]


### PR DESCRIPTION
Transformers has a [change](https://github.com/huggingface/transformers/pull/25598) that updates flash_attn to flash_attn 2 for llama models, but this version of flash attn is not compatible with foundry. 

manual test: codellama-34b-r1z1-8-4096-1-Hafr3R
