### PR TITLE
Add test suite for flash attention 2

### DIFF
--- a/.github/workflows/pr-gpu.yaml
+++ b/.github/workflows/pr-gpu.yaml
@@ -32,11 +32,6 @@ jobs:
           container: mosaicml/pytorch:2.1.0_cu121-python3.10-ubuntu20.04
           markers: 'gpu'
           pytest_command: 'coverage run -m pytest'
-          # TODO: After the PR with the flash attention 2 images goes in, add the new unit test suite
-        # - name: 'gpu-2.1.0-flash2'
-        #   container: # UPDATE AFTER THIS PR GOES TO PRODUCTION IMAGE
-        #   markers: 'gpu'
-        #   pytest_command: 'coverage run -m pytest'
     name: ${{ matrix.name }}
     if: github.repository_owner == 'mosaicml'
     with:

--- a/.github/workflows/pr-gpu.yaml
+++ b/.github/workflows/pr-gpu.yaml
@@ -32,6 +32,10 @@ jobs:
           container: mosaicml/pytorch:2.1.0_cu121-python3.10-ubuntu20.04
           markers: 'gpu'
           pytest_command: 'coverage run -m pytest'
+        - name: 'gpu-2.1.0-flash2'
+          container: mosaicml/llm-foundry:2.1.0_cu121_flash2-latest
+          markers: 'gpu'
+          pytest_command: 'coverage run -m pytest'
     name: ${{ matrix.name }}
     if: github.repository_owner == 'mosaicml'
     with:

--- a/.github/workflows/pr-gpu.yaml
+++ b/.github/workflows/pr-gpu.yaml
@@ -32,6 +32,11 @@ jobs:
           container: mosaicml/pytorch:2.1.0_cu121-python3.10-ubuntu20.04
           markers: 'gpu'
           pytest_command: 'coverage run -m pytest'
+        # TODO: After the PR with the flash attention 2 images goes in, add the new unit test suite
+        # - name: 'gpu-2.1.0-flash2'
+        #   container: # UPDATE AFTER THIS PR GOES TO PRODUCTION IMAGE
+        #   markers: 'gpu'
+        #   pytest_command: 'coverage run -m pytest'
     name: ${{ matrix.name }}
     if: github.repository_owner == 'mosaicml'
     with:

--- a/.github/workflows/pr-gpu.yaml
+++ b/.github/workflows/pr-gpu.yaml
@@ -32,7 +32,7 @@ jobs:
           container: mosaicml/pytorch:2.1.0_cu121-python3.10-ubuntu20.04
           markers: 'gpu'
           pytest_command: 'coverage run -m pytest'
-        # TODO: After the PR with the flash attention 2 images goes in, add the new unit test suite
+          # TODO: After the PR with the flash attention 2 images goes in, add the new unit test suite
         # - name: 'gpu-2.1.0-flash2'
         #   container: # UPDATE AFTER THIS PR GOES TO PRODUCTION IMAGE
         #   markers: 'gpu'

--- a/README.md
+++ b/README.md
@@ -93,8 +93,10 @@ If you have success/failure using LLM Foundry on other systems, please let us kn
 |---------------------------|------------------|--------------|-------------------------------|
 | A100-40GB/80GB            | 1.13.1           | 11.7         | :white_check_mark: Supported  |
 | A100-40GB/80GB            | 2.0.1            | 11.7, 11.8   | :white_check_mark: Supported  |
+| A100-40GB/80GB            | 2.1.0            | 11.8, 12.1   | :white_check_mark: Supported  |
 | H100-80GB                 | 1.13.1           | 11.7         | :x: Not Supported             |
 | H100-80GB                 | 2.0.1            | 11.8         | :white_check_mark: Supported  |
+| H100-80GB                 | 2.1.0            | 12.1         | :white_check_mark: Supported  |
 | A10-24GB                  | 1.13.1           | 11.7         | :construction: In Progress    |
 | A10-24GB                  | 2.0.1            | 11.7, 11.8   | :construction: In Progress    |
 | MI250                     | 2.0.1            | ROCm 5.4     | :construction: In Progress    |
@@ -113,8 +115,11 @@ You can select a specific commit hash such as `mosaicml/llm-foundry:1.13.1_cu117
 |-------------------------------------------------------------|----------------|--------------|-------------------------------------|
 | `mosaicml/pytorch:1.13.1_cu117-python3.10-ubuntu20.04`      | 1.13.1         | 11.7         | No                                  |
 | `mosaicml/pytorch:2.0.1_cu118-python3.10-ubuntu20.04`       | 2.0.1          | 11.8         | No                                  |
+| `mosaicml/pytorch:2.0.1_cu121-python3.10-ubuntu20.04`       | 2.1.0          | 12.1         | No                                  |
 | `mosaicml/llm-foundry:1.13.1_cu117-latest`                  | 1.13.1         | 11.7         | Yes                                 |
 | `mosaicml/llm-foundry:2.0.1_cu118-latest`                   | 2.0.1          | 11.8         | Yes                                 |
+| `mosaicml/llm-foundry:2.1.0_cu121-latest`                   | 2.1.0          | 12.1         | Yes (flash attention v1)            |
+| `mosaicml/llm-foundry:2.1.0_cu121_flash2-latest`            | 2.1.0          | 12.1         | Yes (flash attention v2)            |
 
 
 # Installation

--- a/llmfoundry/models/layers/attention.py
+++ b/llmfoundry/models/layers/attention.py
@@ -16,6 +16,7 @@ from torch import nn
 from llmfoundry.models.layers.fc import FC_CLASS_REGISTRY
 from llmfoundry.models.layers.norm import NORM_CLASS_REGISTRY
 
+
 def raise_if_flash_attn_v2():
     flash_attn_version = None
     # This only needs to be in a try except so that huggingface does not try to import it

--- a/llmfoundry/models/layers/attention.py
+++ b/llmfoundry/models/layers/attention.py
@@ -17,17 +17,19 @@ from llmfoundry.models.layers.fc import FC_CLASS_REGISTRY
 from llmfoundry.models.layers.norm import NORM_CLASS_REGISTRY
 
 
-def raise_if_flash_attn_v2():
-    flash_attn_version = None
-    # This only needs to be in a try except so that huggingface does not try to import it
+def is_flash_v2_installed():
     try:
-        from flash_attn import __version__ as flash_attn_version
-        if version.parse(flash_attn_version) >= version.parse('2.0.0'):
-            raise RuntimeError(
-                'flash-attn==2.0.0+ is not supported. Please use flash-attn==1.0.9.'
-            )
+        import flash_attn as flash_attn
     except:
-        pass
+        return False
+    return version.parse(flash_attn.__version__) >= version.parse('2.0.0')
+
+def is_flash_v1_installed():
+    try:
+        import flash_attn as flash_attn
+    except:
+        return False
+    return version.parse(flash_attn.__version__) < version.parse('2.0.0')
 
 def is_flash_v2_installed():
     try:

--- a/llmfoundry/models/layers/attention.py
+++ b/llmfoundry/models/layers/attention.py
@@ -24,6 +24,7 @@ def is_flash_v2_installed():
         return False
     return version.parse(flash_attn.__version__) >= version.parse('2.0.0')
 
+
 def is_flash_v1_installed():
     try:
         import flash_attn as flash_attn

--- a/llmfoundry/models/layers/attention.py
+++ b/llmfoundry/models/layers/attention.py
@@ -32,21 +32,6 @@ def is_flash_v1_installed():
         return False
     return version.parse(flash_attn.__version__) < version.parse('2.0.0')
 
-def is_flash_v2_installed():
-    try:
-        import flash_attn as flash_attn
-    except:
-        return False
-    return version.parse(flash_attn.__version__) >= version.parse('2.0.0')
-
-
-def is_flash_v1_installed():
-    try:
-        import flash_attn as flash_attn
-    except:
-        return False
-    return version.parse(flash_attn.__version__) < version.parse('2.0.0')
-
 
 def _reset_is_causal(num_query_tokens: int, num_key_tokens: int,
                      original_is_causal: bool) -> bool:

--- a/llmfoundry/models/layers/attention.py
+++ b/llmfoundry/models/layers/attention.py
@@ -16,6 +16,17 @@ from torch import nn
 from llmfoundry.models.layers.fc import FC_CLASS_REGISTRY
 from llmfoundry.models.layers.norm import NORM_CLASS_REGISTRY
 
+def raise_if_flash_attn_v2():
+    flash_attn_version = None
+    # This only needs to be in a try except so that huggingface does not try to import it
+    try:
+        from flash_attn import __version__ as flash_attn_version
+        if version.parse(flash_attn_version) >= version.parse('2.0.0'):
+            raise RuntimeError(
+                'flash-attn==2.0.0+ is not supported. Please use flash-attn==1.0.9.'
+            )
+    except:
+        pass
 
 def is_flash_v2_installed():
     try:


### PR DESCRIPTION
I ran the test suite with `make test-dist-gpu` and `make test-gpu` on an interactive with the flash2 image and all tests pass. I won't mark this test suite as required until after this PR merges and I see a successful run on main though.