### PR TITLE
Convert to DataSpec and add token counts that include padding

### DIFF
--- a/llmfoundry/data/denoising.py
+++ b/llmfoundry/data/denoising.py
@@ -355,7 +355,7 @@ def build_text_denoising_dataloader(
     cfg: DictConfig,
     tokenizer: PreTrainedTokenizerBase,
     device_batch_size: int,
-) -> DataLoader[Dict]:
+) -> DataSpec:
     """Constructor function for a Mixture of Denoisers dataloader.
 
     This function constructs a dataloader that can be used to train an

--- a/llmfoundry/data/denoising.py
+++ b/llmfoundry/data/denoising.py
@@ -10,13 +10,15 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Union
 
 import numpy as np
 import torch
+from composer.core.data_spec import DataSpec
 from omegaconf import DictConfig
 from omegaconf import OmegaConf as om
 from torch.utils.data import DataLoader
 from transformers import PreTrainedTokenizerBase
 
 from llmfoundry.data.packing import BinPackWrapper
-from llmfoundry.data.text_data import StreamingTextDataset
+from llmfoundry.data.text_data import (StreamingTextDataset,
+                                       get_tokens_per_batch_func)
 from llmfoundry.models import utils
 
 __all__ = ['MixtureOfDenoisersCollator', 'build_text_denoising_dataloader']
@@ -506,7 +508,7 @@ def build_text_denoising_dataloader(
             'but cfg.dataset.packing_ratio has not been set. Please set ' +\
             'the latter to turn on packing or remove the former from the config.')
 
-    return DataLoader(
+    dl = DataLoader(
         dataset,
         collate_fn=collate_fn,
         batch_size=device_batch_size,
@@ -517,6 +519,11 @@ def build_text_denoising_dataloader(
         persistent_workers=cfg.get('persistent_workers', False),
         timeout=cfg.get('timeout', 0),
     )
+
+    token_counting_func = get_tokens_per_batch_func(
+        pad_token_id=tokenizer.pad_token_id)
+
+    return DataSpec(dataloader=dl, get_num_tokens_in_batch=token_counting_func)
 
 
 def noise_token_sequence(

--- a/llmfoundry/data/denoising.py
+++ b/llmfoundry/data/denoising.py
@@ -874,6 +874,7 @@ if __name__ == '__main__':
 
     loader = build_text_denoising_dataloader(cfg, tokenizer,
                                              device_batch_size).dataloader
+    assert isinstance(loader, DataLoader)
     assert isinstance(loader.dataset, StreamingTextDataset)
 
     print(f'\n\nTRUNCATING TO: {loader.dataset.max_seq_len}\n\n')

--- a/llmfoundry/data/denoising.py
+++ b/llmfoundry/data/denoising.py
@@ -878,8 +878,8 @@ if __name__ == '__main__':
 
     loader = build_text_denoising_dataloader(cfg, tokenizer,
                                              device_batch_size).dataloader
-    assert isinstance(loader.dataset, StreamingTextDataset)
     assert isinstance(loader, DataLoader)
+    assert isinstance(loader.dataset, StreamingTextDataset)
 
     print(f'\n\nTRUNCATING TO: {loader.dataset.max_seq_len}\n\n')
 

--- a/llmfoundry/data/denoising.py
+++ b/llmfoundry/data/denoising.py
@@ -876,7 +876,8 @@ if __name__ == '__main__':
     tokenizer = build_tokenizer(tokenizer_name=tokenizer_name,
                                 tokenizer_kwargs=tokenizer_kwargs)
 
-    loader = build_text_denoising_dataloader(cfg, tokenizer, device_batch_size).dataloader
+    loader = build_text_denoising_dataloader(cfg, tokenizer,
+                                             device_batch_size).dataloader
     assert isinstance(loader.dataset, StreamingTextDataset)
 
     print(f'\n\nTRUNCATING TO: {loader.dataset.max_seq_len}\n\n')

--- a/llmfoundry/data/denoising.py
+++ b/llmfoundry/data/denoising.py
@@ -876,7 +876,7 @@ if __name__ == '__main__':
     tokenizer = build_tokenizer(tokenizer_name=tokenizer_name,
                                 tokenizer_kwargs=tokenizer_kwargs)
 
-    loader = build_text_denoising_dataloader(cfg, tokenizer, device_batch_size)
+    loader = build_text_denoising_dataloader(cfg, tokenizer, device_batch_size).dataloader
     assert isinstance(loader.dataset, StreamingTextDataset)
 
     print(f'\n\nTRUNCATING TO: {loader.dataset.max_seq_len}\n\n')

--- a/llmfoundry/data/denoising.py
+++ b/llmfoundry/data/denoising.py
@@ -17,7 +17,8 @@ from torch.utils.data import DataLoader
 from transformers import PreTrainedTokenizerBase
 
 from llmfoundry.data.packing import BinPackWrapper
-from llmfoundry.data.text_data import StreamingTextDataset
+from llmfoundry.data.text_data import (StreamingTextDataset,
+                                       get_tokens_per_batch_func)
 from llmfoundry.models import utils
 
 __all__ = ['MixtureOfDenoisersCollator', 'build_text_denoising_dataloader']
@@ -354,7 +355,7 @@ def build_text_denoising_dataloader(
     cfg: DictConfig,
     tokenizer: PreTrainedTokenizerBase,
     device_batch_size: int,
-) -> DataSpec:
+) -> DataLoader[Dict]:
     """Constructor function for a Mixture of Denoisers dataloader.
 
     This function constructs a dataloader that can be used to train an
@@ -519,7 +520,10 @@ def build_text_denoising_dataloader(
         timeout=cfg.get('timeout', 0),
     )
 
-    return DataSpec(dataloader=dl)
+    token_counting_func = get_tokens_per_batch_func(
+        pad_token_id=tokenizer.pad_token_id)
+
+    return DataSpec(dataloader=dl, get_num_tokens_in_batch=token_counting_func)
 
 
 def noise_token_sequence(
@@ -872,9 +876,7 @@ if __name__ == '__main__':
     tokenizer = build_tokenizer(tokenizer_name=tokenizer_name,
                                 tokenizer_kwargs=tokenizer_kwargs)
 
-    loader = build_text_denoising_dataloader(cfg, tokenizer,
-                                             device_batch_size).dataloader
-    assert isinstance(loader, DataLoader)
+    loader = build_text_denoising_dataloader(cfg, tokenizer, device_batch_size)
     assert isinstance(loader.dataset, StreamingTextDataset)
 
     print(f'\n\nTRUNCATING TO: {loader.dataset.max_seq_len}\n\n')

--- a/llmfoundry/data/denoising.py
+++ b/llmfoundry/data/denoising.py
@@ -879,6 +879,7 @@ if __name__ == '__main__':
     loader = build_text_denoising_dataloader(cfg, tokenizer,
                                              device_batch_size).dataloader
     assert isinstance(loader.dataset, StreamingTextDataset)
+    assert isinstance(loader, DataLoader)
 
     print(f'\n\nTRUNCATING TO: {loader.dataset.max_seq_len}\n\n')
 

--- a/llmfoundry/data/denoising.py
+++ b/llmfoundry/data/denoising.py
@@ -17,8 +17,7 @@ from torch.utils.data import DataLoader
 from transformers import PreTrainedTokenizerBase
 
 from llmfoundry.data.packing import BinPackWrapper
-from llmfoundry.data.text_data import (StreamingTextDataset,
-                                       get_tokens_per_batch_func)
+from llmfoundry.data.text_data import StreamingTextDataset
 from llmfoundry.models import utils
 
 __all__ = ['MixtureOfDenoisersCollator', 'build_text_denoising_dataloader']
@@ -355,7 +354,7 @@ def build_text_denoising_dataloader(
     cfg: DictConfig,
     tokenizer: PreTrainedTokenizerBase,
     device_batch_size: int,
-) -> DataLoader[Dict]:
+) -> DataSpec:
     """Constructor function for a Mixture of Denoisers dataloader.
 
     This function constructs a dataloader that can be used to train an
@@ -520,10 +519,7 @@ def build_text_denoising_dataloader(
         timeout=cfg.get('timeout', 0),
     )
 
-    token_counting_func = get_tokens_per_batch_func(
-        pad_token_id=tokenizer.pad_token_id)
-
-    return DataSpec(dataloader=dl, get_num_tokens_in_batch=token_counting_func)
+    return DataSpec(dataloader=dl)
 
 
 def noise_token_sequence(
@@ -876,7 +872,8 @@ if __name__ == '__main__':
     tokenizer = build_tokenizer(tokenizer_name=tokenizer_name,
                                 tokenizer_kwargs=tokenizer_kwargs)
 
-    loader = build_text_denoising_dataloader(cfg, tokenizer, device_batch_size).dataloader
+    loader = build_text_denoising_dataloader(cfg, tokenizer,
+                                             device_batch_size).dataloader
     assert isinstance(loader.dataset, StreamingTextDataset)
 
     print(f'\n\nTRUNCATING TO: {loader.dataset.max_seq_len}\n\n')

--- a/llmfoundry/data/denoising.py
+++ b/llmfoundry/data/denoising.py
@@ -521,7 +521,8 @@ def build_text_denoising_dataloader(
     )
 
     token_counting_func = get_tokens_per_batch_func(
-        pad_token_id=tokenizer.pad_token_id)
+        pad_token_id=tokenizer.pad_token_id,
+        decoder_only=cfg.mixture_of_denoisers.decoder_only_format)
 
     return DataSpec(dataloader=dl, get_num_tokens_in_batch=token_counting_func)
 

--- a/llmfoundry/data/finetuning/dataloader.py
+++ b/llmfoundry/data/finetuning/dataloader.py
@@ -449,7 +449,7 @@ if __name__ == '__main__':
     tokenizer = build_tokenizer(tokenizer_name, tokenizer_kwargs)
 
     device_batch_size = 2
-    dataloader = build_finetuning_dataloader(cfg, tokenizer, device_batch_size)
+    dataloader = build_finetuning_dataloader(cfg, tokenizer, device_batch_size).dataloader
 
     packing = cfg.dataset.get('packing_ratio') is not None
 

--- a/llmfoundry/data/finetuning/dataloader.py
+++ b/llmfoundry/data/finetuning/dataloader.py
@@ -6,6 +6,7 @@ from typing import Tuple, Union
 
 import datasets as hf_datasets
 import torch
+from composer.core.data_spec import DataSpec
 from composer.utils import dist, get_file, parse_uri
 from omegaconf import DictConfig
 from torch.utils.data import DataLoader
@@ -14,6 +15,7 @@ from transformers import PreTrainedTokenizerBase
 from llmfoundry.data.finetuning.collator import Seq2SeqFinetuningCollator
 from llmfoundry.data.finetuning.tasks import dataset_constructor
 from llmfoundry.data.packing import BinPackWrapper
+from llmfoundry.data.text_data import get_tokens_per_batch_func
 
 log = logging.getLogger(__name__)
 
@@ -23,7 +25,7 @@ _HF_IGNORE_INDEX = -100
 
 def build_finetuning_dataloader(cfg: DictConfig,
                                 tokenizer: PreTrainedTokenizerBase,
-                                device_batch_size: int) -> DataLoader:
+                                device_batch_size: int) -> DataSpec:
     """Builds a finetuning dataloader for training or evaluating.
 
     The underlying dataset can be built through one of two code paths:
@@ -143,7 +145,7 @@ def build_finetuning_dataloader(cfg: DictConfig,
         collate_fn, dataloader_batch_size = _build_collate_fn(
             cfg.dataset, tokenizer, device_batch_size)
 
-        return DataLoader(
+        dl = DataLoader(
             dataset,
             collate_fn=collate_fn,
             batch_size=dataloader_batch_size,
@@ -193,7 +195,7 @@ def build_finetuning_dataloader(cfg: DictConfig,
                     )
 
         assert dataset is not None
-        return DataLoader(
+        dl = DataLoader(
             dataset,
             collate_fn=collate_fn,
             batch_size=dataloader_batch_size,
@@ -207,6 +209,11 @@ def build_finetuning_dataloader(cfg: DictConfig,
             persistent_workers=cfg.get('persistent_workers', True),
             timeout=cfg.get('timeout', 0),
         )
+
+    token_counting_func = get_tokens_per_batch_func(
+        pad_token_id=tokenizer.pad_token_id)
+
+    return DataSpec(dataloader=dl, get_num_tokens_in_batch=token_counting_func)
 
 
 def _validate_config(dataset_cfg: DictConfig) -> None:

--- a/llmfoundry/data/finetuning/dataloader.py
+++ b/llmfoundry/data/finetuning/dataloader.py
@@ -449,7 +449,8 @@ if __name__ == '__main__':
     tokenizer = build_tokenizer(tokenizer_name, tokenizer_kwargs)
 
     device_batch_size = 2
-    dataloader = build_finetuning_dataloader(cfg, tokenizer, device_batch_size).dataloader
+    dataloader = build_finetuning_dataloader(cfg, tokenizer,
+                                             device_batch_size).dataloader
 
     packing = cfg.dataset.get('packing_ratio') is not None
 

--- a/llmfoundry/data/packing.py
+++ b/llmfoundry/data/packing.py
@@ -377,7 +377,7 @@ if __name__ == '__main__':
     dataloader_cfg.dataset.packing_ratio = None
     dataloader_cfg.dataset.max_leftovers_to_keep = None
     train_dataloader = build_dataloader(dataloader_cfg, tokenizer,
-                                        max(raw_batch_sizes) * 100)
+                                        max(raw_batch_sizes) * 100).dataloader
 
     # Get a bunch of raw examples
     big_batch = next(iter(train_dataloader))

--- a/llmfoundry/data/text_data.py
+++ b/llmfoundry/data/text_data.py
@@ -307,6 +307,15 @@ def build_text_dataloader(
 
 
 def get_tokens_per_batch_func(pad_token_id: int) -> Callable[[Batch], int]:
+    """Returns a callable that counts the number of tokens in a batch.
+
+    Args:
+        pad_token_id (int): The id of the padding token.
+
+    Returns:
+        Callable[[Batch], int]: A callable that counts the number of tokens in a batch.
+    """
+
     def get_num_samples_in_batch(batch: Batch) -> int:
         if not isinstance(batch, Mapping) or 'input_ids' not in batch:
             raise ValueError(

--- a/llmfoundry/data/text_data.py
+++ b/llmfoundry/data/text_data.py
@@ -378,7 +378,7 @@ if __name__ == '__main__':
     tokenizer_kwargs = {'model_max_length': args.max_seq_len}
     tokenizer = build_tokenizer(tokenizer_name, tokenizer_kwargs)
 
-    loader = build_text_dataloader(cfg, tokenizer, device_batch_size)
+    loader = build_text_dataloader(cfg, tokenizer, device_batch_size).dataloader
     assert isinstance(loader.dataset, StreamingTextDataset)
     tokenizer = loader.dataset.tokenizer
 

--- a/llmfoundry/data/text_data.py
+++ b/llmfoundry/data/text_data.py
@@ -321,9 +321,16 @@ def get_tokens_per_batch_func(pad_token_id: int) -> Callable[[Batch], int]:
             raise ValueError(
                 'get_tokens_per_batch_func() requires a batch with an input_ids key'
             )
+        
+         # count number of non padding tokens in batch
+        input_ids_tokens = int(torch.sum(batch['input_ids'] != pad_token_id).item())
 
-        # count number of non padding tokens in batch
-        return int(torch.sum(batch['input_ids'] != pad_token_id).item())
+        # for encoder decoder models only
+        decoder_input_ids_tokens = 0
+        if 'decoder_input_ids' in batch:
+            decoder_input_ids_tokens = int(torch.sum(batch['decoder_input_ids'] != pad_token_id).item())
+
+        return input_ids_tokens + decoder_input_ids_tokens
 
     return get_num_samples_in_batch
 

--- a/llmfoundry/data/text_data.py
+++ b/llmfoundry/data/text_data.py
@@ -11,6 +11,8 @@ from typing import (Any, Callable, Dict, List, Mapping, Optional, Sequence,
 import numpy as np
 import torch
 import transformers
+from composer.core.data_spec import DataSpec
+from composer.core.types import Batch
 from omegaconf import DictConfig
 from omegaconf import OmegaConf as om
 from streaming import Stream, StreamingDataset
@@ -237,7 +239,7 @@ def build_text_dataloader(
     cfg: DictConfig,
     tokenizer: PreTrainedTokenizerBase,
     device_batch_size: int,
-) -> DataLoader:
+) -> DataSpec:
     assert cfg.name == 'text', f'Tried to build text dataloader with cfg.name={cfg.name}'
     if cfg.dataset.get('group_method', None) is not None:
         raise NotImplementedError(
@@ -281,7 +283,7 @@ def build_text_dataloader(
             eos_token_id=eos_token_id,
             bos_token_id=bos_token_id)
 
-    return DataLoader(
+    dl = DataLoader(
         dataset,
         collate_fn=collate_fn,
         batch_size=device_batch_size,
@@ -292,6 +294,29 @@ def build_text_dataloader(
         persistent_workers=cfg.get('persistent_workers', True),
         timeout=cfg.get('timeout', 0),
     )
+
+    # If we pretokenized, we may not have padding, in which the
+    # tokenizer may not have a pad_token_id. In this case, we can
+    # just use the default token counting function.
+    token_counting_func = None
+    if tokenizer.pad_token_id is not None:
+        token_counting_func = get_tokens_per_batch_func(
+            pad_token_id=tokenizer.pad_token_id)
+
+    return DataSpec(dataloader=dl, get_num_tokens_in_batch=token_counting_func)
+
+
+def get_tokens_per_batch_func(pad_token_id: int) -> Callable[[Batch], int]:
+    def get_num_samples_in_batch(batch: Batch) -> int:
+        if not isinstance(batch, Mapping) or 'input_ids' not in batch:
+            raise ValueError(
+                'get_tokens_per_batch_func() requires a batch with an input_ids key'
+            )
+
+        # count number of non padding tokens in batch
+        return int(torch.sum(batch['input_ids'] != pad_token_id).item())
+
+    return get_num_samples_in_batch
 
 
 # Helpful to test if your dataloader is working locally

--- a/llmfoundry/data/text_data.py
+++ b/llmfoundry/data/text_data.py
@@ -322,7 +322,7 @@ def get_tokens_per_batch_func(pad_token_id: int) -> Callable[[Batch], int]:
                 'get_tokens_per_batch_func() requires a batch with an input_ids key'
             )
         
-         # count number of non padding tokens in batch
+         # Count number of non padding tokens in batch
         input_ids_tokens = int(torch.sum(batch['input_ids'] != pad_token_id).item())
 
         # for encoder decoder models only

--- a/llmfoundry/data/text_data.py
+++ b/llmfoundry/data/text_data.py
@@ -325,7 +325,7 @@ def get_tokens_per_batch_func(pad_token_id: int) -> Callable[[Batch], int]:
          # Count number of non padding tokens in batch
         input_ids_tokens = int(torch.sum(batch['input_ids'] != pad_token_id).item())
 
-        # for encoder decoder models only
+        # For encoder decoder models only
         decoder_input_ids_tokens = 0
         if 'decoder_input_ids' in batch:
             decoder_input_ids_tokens = int(torch.sum(batch['decoder_input_ids'] != pad_token_id).item())

--- a/llmfoundry/data/text_data.py
+++ b/llmfoundry/data/text_data.py
@@ -295,9 +295,11 @@ def build_text_dataloader(
         timeout=cfg.get('timeout', 0),
     )
 
-    # If we pretokenized, we may not have padding, in which the
+    # If we pretokenized, we may not have padding, in which case the
     # tokenizer may not have a pad_token_id. In this case, we can
-    # just use the default token counting function.
+    # just use the default token counting function. This is correct
+    # because we do not support training on pretokenized data with padding,
+    # and if tokenizing on the fly, we require that the tokenizer has a pad token.
     token_counting_func = None
     if tokenizer.pad_token_id is not None:
         token_counting_func = get_tokens_per_batch_func(
@@ -306,11 +308,15 @@ def build_text_dataloader(
     return DataSpec(dataloader=dl, get_num_tokens_in_batch=token_counting_func)
 
 
-def get_tokens_per_batch_func(pad_token_id: int) -> Callable[[Batch], int]:
+def get_tokens_per_batch_func(pad_token_id: int,
+                              decoder_only: bool = True
+                             ) -> Callable[[Batch], int]:
     """Returns a callable that counts the number of tokens in a batch.
 
     Args:
         pad_token_id (int): The id of the padding token.
+        decoder_only (bool, optional): Whether to expect the batch to just contain ``input_ids`` (decoder only)
+            or to also contain ``decoder_input_ids`` (encoder decoder). Defaults to ``True``.
 
     Returns:
         Callable[[Batch], int]: A callable that counts the number of tokens in a batch.
@@ -322,13 +328,18 @@ def get_tokens_per_batch_func(pad_token_id: int) -> Callable[[Batch], int]:
                 'get_tokens_per_batch_func() requires a batch with an input_ids key'
             )
 
+        if not decoder_only and 'decoder_input_ids' not in batch:
+            raise ValueError(
+                'get_tokens_per_batch_func() for encoder decoder requires a batch with a decoder_input_ids key'
+            )
+
         # Count number of non padding tokens in batch
         input_ids_tokens = int(
             torch.sum(batch['input_ids'] != pad_token_id).item())
 
         # For encoder decoder models only
         decoder_input_ids_tokens = 0
-        if 'decoder_input_ids' in batch:
+        if not decoder_only:
             decoder_input_ids_tokens = int(
                 torch.sum(batch['decoder_input_ids'] != pad_token_id).item())
 

--- a/llmfoundry/data/text_data.py
+++ b/llmfoundry/data/text_data.py
@@ -321,14 +321,16 @@ def get_tokens_per_batch_func(pad_token_id: int) -> Callable[[Batch], int]:
             raise ValueError(
                 'get_tokens_per_batch_func() requires a batch with an input_ids key'
             )
-        
-         # Count number of non padding tokens in batch
-        input_ids_tokens = int(torch.sum(batch['input_ids'] != pad_token_id).item())
+
+        # Count number of non padding tokens in batch
+        input_ids_tokens = int(
+            torch.sum(batch['input_ids'] != pad_token_id).item())
 
         # For encoder decoder models only
         decoder_input_ids_tokens = 0
         if 'decoder_input_ids' in batch:
-            decoder_input_ids_tokens = int(torch.sum(batch['decoder_input_ids'] != pad_token_id).item())
+            decoder_input_ids_tokens = int(
+                torch.sum(batch['decoder_input_ids'] != pad_token_id).item())
 
         return input_ids_tokens + decoder_input_ids_tokens
 

--- a/llmfoundry/data/text_data.py
+++ b/llmfoundry/data/text_data.py
@@ -379,6 +379,7 @@ if __name__ == '__main__':
     tokenizer = build_tokenizer(tokenizer_name, tokenizer_kwargs)
 
     loader = build_text_dataloader(cfg, tokenizer, device_batch_size).dataloader
+    assert isinstance(loader, DataLoader)
     assert isinstance(loader.dataset, StreamingTextDataset)
     tokenizer = loader.dataset.tokenizer
 

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -142,7 +142,7 @@ def test_correct_padding(tokenizer_name: str,
         test_cfg.eval_loader,
         tokenizer,
         batch_size,
-    )
+    ).dataloader
     batch = next(iter(eval_loader))
 
     assert batch['input_ids'].shape == torch.Size([batch_size, 2048])
@@ -233,7 +233,7 @@ def test_denoising_dataloader(decoder_only_format: bool, pretokenize: bool,
             tokenizer_kwargs={'model_max_length': max_seq_len})
 
         loader = build_text_denoising_dataloader(cfg, tokenizer,
-                                                 device_batch_size)
+                                                 device_batch_size).dataloader
         batch_ix = 0
         for batch in loader:
             for k in expected_keys:
@@ -292,7 +292,7 @@ def test_finetuning_dataloader(decoder_only_format: bool,
     else:
         expected_keys += ['decoder_attention_mask', 'decoder_input_ids']
 
-    loader = build_finetuning_dataloader(cfg, tokenizer, device_batch_size)
+    loader = build_finetuning_dataloader(cfg, tokenizer, device_batch_size).dataloader
     batch_ix = 0
     for batch in loader:
         for k in expected_keys:
@@ -546,7 +546,7 @@ def test_malformed_data(
                                       match='Unable to tokenize example')
 
     with error_context:
-        dl = build_finetuning_dataloader(cfg, tokenizer, device_batch_size)
+        dl = build_finetuning_dataloader(cfg, tokenizer, device_batch_size).dataloader
 
     if not add_bad_data_error:
         # +5 because we added samples with just bos/eos in each of prompt/response

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -567,7 +567,8 @@ def test_malformed_data(
 @pytest.mark.parametrize('padding_side', ['left', 'right'])
 @pytest.mark.parametrize('add_decoder_input_ids', [True, False])
 def test_token_counting_func(pad_token_id: int, batch_size: int,
-                             model_max_length: int, padding_side: str, add_decoder_input_ids: bool):
+                             model_max_length: int, padding_side: str,
+                             add_decoder_input_ids: bool):
     gptt = transformers.AutoTokenizer.from_pretrained('gpt2')
     gptt.pad_token_id = pad_token_id
     gptt.model_max_length = model_max_length
@@ -590,7 +591,9 @@ def test_token_counting_func(pad_token_id: int, batch_size: int,
             decoder_batch_strings.append(' '.join(['hello'] * sample_length))
             decoder_expected_token_count += sample_length
             expected_token_count += sample_length
-        batch_tokenized['decoder_input_ids'] = gptt(decoder_batch_strings, padding=True, return_tensors='pt')['input_ids']
+        batch_tokenized['decoder_input_ids'] = gptt(
+            decoder_batch_strings, padding=True,
+            return_tensors='pt')['input_ids']
 
     token_counting_func = get_tokens_per_batch_func(pad_token_id)
 
@@ -599,8 +602,9 @@ def test_token_counting_func(pad_token_id: int, batch_size: int,
     assert actual_token_count == expected_token_count
 
 
-@pytest.mark.parametrize('dataloader_type',
-                         ['finetuning-hf', 'finetuning-streaming', 'denoising', 'text'])
+@pytest.mark.parametrize(
+    'dataloader_type',
+    ['finetuning-hf', 'finetuning-streaming', 'denoising', 'text'])
 @pytest.mark.parametrize('pad_token_id', [100, None])
 @pytest.mark.parametrize('batch_size', [1, 8])
 @pytest.mark.parametrize('model_max_length', [1024])
@@ -626,9 +630,10 @@ def test_token_counting_func_dataloader_setting(
     batch_tokenized = gptt(batch_strings,
                            padding=True if pad_token_id is not None else False,
                            return_tensors='pt')
-    
+
     if dataloader_type == 'denoising':
-        batch_tokenized['decoder_input_ids'] = batch_tokenized['input_ids'].clone()
+        batch_tokenized['decoder_input_ids'] = batch_tokenized[
+            'input_ids'].clone()
         expected_token_count *= 2
 
     common_args = {

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -292,7 +292,8 @@ def test_finetuning_dataloader(decoder_only_format: bool,
     else:
         expected_keys += ['decoder_attention_mask', 'decoder_input_ids']
 
-    loader = build_finetuning_dataloader(cfg, tokenizer, device_batch_size).dataloader
+    loader = build_finetuning_dataloader(cfg, tokenizer,
+                                         device_batch_size).dataloader
     batch_ix = 0
     for batch in loader:
         for k in expected_keys:
@@ -546,7 +547,8 @@ def test_malformed_data(
                                       match='Unable to tokenize example')
 
     with error_context:
-        dl = build_finetuning_dataloader(cfg, tokenizer, device_batch_size).dataloader
+        dl = build_finetuning_dataloader(cfg, tokenizer,
+                                         device_batch_size).dataloader
 
     if not add_bad_data_error:
         # +5 because we added samples with just bos/eos in each of prompt/response

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -595,7 +595,8 @@ def test_token_counting_func(pad_token_id: int, batch_size: int,
             decoder_batch_strings, padding=True,
             return_tensors='pt')['input_ids']
 
-    token_counting_func = get_tokens_per_batch_func(pad_token_id)
+    token_counting_func = get_tokens_per_batch_func(
+        pad_token_id, decoder_only=not add_decoder_input_ids)
 
     actual_token_count = token_counting_func(batch_tokenized)
 


### PR DESCRIPTION
This PR changes DataLoader to DataSpec in order to provide a non default token counting function that takes into account padding.

Two runs that are the same except that one of them counts tokens with padding and one counts them without.
<img width="1207" alt="Screenshot 2023-10-14 at 8 20 59 PM" src="https://github.com/mosaicml/llm-foundry/assets/43149077/5f3fae85-6c42-47f5-902d-d645ddd47698">
<img width="408" alt="Screenshot 2023-10-14 at 8 21 17 PM" src="https://github.com/mosaicml/llm-foundry/assets/43149077/c0df3222-3cac-4221-97e8-e1d01e543a9a">

- [x] Fix all the places we assume that dataloaders are returned not dataspecs (mostly tests)
- [x] support denoising dataloader too (maybe)
