### PR TITLE
Switch ordering of foundry gpu tests

### DIFF
--- a/.github/mcp/mcp_pytest.py
+++ b/.github/mcp/mcp_pytest.py
@@ -96,7 +96,7 @@ if __name__ == '__main__':
     make test-dist PYTEST='{args.pytest_command}' EXTRA_ARGS="$COMMON_ARGS" WORLD_SIZE=2
 
     make test PYTEST='{args.pytest_command}' EXTRA_ARGS="$COMMON_ARGS --codeblocks"
-    
+
     python -m coverage combine
 
     python -m coverage report

--- a/.github/mcp/mcp_pytest.py
+++ b/.github/mcp/mcp_pytest.py
@@ -93,10 +93,10 @@ if __name__ == '__main__':
 
     export COMMON_ARGS="-v --durations=20 -m '{args.pytest_markers}' {clear_tmp_path_flag}"
 
-    make test PYTEST='{args.pytest_command}' EXTRA_ARGS="$COMMON_ARGS --codeblocks"
-
     make test-dist PYTEST='{args.pytest_command}' EXTRA_ARGS="$COMMON_ARGS" WORLD_SIZE=2
 
+    make test PYTEST='{args.pytest_command}' EXTRA_ARGS="$COMMON_ARGS --codeblocks"
+    
     python -m coverage combine
 
     python -m coverage report


### PR DESCRIPTION
# Description
Fix broken tests on main by switching ordering of distributed vs non distributed tests. 

# Tests
<img width="876" alt="Screenshot 2023-10-09 at 7 35 46 PM" src="https://github.com/mosaicml/llm-foundry/assets/13524881/31d217f1-669f-452c-941b-221b76515cef">

- https://github.com/mosaicml/llm-foundry/actions/runs/6463818510
- https://github.com/mosaicml/llm-foundry/actions/runs/6463818510/job/17547526998#step:6:593 (distributed first)
- https://github.com/mosaicml/llm-foundry/actions/runs/6463818510/job/17547526998#step:6:897 (then single node gpu tests) 
