### PR TITLE
Add Hugging Face model download script

### DIFF
--- a/llmfoundry/utils/__init__.py
+++ b/llmfoundry/utils/__init__.py
@@ -11,8 +11,8 @@ try:
     from llmfoundry.utils.config_utils import (calculate_batch_size_info,
                                                log_config, pop_config,
                                                update_batch_size_info)
-    from llmfoundry.utils.model_download_utils import (download_from_cache_server,
-                                                       download_from_hf_hub)
+    from llmfoundry.utils.model_download_utils import (
+        download_from_cache_server, download_from_hf_hub)
 except ImportError as e:
     raise ImportError(
         'Please make sure to pip install . to get requirements for llm-foundry.'

--- a/llmfoundry/utils/__init__.py
+++ b/llmfoundry/utils/__init__.py
@@ -11,6 +11,8 @@ try:
     from llmfoundry.utils.config_utils import (calculate_batch_size_info,
                                                log_config, pop_config,
                                                update_batch_size_info)
+    from llmfoundry.utils.model_download_utils import (download_from_cache_server,
+                                                       download_from_hf_hub)
 except ImportError as e:
     raise ImportError(
         'Please make sure to pip install . to get requirements for llm-foundry.'
@@ -26,6 +28,8 @@ __all__ = [
     'build_tokenizer',
     'calculate_batch_size_info',
     'convert_and_save_ft_weights',
+    'download_from_cache_server',
+    'download_from_hf_hub',
     'get_hf_tokenizer_from_composer_state_dict',
     'update_batch_size_info',
     'log_config',

--- a/llmfoundry/utils/model_download_utils.py
+++ b/llmfoundry/utils/model_download_utils.py
@@ -27,7 +27,7 @@ log = logging.getLogger(__name__)
 
 def download_from_hf_hub(
     repo_id: str,
-    save_dir: str = None,
+    save_dir: Optional[str] = None,
     prefer_safetensors: bool = True,
     token: Optional[str] = None,
 ):

--- a/llmfoundry/utils/model_download_utils.py
+++ b/llmfoundry/utils/model_download_utils.py
@@ -31,7 +31,10 @@ def download_from_hf_hub(
     prefer_safetensors: bool = True,
     token: Optional[str] = None,
 ):
-    """Downloads the model weights and suppporting files/metadata from a Hugging Face Hub model repo.
+    """Downloads model files from a Hugging Face Hub model repo.
+
+    Only supports models stored in Safetensors and PyTorch formats for now. If both formats are available, only the
+    Safetensors weights will be downloaded unless `prefer_safetensors` is set to False.
 
     Args:
         repo_id (str): The Hugging Face Hub repo ID.
@@ -41,10 +44,6 @@ def download_from_hf_hub(
             available. Defaults to True.
         token (str, optional): The HuggingFace API token. If not provided, the token will be read from the
             `HUGGING_FACE_HUB_TOKEN` environment variable.
-
-    Note:
-        Only supports models stored in Safetensors and PyTorch formats for now. If both formats are available, only the
-        Safetensors weights will be downloaded unless `prefer_safetensors` is set to False.
     """
     repo_files = set(hf_hub.list_repo_files(repo_id))
 
@@ -102,7 +101,7 @@ def _recursive_download(
     save_dir: str,
     ignore_cert: bool = False,
 ):
-    """Downloads all files from a directory on a remote server, including subdirectories.
+    """Downloads all files/subdirectories from a directory on a remote server.
 
     Args:
         session: A requests.Session through which to make requests to the remote server.
@@ -159,7 +158,10 @@ def download_from_cache_server(
     token: Optional[str] = None,
     ignore_cert: bool = False,
 ):
-    """Downloads Hugging Face model files from a file server that mirrors the Hugging Face Hub cache structure.
+    """Downloads Hugging Face models from a mirror file server.
+
+    The file server is expected to store the files in the same structure as the Hugging Face cache
+    structure. See https://huggingface.co/docs/huggingface_hub/guides/manage-cache.
 
     Args:
         model_name: The name of the model to download. This should be the same as the repository ID in the Hugging Face
@@ -182,7 +184,6 @@ def download_from_cache_server(
 
         # Only downloads the blobs in order to avoid downloading model files twice due to the
         # symlnks in the Hugging Face cache structure:
-        # https://huggingface.co/docs/huggingface_hub/guides/manage-cache
         _recursive_download(
             session,
             cache_base_url,

--- a/llmfoundry/utils/model_download_utils.py
+++ b/llmfoundry/utils/model_download_utils.py
@@ -143,7 +143,6 @@ def _recursive_download(
         ValueError: If the remote server returns a 404 Not Found status code.
         RuntimeError: If the remote server returns a status code other than 200 OK or 401 Unauthorized.
     """
-
     url = urljoin(base_url, path)
     response = session.get(url, verify=(not ignore_cert))
 

--- a/llmfoundry/utils/model_download_utils.py
+++ b/llmfoundry/utils/model_download_utils.py
@@ -10,6 +10,7 @@ import time
 
 from typing import Optional
 from http import HTTPStatus
+from urllib.parse import urljoin
 
 from bs4 import BeautifulSoup
 import huggingface_hub as hf_hub
@@ -130,7 +131,8 @@ def _recursive_download(
         PermissionError: If the remote server returns a 401 Unauthorized status code.
         RuntimeError: If the remote server returns a status code other than 200 OK or 401 Unauthorized.
     """
-    url = f'{base_url}/{path}'
+
+    url = urljoin(base_url, path)
     response = session.get(url, verify=(not ignore_cert))
 
     if response.status_code == HTTPStatus.UNAUTHORIZED:
@@ -144,7 +146,7 @@ def _recursive_download(
 
     # Assume that the URL points to a file if it does not end with a slash.
     if not path.endswith('/'):
-        save_path = f'{save_dir}/{path}'
+        save_path = os.path.join(save_dir, path)
         parent_dir = os.path.dirname(save_path)
         if not os.path.exists(parent_dir):
             os.makedirs(parent_dir)
@@ -160,7 +162,7 @@ def _recursive_download(
     child_links = _extract_links_from_html(response.content.decode())
     for child_link in child_links:
         _recursive_download(
-            session, base_url, f'{path}/{child_link}', save_dir, ignore_cert=ignore_cert
+            session, base_url, urljoin(path, child_link), save_dir, ignore_cert=ignore_cert
         )
 
 

--- a/llmfoundry/utils/model_download_utils.py
+++ b/llmfoundry/utils/model_download_utils.py
@@ -1,0 +1,195 @@
+"""Utility functions for downloading models.
+
+Copyright 2022 MosaicML LLM Foundry authors
+SPDX-License-Identifier: Apache-2.0
+"""
+import logging
+import os
+import time
+
+from typing import Optional
+from http import HTTPStatus
+
+from bs4 import BeautifulSoup
+import huggingface_hub as hf_hub
+import requests
+from transformers.utils import (
+    WEIGHTS_NAME as PYTORCH_WEIGHTS_NAME,
+    WEIGHTS_INDEX_NAME as PYTORCH_WEIGHTS_INDEX_NAME,
+    SAFE_WEIGHTS_NAME,
+    SAFE_WEIGHTS_INDEX_NAME,
+)
+
+PYTORCH_WEIGHTS_PATTERN = "pytorch_model*.bin*"
+SAFE_WEIGHTS_PATTERN = "model*.safetensors*"
+
+
+def download_from_hf_hub(
+    repo_id: str,
+    save_dir: str = None,
+    prefer_safetensors: bool = True,
+    token: Optional[str] = None,
+):
+    """Downloads the model weights and suppporting files/metadata from a Hugging Face Hub model repo.
+
+    Only supports models stored in Safetensors and PyTorch formats for now. If both formats are available, only the
+    Safetensors weights will be downloaded unless `prefer_safetensors` is set to False.
+
+    Args:
+        repo_id (str): The Hugging Face Hub repo ID.
+        save_dir (str, optional): The path to the directory where the model files will be downloaded. If `None`, reads
+            from the `HUGGINGFACE_HUB_CACHE` environment variable or uses the default Hugging Face Hub cache directory.
+        prefer_safetensors (bool): Whether to prefer Safetensors weights over PyTorch weights if both are
+            available. Defaults to True.
+        token (str, optional): The HuggingFace API token. If not provided, the token will be read from the
+            `HUGGING_FACE_HUB_TOKEN` environment variable.
+    """
+    repo_files = set(hf_hub.list_repo_files(repo_id))
+
+    # Ignore TensorFlow, TensorFlow 2, and Flax weights as they are not supported by Composer.
+    ignore_patterns = [
+        "*.ckpt",
+        "*.h5",
+        "*.msgpack",
+    ]
+
+    if (
+        SAFE_WEIGHTS_NAME in repo_files or SAFE_WEIGHTS_INDEX_NAME in repo_files
+    ) and prefer_safetensors:
+        logging.info("Safetensors found and preferred. Excluding pytorch files")
+        ignore_patterns.append(PYTORCH_WEIGHTS_PATTERN)
+    elif PYTORCH_WEIGHTS_NAME in repo_files or PYTORCH_WEIGHTS_INDEX_NAME in repo_files:
+        logging.info(
+            "Safetensors not found or prefer_safetensors is False. Excluding safetensors files"
+        )
+        ignore_patterns.append(SAFE_WEIGHTS_PATTERN)
+    else:
+        raise ValueError(
+            f"No supported model weights found in repo {repo_id}."
+            + " Please make sure the repo contains either safetensors or pytorch weights."
+        )
+
+    download_start = time.time()
+    hf_hub.snapshot_download(
+        repo_id, cache_dir=save_dir, ignore_patterns=ignore_patterns, token=token
+    )
+    download_duration = time.time() - download_start
+    logging.info(
+        f"Downloaded model {repo_id} from Hugging Face Hub in {download_duration} seconds"
+    )
+
+
+def _extract_links_from_html(html: str):
+    """Extracts links from HTML content.
+
+    Args:
+        html (str): The HTML content
+
+    Returns:
+        list[str]: A list of links to download.
+    """
+    soup = BeautifulSoup(html, "html.parser")
+    links = [a["href"] for a in soup.find_all("a")]
+    return links
+
+
+def _recursive_download(
+    session: requests.Session,
+    base_url: str,
+    path: str,
+    save_dir: str,
+    ignore_cert: bool = False,
+):
+    """Downloads all files from a directory on a remote server, including subdirectories.
+
+    Args:
+        session: A requests.Session through which to make requests to the remote server.
+        url (str): The base URL where the files are located.
+        path (str): The path from the base URL to the files to download. The full URL for the download is equal to
+            '<base_url>/<path>'.
+        save_dir (str): The directory to save downloaded files to.
+        ignore_cert (bool): Whether or not to ignore the validity of the SSL certificate of the remote server.
+            Defaults to False.
+            WARNING: Setting this to true is *not* secure, as no certificate verification will be performed.
+    Raises:
+        PermissionError: If the remote server returns a 401 Unauthorized status code.
+        RuntimeError: If the remote server returns a status code other than 200 OK or 401 Unauthorized.
+    """
+    url = f"{base_url}/{path}"
+    response = session.get(url, verify=(not ignore_cert))
+
+    if response.status_code == HTTPStatus.UNAUTHORIZED:
+        raise PermissionError(
+            f"Not authorized to download file from {url}. Received status code {response.status_code}. "
+        )
+    elif response.status_code != HTTPStatus.OK:
+        raise RuntimeError(
+            f"Could not download file from {url}. Received unexpected status code {response.status_code}"
+        )
+
+    # Assume that the URL points to a file if it does not end with a slash.
+    if not path.endswith("/"):
+        save_path = f"{save_dir}/{path}"
+        parent_dir = os.path.dirname(save_path)
+        if not os.path.exists(parent_dir):
+            os.makedirs(parent_dir)
+
+        with open(save_path, "wb") as f:
+            f.write(response.content)
+
+            logging.info(f"Downloaded file {save_path}")
+            return
+
+    # If the URL is a directory, the response should be an HTML directory listing that we can parse for additional links
+    # to download.
+    child_links = _extract_links_from_html(response.content.decode())
+    for child_link in child_links:
+        _recursive_download(
+            session, base_url, f"{path}/{child_link}", save_dir, ignore_cert=ignore_cert
+        )
+
+
+def download_from_cache_server(
+    model_name: str,
+    cache_base_url: str,
+    save_dir: str,
+    token: Optional[str] = None,
+    ignore_cert: bool = False,
+):
+    """Downloads Hugging Face model files from a file server that mirrors the Hugging Face Hub cache structure.
+
+    This function will attempt to download all of the blob files from `<cache_base_url>/<formatted_model_name>/blobs/`
+    on the remote cache file server, where `formatted_model_name` is equal to `models/<model_name>` with all slashes
+    replaced with `--`.
+
+    It only downloads the blobs in order to avoid downloading model files twice due to the symlink structure of the
+    Hugging Face cache.
+    For details on the cache structure: https://huggingface.co/docs/huggingface_hub/guides/manage-cache
+
+    Args:
+        model_name: The name of the model to download. This should be the same as the repository ID in the Hugging Face
+            Hub.
+        cache_base_url: The base URL of the cache file server.
+        save_dir: The directory to save the downloaded files to.
+        token: The Hugging Face API token. If not provided, the token will be read from the `HUGGING_FACE_HUB_TOKEN`
+            environment variable.
+        ignore_cert: Whether or not to ignore the validity of the SSL certificate of the remote server. Defaults to
+            False.
+            WARNING: Setting this to true is *not* secure, as no certificate verification will be performed.
+    """
+    formatted_model_name = f"models/{model_name}".replace("/", "--")
+    with requests.Session() as session:
+        session.headers.update({"Authorization": f"Bearer {token}"})
+
+        download_start = time.time()
+        _recursive_download(
+            session,
+            cache_base_url,
+            f"{formatted_model_name}/blobs/",  # Trailing slash to indicate directory
+            save_dir,
+            ignore_cert=ignore_cert,
+        )
+        download_duration = time.time() - download_start
+        logging.info(
+            f"Downloaded model {model_name} from cache server in {download_duration} seconds"
+        )

--- a/llmfoundry/utils/model_download_utils.py
+++ b/llmfoundry/utils/model_download_utils.py
@@ -3,13 +3,13 @@
 Copyright 2022 MosaicML LLM Foundry authors
 SPDX-License-Identifier: Apache-2.0
 """
+from typing import Optional
+
 import copy
+from http import HTTPStatus
 import logging
 import os
 import time
-
-from typing import Optional
-from http import HTTPStatus
 from urllib.parse import urljoin
 
 from bs4 import BeautifulSoup

--- a/scripts/misc/download_hf_model.py
+++ b/scripts/misc/download_hf_model.py
@@ -3,17 +3,17 @@
 Copyright 2022 MosaicML LLM Foundry authors
 SPDX-License-Identifier: Apache-2.0
 """
+import argparse
 import logging
 import os
 import sys
 
-import argparse
+from huggingface_hub.constants import HUGGINGFACE_HUB_CACHE
 
 from llmfoundry.utils.model_download_utils import (
     download_from_cache_server,
     download_from_hf_hub,
 )
-from huggingface_hub.constants import HUGGINGFACE_HUB_CACHE
 
 HF_TOKEN_ENV_VAR = 'HUGGING_FACE_HUB_TOKEN'
 

--- a/scripts/misc/download_hf_model.py
+++ b/scripts/misc/download_hf_model.py
@@ -149,7 +149,7 @@ def _recursive_download(
 
     # If the URL is a directory, the response should be an HTML directory listing that we can parse for additional links
     # to download.
-    child_links = _extract_links_from_html(response.content)
+    child_links = _extract_links_from_html(response.content.decode())
     for child_link in child_links:
         _recursive_download(
             session, base_url, f"{path}/{child_link}", save_dir, ignore_cert=ignore_cert

--- a/scripts/misc/download_hf_model.py
+++ b/scripts/misc/download_hf_model.py
@@ -25,8 +25,10 @@ if __name__ == '__main__':
     argparser.add_argument(
         '--download-from', type=str, choices=['hf', 'cache'], default='hf'
     )
-    argparser.add_argument('--token', type=str, default=os.getenv(HF_TOKEN_ENV_VAR))
-    argparser.add_argument('--save-dir', type=str, default=HUGGINGFACE_HUB_CACHE)
+    argparser.add_argument('--token', type=str,
+                           default=os.getenv(HF_TOKEN_ENV_VAR))
+    argparser.add_argument('--save-dir', type=str,
+                           default=HUGGINGFACE_HUB_CACHE)
     argparser.add_argument('--cache-url', type=str, default=None)
     argparser.add_argument('--ignore-cert', action='store_true', default=False)
     argparser.add_argument(
@@ -38,7 +40,8 @@ if __name__ == '__main__':
 
     args = argparser.parse_args(sys.argv[1:])
     if args.download_from == 'hf':
-        download_from_hf_hub(args.model, save_dir=args.save_dir, token=args.token)
+        download_from_hf_hub(
+            args.model, save_dir=args.save_dir, token=args.token)
     else:
         try:
             download_from_cache_server(

--- a/scripts/misc/download_hf_model.py
+++ b/scripts/misc/download_hf_model.py
@@ -1,0 +1,245 @@
+"""Download functions for Hugging Face models.
+
+TODO(jerry): Add better logging throughout
+TODO(jerry): Track download metrics
+"""
+import os
+import sys
+import time
+
+import argparse
+from typing import Optional
+from http import HTTPStatus
+from bs4 import BeautifulSoup
+
+import huggingface_hub as hf_hub
+import requests
+
+# Constants derived from https://github.com/huggingface/transformers/blob/main/src/transformers/utils/__init__.py
+PYTORCH_WEIGHTS_NAME = "pytorch_model.bin"
+PYTORCH_WEIGHTS_INDEX_NAME = "pytorch_model.bin.index.json"
+PYTORCH_WEIGHTS_PATTERN = "pytorch_model*.bin*"
+
+SAFETENSORS_WEIGHTS_NAME = "model.safetensors"
+SAFETENSORS_WEIGHTS_INDEX_NAME = "model.safetensors.index.json"
+SAFETENSORS_EXCLUDE_PATTERN = "model*.safetensors*"
+
+DEFAULT_HF_HUB_CACHE_DIR = os.getenv(
+    "HUGGINGFACE_HUB_CACHE", os.path.expanduser("~/.cache/huggingface/hub")
+)
+
+
+def download_from_hf_hub(
+    repo_id: str,
+    save_dir: Optional[str] = None,
+    prefer_safetensors: bool = True,
+    token: Optional[str] = None,
+):
+    """Downloads the model weights and suppporting files/metadata from a Hugging Face Hub model repo.
+
+    Only supports models stored in Safetensors and PyTorch formats for now. If both formats are available, only the
+    Safetensors weights will be downloaded unless `prefer_safetensors` is set to False.
+
+    Args:
+        repo_id (str): The Hugging Face Hub repo ID.
+        save_dir (str, optional): The path to the directory where the model files will be downloaded. If `None`, reads
+            from the `HUGGINGFACE_HUB_CACHE` environment variable or uses the default Hugging Face Hub cache directory.
+        prefer_safetensors (bool): Whether to prefer Safetensors weights over PyTorch weights if both are
+            available. Defaults to True.
+        token (str, optional): The HuggingFace API token. If not provided, the token will be read from the
+            `HUGGING_FACE_HUB_TOKEN` environment variable.
+    """
+    repo_files = set(hf_hub.list_repo_files(repo_id))
+
+    # Ignore TensorFlow, TensorFlow 2, and Flax weights as they are not supported by Composer.
+    ignore_patterns = [
+        "*.ckpt",
+        "*.h5",
+        "*.msgpack",
+    ]
+
+    if (
+        SAFETENSORS_WEIGHTS_NAME in repo_files
+        or SAFETENSORS_WEIGHTS_INDEX_NAME in repo_files
+    ) and prefer_safetensors:
+        print("Safetensors found and preferred. Excluding pytorch files")
+        ignore_patterns.append(PYTORCH_WEIGHTS_PATTERN)
+    elif PYTORCH_WEIGHTS_NAME in repo_files or PYTORCH_WEIGHTS_INDEX_NAME in repo_files:
+        print(
+            "Safetensors not found or prefer_safetensors is False. Excluding safetensors files"
+        )
+        ignore_patterns.append(SAFETENSORS_EXCLUDE_PATTERN)
+    else:
+        raise ValueError(
+            f"No supported model weights found in repo {repo_id}."
+            "Please make sure the repo contains either safetensors or pytorch weights."
+        )
+
+    download_start = time.time()
+    hf_hub.snapshot_download(
+        repo_id, cache_dir=save_dir, ignore_patterns=ignore_patterns, token=token
+    )
+    download_duration = time.time() - download_start
+    print(
+        f"Downloaded model {repo_id} from Hugging Face Hub in {download_duration} seconds"
+    )
+
+
+def _extract_links_from_html(html: str):
+    """Extracts links from HTML content.
+
+    Args:
+        html (str): The HTML content
+
+    Returns:
+        list[str]: A list of links to download.
+    """
+    soup = BeautifulSoup(html, "html.parser")
+    links = [a["href"] for a in soup.find_all("a")]
+    return links
+
+
+def _recursive_download(
+    session: requests.Session,
+    base_url: str,
+    path: str,
+    save_dir: str,
+    ignore_cert: bool = False,
+):
+    """Downloads all files from a directory on a remote server, including subdirectories.
+
+    Args:
+        session: A requests.Session through which to make requests to the remote server.
+        url (str): The base URL where the files are located.
+        path (str): The path from the base URL to the files to download. The full URL for the download is equal to
+            '<base_url>/<path>'.
+        save_dir (str): The directory to save downloaded files to.
+        ignore_cert (bool): Whether or not to ignore the validity of the SSL certificate of the remote server.
+            Defaults to False.
+            WARNING: Setting this to true is *not* secure, as no certificate verification will be performed.
+    Raises:
+        PermissionError: If the remote server returns a 401 Unauthorized status code.
+        RuntimeError: If the remote server returns a status code other than 200 OK or 401 Unauthorized.
+    """
+    url = f"{base_url}/{path}"
+    response = session.get(url, verify=(not ignore_cert))
+
+    if response.status_code == HTTPStatus.UNAUTHORIZED:
+        raise PermissionError(
+            f"Could not download file from {url}. Received status code {response.status_code}. "
+            + "Please check that your token is valid and try again."
+        )
+    elif response.status_code != HTTPStatus.OK:
+        raise RuntimeError(
+            f"Could not download file from {url}. Received status code {response.status_code}"
+        )
+
+    # Assume that the URL points to a file if it does not end with a slash.
+    if not path.endswith("/"):
+        save_path = f"{save_dir}/{path}"
+        parent_dir = os.path.dirname(save_path)
+        if not os.path.exists(parent_dir):
+            os.makedirs(parent_dir)
+
+        with open(save_path, "wb") as f:
+            f.write(response.content)
+
+            print(f"Downloaded file {save_path}")
+            return
+
+    # If the URL is a directory, the response should be an HTML directory listing that we can parse for additional links
+    # to download.
+    child_links = _extract_links_from_html(response.content)
+    for child_link in child_links:
+        _recursive_download(
+            session, base_url, f"{path}/{child_link}", save_dir, ignore_cert=ignore_cert
+        )
+
+
+def download_from_cache_server(
+    model_name: str,
+    cache_base_url: str,
+    save_dir: str,
+    token: Optional[str] = None,
+    ignore_cert: bool = False,
+):
+    """Downloads Hugging Face model files from a file server that mirrors the Hugging Face Hub cache structure.
+
+    This function will attempt to download all of the blob files from `<cache_base_url>/<formatted_model_name>/blobs/`
+    on the remote cache file server, where `formatted_model_name` is equal to `models/<model_name>` with all slashes
+    replaced with `--`.
+
+    It only downloads the blobs in order to avoid downloading model files twice due to the symlink structure of the
+    Hugging Face cache.
+    For details on the cache structure: https://huggingface.co/docs/huggingface_hub/guides/manage-cache
+
+    Args:
+        model_name: The name of the model to download. This should be the same as the repository ID in the Hugging Face
+            Hub.
+        cache_base_url: The base URL of the cache file server.
+        save_dir: The directory to save the downloaded files to.
+        token: The HuggingFace API token. If not provided, the token will be read from the `HUGGING_FACE_HUB_TOKEN`
+            environment variable.
+        ignore_cert: Whether or not to ignore the validity of the SSL certificate of the remote server. Defaults to
+            False.
+            WARNING: Setting this to true is *not* secure, as no certificate verification will be performed.
+    """
+    formatted_model_name = f"models/{model_name}".replace("/", "--")
+    with requests.Session() as session:
+        session.headers.update({"Authorization": f"Bearer {token}"})
+
+        download_start = time.time()
+        _recursive_download(
+            session,
+            cache_base_url,
+            f"{formatted_model_name}/blobs/",  # Trailing slash to indicate directory
+            save_dir,
+            ignore_cert=ignore_cert,
+        )
+        download_duration = time.time() - download_start
+        print(
+            f"Downloaded model {model_name} from cache server in {download_duration} seconds"
+        )
+
+
+if __name__ == "__main__":
+    argparser = argparse.ArgumentParser()
+    argparser.add_argument("--model", type=str, required=True)
+    argparser.add_argument(
+        "--download-from", type=str, choices=["hf", "cache"], default="hf"
+    )
+    argparser.add_argument("--save-dir", type=str, default=DEFAULT_HF_HUB_CACHE_DIR)
+    argparser.add_argument("--cache-url", type=str, default=None)
+    argparser.add_argument("--token", type=str, default=None)
+    argparser.add_argument("--ignore-cert", action="store_true", default=False)
+    argparser.add_argument(
+        "--fallback",
+        action="store_true",
+        default=False,
+        help="Whether to fallback to downloading from Hugging Face if download from cache fails",
+    )
+
+    args = argparser.parse_args(sys.argv[1:])
+    if args.download_from == "hf":
+        download_from_hf_hub(args.model, save_dir=args.save_dir, token=args.token)
+    else:
+        try:
+            download_from_cache_server(
+                args.model,
+                args.cache_url,
+                args.save_dir,
+                token=args.token,
+                ignore_cert=args.ignore_cert,
+            )
+        except PermissionError:
+            print(f"Not authorized to download {args.model}.")
+        except Exception as e:
+            if args.fallback:
+                print(
+                    f"Failed to download from cache server. Falling back to Hugging Face Hub. Error: {e}"
+                )
+                download_from_hf_hub(
+                    args.model, save_dir=args.save_dir, token=args.token
+                )
+            else:
+                raise e

--- a/scripts/misc/download_hf_model.py
+++ b/scripts/misc/download_hf_model.py
@@ -1,8 +1,7 @@
-"""Script to download model weights from Hugging Face Hub or a cache server.
+# Copyright 2022 MosaicML LLM Foundry authors
+# SPDX-License-Identifier: Apache-2.0
 
-Copyright 2022 MosaicML LLM Foundry authors
-SPDX-License-Identifier: Apache-2.0
-"""
+"""Script to download model weights from Hugging Face Hub or a cache server."""
 import argparse
 import logging
 import os
@@ -10,10 +9,8 @@ import sys
 
 from huggingface_hub.constants import HUGGINGFACE_HUB_CACHE
 
-from llmfoundry.utils.model_download_utils import (
-    download_from_cache_server,
-    download_from_hf_hub,
-)
+from llmfoundry.utils.model_download_utils import (download_from_cache_server,
+                                                   download_from_hf_hub)
 
 HF_TOKEN_ENV_VAR = 'HUGGING_FACE_HUB_TOKEN'
 
@@ -22,12 +19,15 @@ log = logging.getLogger(__name__)
 if __name__ == '__main__':
     argparser = argparse.ArgumentParser()
     argparser.add_argument('--model', type=str, required=True)
-    argparser.add_argument(
-        '--download-from', type=str, choices=['hf', 'cache'], default='hf'
-    )
-    argparser.add_argument('--token', type=str,
+    argparser.add_argument('--download-from',
+                           type=str,
+                           choices=['hf', 'cache'],
+                           default='hf')
+    argparser.add_argument('--token',
+                           type=str,
                            default=os.getenv(HF_TOKEN_ENV_VAR))
-    argparser.add_argument('--save-dir', type=str,
+    argparser.add_argument('--save-dir',
+                           type=str,
                            default=HUGGINGFACE_HUB_CACHE)
     argparser.add_argument('--cache-url', type=str, default=None)
     argparser.add_argument('--ignore-cert', action='store_true', default=False)
@@ -35,13 +35,15 @@ if __name__ == '__main__':
         '--fallback',
         action='store_true',
         default=False,
-        help='Whether to fallback to downloading from Hugging Face if download from cache fails',
+        help=
+        'Whether to fallback to downloading from Hugging Face if download from cache fails',
     )
 
     args = argparser.parse_args(sys.argv[1:])
     if args.download_from == 'hf':
-        download_from_hf_hub(
-            args.model, save_dir=args.save_dir, token=args.token)
+        download_from_hf_hub(args.model,
+                             save_dir=args.save_dir,
+                             token=args.token)
     else:
         try:
             download_from_cache_server(
@@ -58,8 +60,8 @@ if __name__ == '__main__':
                 log.warn(
                     f'Failed to download {args.model} from cache server. Falling back to Hugging Face Hub. Error: {e}'
                 )
-                download_from_hf_hub(
-                    args.model, save_dir=args.save_dir, token=args.token
-                )
+                download_from_hf_hub(args.model,
+                                     save_dir=args.save_dir,
+                                     token=args.token)
             else:
                 raise e

--- a/scripts/misc/download_hf_model.py
+++ b/scripts/misc/download_hf_model.py
@@ -2,6 +2,9 @@
 
 TODO(jerry): Add better logging throughout
 TODO(jerry): Track download metrics
+
+Copyright 2022 MosaicML LLM Foundry authors
+SPDX-License-Identifier: Apache-2.0
 """
 import os
 import sys
@@ -10,8 +13,8 @@ import time
 import argparse
 from typing import Optional
 from http import HTTPStatus
-from bs4 import BeautifulSoup
 
+from bs4 import BeautifulSoup
 import huggingface_hub as hf_hub
 import requests
 
@@ -72,7 +75,7 @@ def download_from_hf_hub(
     else:
         raise ValueError(
             f"No supported model weights found in repo {repo_id}."
-            "Please make sure the repo contains either safetensors or pytorch weights."
+            + " Please make sure the repo contains either safetensors or pytorch weights."
         )
 
     download_start = time.time()

--- a/scripts/misc/download_hf_model.py
+++ b/scripts/misc/download_hf_model.py
@@ -1,229 +1,43 @@
-"""Download functions for Hugging Face models.
-
-TODO(jerry): Add better logging throughout
-TODO(jerry): Track download metrics
+"""Script to download model weights from Hugging Face Hub or a cache server.
 
 Copyright 2022 MosaicML LLM Foundry authors
 SPDX-License-Identifier: Apache-2.0
 """
+import logging
 import os
 import sys
-import time
 
 import argparse
-from typing import Optional
-from http import HTTPStatus
 
-from bs4 import BeautifulSoup
-import huggingface_hub as hf_hub
-import requests
-
-# Constants derived from https://github.com/huggingface/transformers/blob/main/src/transformers/utils/__init__.py
-PYTORCH_WEIGHTS_NAME = "pytorch_model.bin"
-PYTORCH_WEIGHTS_INDEX_NAME = "pytorch_model.bin.index.json"
-PYTORCH_WEIGHTS_PATTERN = "pytorch_model*.bin*"
-
-SAFETENSORS_WEIGHTS_NAME = "model.safetensors"
-SAFETENSORS_WEIGHTS_INDEX_NAME = "model.safetensors.index.json"
-SAFETENSORS_EXCLUDE_PATTERN = "model*.safetensors*"
-
-DEFAULT_HF_HUB_CACHE_DIR = os.getenv(
-    "HUGGINGFACE_HUB_CACHE", os.path.expanduser("~/.cache/huggingface/hub")
+from llmfoundry.utils.model_download_utils import (
+    download_from_cache_server,
+    download_from_hf_hub,
 )
+from huggingface_hub.constants import HUGGINGFACE_HUB_CACHE
 
+HF_TOKEN_ENV_VAR = 'HUGGING_FACE_HUB_TOKEN'
 
-def download_from_hf_hub(
-    repo_id: str,
-    save_dir: Optional[str] = None,
-    prefer_safetensors: bool = True,
-    token: Optional[str] = None,
-):
-    """Downloads the model weights and suppporting files/metadata from a Hugging Face Hub model repo.
+log = logging.getLogger(__name__)
 
-    Only supports models stored in Safetensors and PyTorch formats for now. If both formats are available, only the
-    Safetensors weights will be downloaded unless `prefer_safetensors` is set to False.
-
-    Args:
-        repo_id (str): The Hugging Face Hub repo ID.
-        save_dir (str, optional): The path to the directory where the model files will be downloaded. If `None`, reads
-            from the `HUGGINGFACE_HUB_CACHE` environment variable or uses the default Hugging Face Hub cache directory.
-        prefer_safetensors (bool): Whether to prefer Safetensors weights over PyTorch weights if both are
-            available. Defaults to True.
-        token (str, optional): The HuggingFace API token. If not provided, the token will be read from the
-            `HUGGING_FACE_HUB_TOKEN` environment variable.
-    """
-    repo_files = set(hf_hub.list_repo_files(repo_id))
-
-    # Ignore TensorFlow, TensorFlow 2, and Flax weights as they are not supported by Composer.
-    ignore_patterns = [
-        "*.ckpt",
-        "*.h5",
-        "*.msgpack",
-    ]
-
-    if (
-        SAFETENSORS_WEIGHTS_NAME in repo_files
-        or SAFETENSORS_WEIGHTS_INDEX_NAME in repo_files
-    ) and prefer_safetensors:
-        print("Safetensors found and preferred. Excluding pytorch files")
-        ignore_patterns.append(PYTORCH_WEIGHTS_PATTERN)
-    elif PYTORCH_WEIGHTS_NAME in repo_files or PYTORCH_WEIGHTS_INDEX_NAME in repo_files:
-        print(
-            "Safetensors not found or prefer_safetensors is False. Excluding safetensors files"
-        )
-        ignore_patterns.append(SAFETENSORS_EXCLUDE_PATTERN)
-    else:
-        raise ValueError(
-            f"No supported model weights found in repo {repo_id}."
-            + " Please make sure the repo contains either safetensors or pytorch weights."
-        )
-
-    download_start = time.time()
-    hf_hub.snapshot_download(
-        repo_id, cache_dir=save_dir, ignore_patterns=ignore_patterns, token=token
-    )
-    download_duration = time.time() - download_start
-    print(
-        f"Downloaded model {repo_id} from Hugging Face Hub in {download_duration} seconds"
-    )
-
-
-def _extract_links_from_html(html: str):
-    """Extracts links from HTML content.
-
-    Args:
-        html (str): The HTML content
-
-    Returns:
-        list[str]: A list of links to download.
-    """
-    soup = BeautifulSoup(html, "html.parser")
-    links = [a["href"] for a in soup.find_all("a")]
-    return links
-
-
-def _recursive_download(
-    session: requests.Session,
-    base_url: str,
-    path: str,
-    save_dir: str,
-    ignore_cert: bool = False,
-):
-    """Downloads all files from a directory on a remote server, including subdirectories.
-
-    Args:
-        session: A requests.Session through which to make requests to the remote server.
-        url (str): The base URL where the files are located.
-        path (str): The path from the base URL to the files to download. The full URL for the download is equal to
-            '<base_url>/<path>'.
-        save_dir (str): The directory to save downloaded files to.
-        ignore_cert (bool): Whether or not to ignore the validity of the SSL certificate of the remote server.
-            Defaults to False.
-            WARNING: Setting this to true is *not* secure, as no certificate verification will be performed.
-    Raises:
-        PermissionError: If the remote server returns a 401 Unauthorized status code.
-        RuntimeError: If the remote server returns a status code other than 200 OK or 401 Unauthorized.
-    """
-    url = f"{base_url}/{path}"
-    response = session.get(url, verify=(not ignore_cert))
-
-    if response.status_code == HTTPStatus.UNAUTHORIZED:
-        raise PermissionError(
-            f"Could not download file from {url}. Received status code {response.status_code}. "
-            + "Please check that your token is valid and try again."
-        )
-    elif response.status_code != HTTPStatus.OK:
-        raise RuntimeError(
-            f"Could not download file from {url}. Received status code {response.status_code}"
-        )
-
-    # Assume that the URL points to a file if it does not end with a slash.
-    if not path.endswith("/"):
-        save_path = f"{save_dir}/{path}"
-        parent_dir = os.path.dirname(save_path)
-        if not os.path.exists(parent_dir):
-            os.makedirs(parent_dir)
-
-        with open(save_path, "wb") as f:
-            f.write(response.content)
-
-            print(f"Downloaded file {save_path}")
-            return
-
-    # If the URL is a directory, the response should be an HTML directory listing that we can parse for additional links
-    # to download.
-    child_links = _extract_links_from_html(response.content.decode())
-    for child_link in child_links:
-        _recursive_download(
-            session, base_url, f"{path}/{child_link}", save_dir, ignore_cert=ignore_cert
-        )
-
-
-def download_from_cache_server(
-    model_name: str,
-    cache_base_url: str,
-    save_dir: str,
-    token: Optional[str] = None,
-    ignore_cert: bool = False,
-):
-    """Downloads Hugging Face model files from a file server that mirrors the Hugging Face Hub cache structure.
-
-    This function will attempt to download all of the blob files from `<cache_base_url>/<formatted_model_name>/blobs/`
-    on the remote cache file server, where `formatted_model_name` is equal to `models/<model_name>` with all slashes
-    replaced with `--`.
-
-    It only downloads the blobs in order to avoid downloading model files twice due to the symlink structure of the
-    Hugging Face cache.
-    For details on the cache structure: https://huggingface.co/docs/huggingface_hub/guides/manage-cache
-
-    Args:
-        model_name: The name of the model to download. This should be the same as the repository ID in the Hugging Face
-            Hub.
-        cache_base_url: The base URL of the cache file server.
-        save_dir: The directory to save the downloaded files to.
-        token: The HuggingFace API token. If not provided, the token will be read from the `HUGGING_FACE_HUB_TOKEN`
-            environment variable.
-        ignore_cert: Whether or not to ignore the validity of the SSL certificate of the remote server. Defaults to
-            False.
-            WARNING: Setting this to true is *not* secure, as no certificate verification will be performed.
-    """
-    formatted_model_name = f"models/{model_name}".replace("/", "--")
-    with requests.Session() as session:
-        session.headers.update({"Authorization": f"Bearer {token}"})
-
-        download_start = time.time()
-        _recursive_download(
-            session,
-            cache_base_url,
-            f"{formatted_model_name}/blobs/",  # Trailing slash to indicate directory
-            save_dir,
-            ignore_cert=ignore_cert,
-        )
-        download_duration = time.time() - download_start
-        print(
-            f"Downloaded model {model_name} from cache server in {download_duration} seconds"
-        )
-
-
-if __name__ == "__main__":
+if __name__ == '__main__':
     argparser = argparse.ArgumentParser()
-    argparser.add_argument("--model", type=str, required=True)
+    argparser.add_argument('--model', type=str, required=True)
     argparser.add_argument(
-        "--download-from", type=str, choices=["hf", "cache"], default="hf"
+        '--download-from', type=str, choices=['hf', 'cache'], default='hf'
     )
-    argparser.add_argument("--save-dir", type=str, default=DEFAULT_HF_HUB_CACHE_DIR)
-    argparser.add_argument("--cache-url", type=str, default=None)
-    argparser.add_argument("--token", type=str, default=None)
-    argparser.add_argument("--ignore-cert", action="store_true", default=False)
+    argparser.add_argument('--token', type=str, default=os.getenv(HF_TOKEN_ENV_VAR))
+    argparser.add_argument('--save-dir', type=str, default=HUGGINGFACE_HUB_CACHE)
+    argparser.add_argument('--cache-url', type=str, default=None)
+    argparser.add_argument('--ignore-cert', action='store_true', default=False)
     argparser.add_argument(
-        "--fallback",
-        action="store_true",
+        '--fallback',
+        action='store_true',
         default=False,
-        help="Whether to fallback to downloading from Hugging Face if download from cache fails",
+        help='Whether to fallback to downloading from Hugging Face if download from cache fails',
     )
 
     args = argparser.parse_args(sys.argv[1:])
-    if args.download_from == "hf":
+    if args.download_from == 'hf':
         download_from_hf_hub(args.model, save_dir=args.save_dir, token=args.token)
     else:
         try:
@@ -235,11 +49,11 @@ if __name__ == "__main__":
                 ignore_cert=args.ignore_cert,
             )
         except PermissionError:
-            print(f"Not authorized to download {args.model}.")
+            log.error(f'Not authorized to download {args.model}.')
         except Exception as e:
             if args.fallback:
-                print(
-                    f"Failed to download from cache server. Falling back to Hugging Face Hub. Error: {e}"
+                log.warn(
+                    f'Failed to download {args.model} from cache server. Falling back to Hugging Face Hub. Error: {e}'
                 )
                 download_from_hf_hub(
                     args.model, save_dir=args.save_dir, token=args.token

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ install_requires = [
     'triton-pre-mlir@git+https://github.com/vchiley/triton.git@triton_pre_mlir_sm90#subdirectory=python',
     'boto3>=1.21.45,<2',
     'huggingface-hub>=0.17.0,<1.0',
+    'beautifulsoup4>=4.12.2,<5',  # required for model download utils
 ]
 
 extra_deps = {}

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ install_requires = [
     'boto3>=1.21.45,<2',
     'huggingface-hub>=0.17.0,<1.0',
     'beautifulsoup4>=4.12.2,<5',  # required for model download utils
+    'tenacity>=8.2.3,<9',
 ]
 
 extra_deps = {}
@@ -102,7 +103,8 @@ extra_deps['gpu-flash2'] = [
 extra_deps['peft'] = [
     'loralib==0.1.1',  # lora core
     'bitsandbytes==0.39.1',  # 8bit
-    'scipy>=1.10.0,<=1.11.0',  # bitsandbytes dependency; TODO: eliminate when incorporated to bitsandbytes
+    # bitsandbytes dependency; TODO: eliminate when incorporated to bitsandbytes
+    'scipy>=1.10.0,<=1.11.0',
     # TODO: pin peft when it stabilizes.
     # PyPI does not support direct dependencies, so we remove this line before uploading from PyPI
     'peft==0.4.0',

--- a/tests/test_model_download_utils.py
+++ b/tests/test_model_download_utils.py
@@ -1,114 +1,107 @@
-# Copyright 2023 MosaicML LLM Foundry authors
+# Copyright 2022 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Dict, List
-
-from http import HTTPStatus
 import os
-import requests
 import unittest.mock as mock
+from http import HTTPStatus
+from typing import Any, Dict, List
 from unittest.mock import MagicMock
 from urllib.parse import urljoin
 
-from huggingface_hub.utils import RepositoryNotFoundError
 import pytest
+import requests
 import tenacity
-from transformers.utils import (
-    WEIGHTS_NAME as PYTORCH_WEIGHTS_NAME,
-    WEIGHTS_INDEX_NAME as PYTORCH_WEIGHTS_INDEX_NAME,
-    SAFE_WEIGHTS_NAME,
-    SAFE_WEIGHTS_INDEX_NAME,
-)
+from huggingface_hub.utils import RepositoryNotFoundError
+from transformers.utils import SAFE_WEIGHTS_INDEX_NAME, SAFE_WEIGHTS_NAME
+from transformers.utils import WEIGHTS_INDEX_NAME as PYTORCH_WEIGHTS_INDEX_NAME
+from transformers.utils import WEIGHTS_NAME as PYTORCH_WEIGHTS_NAME
 
-from llmfoundry.utils.model_download_utils import (
-    download_from_cache_server,
-    download_from_hf_hub,
-    DEFAULT_IGNORE_PATTERNS,
-    PYTORCH_WEIGHTS_PATTERN,
-    SAFE_WEIGHTS_PATTERN
-)
-
+from llmfoundry.utils.model_download_utils import (DEFAULT_IGNORE_PATTERNS,
+                                                   PYTORCH_WEIGHTS_PATTERN,
+                                                   SAFE_WEIGHTS_PATTERN,
+                                                   download_from_cache_server,
+                                                   download_from_hf_hub)
 
 # ======================== download_from_hf_hub tests ========================
 
 
-@pytest.mark.parametrize(['prefer_safetensors', 'repo_files', 'expected_ignore_patterns'], [
-    [   # Should use default ignore if only safetensors available
-        True,
-        [SAFE_WEIGHTS_NAME],
-        DEFAULT_IGNORE_PATTERNS,
-    ],
+@pytest.mark.parametrize(
+    ['prefer_safetensors', 'repo_files', 'expected_ignore_patterns'],
     [
-        # Should use default ignore if only safetensors available
-        False,
-        [SAFE_WEIGHTS_NAME],
-        DEFAULT_IGNORE_PATTERNS,
-    ],
-    [   # Should use default ignore if only sharded safetensors available
-        True,
-        [SAFE_WEIGHTS_INDEX_NAME],
-        DEFAULT_IGNORE_PATTERNS,
-    ],
-    [
-        # Should use default ignore if only sharded safetensors available
-        False,
-        [SAFE_WEIGHTS_INDEX_NAME],
-        DEFAULT_IGNORE_PATTERNS,
-    ],
-    [
-        # Should use default ignore if only pytorch available
-        True,
-        [PYTORCH_WEIGHTS_NAME],
-        DEFAULT_IGNORE_PATTERNS,
-    ],
-    [
-        # Should use default ignore if only pytorch available
-        False,
-        [PYTORCH_WEIGHTS_NAME],
-        DEFAULT_IGNORE_PATTERNS,
-    ],
-    [
-        # Should use default ignore if only sharded pytorch available
-        True,
-        [PYTORCH_WEIGHTS_INDEX_NAME],
-        DEFAULT_IGNORE_PATTERNS,
-    ],
-    [
-        # Should use default ignore if only sharded pytorch available
-        False,
-        [PYTORCH_WEIGHTS_INDEX_NAME],
-        DEFAULT_IGNORE_PATTERNS,
-    ],
-    [   # Ignore pytorch if safetensors are preferred
-        True,
-        [PYTORCH_WEIGHTS_NAME, SAFE_WEIGHTS_NAME],
-        DEFAULT_IGNORE_PATTERNS + [PYTORCH_WEIGHTS_PATTERN],
-    ],
-    [   # Ignore safetensors if pytorch is preferred
-        False,
-        [PYTORCH_WEIGHTS_NAME, SAFE_WEIGHTS_NAME],
-        DEFAULT_IGNORE_PATTERNS + [SAFE_WEIGHTS_PATTERN],
-    ],
-    [   # Ignore pytorch if safetensors are preferred
-        True,
-        [PYTORCH_WEIGHTS_INDEX_NAME, SAFE_WEIGHTS_INDEX_NAME],
-        DEFAULT_IGNORE_PATTERNS + [PYTORCH_WEIGHTS_PATTERN],
-    ],
-    [   # Ignore safetensors if pytorch is preferred
-        False,
-        [PYTORCH_WEIGHTS_NAME, SAFE_WEIGHTS_NAME],
-        DEFAULT_IGNORE_PATTERNS + [SAFE_WEIGHTS_PATTERN],
-    ],
-])
+        [  # Should use default ignore if only safetensors available
+            True,
+            [SAFE_WEIGHTS_NAME],
+            DEFAULT_IGNORE_PATTERNS,
+        ],
+        [
+            # Should use default ignore if only safetensors available
+            False,
+            [SAFE_WEIGHTS_NAME],
+            DEFAULT_IGNORE_PATTERNS,
+        ],
+        [  # Should use default ignore if only sharded safetensors available
+            True,
+            [SAFE_WEIGHTS_INDEX_NAME],
+            DEFAULT_IGNORE_PATTERNS,
+        ],
+        [
+            # Should use default ignore if only sharded safetensors available
+            False,
+            [SAFE_WEIGHTS_INDEX_NAME],
+            DEFAULT_IGNORE_PATTERNS,
+        ],
+        [
+            # Should use default ignore if only pytorch available
+            True,
+            [PYTORCH_WEIGHTS_NAME],
+            DEFAULT_IGNORE_PATTERNS,
+        ],
+        [
+            # Should use default ignore if only pytorch available
+            False,
+            [PYTORCH_WEIGHTS_NAME],
+            DEFAULT_IGNORE_PATTERNS,
+        ],
+        [
+            # Should use default ignore if only sharded pytorch available
+            True,
+            [PYTORCH_WEIGHTS_INDEX_NAME],
+            DEFAULT_IGNORE_PATTERNS,
+        ],
+        [
+            # Should use default ignore if only sharded pytorch available
+            False,
+            [PYTORCH_WEIGHTS_INDEX_NAME],
+            DEFAULT_IGNORE_PATTERNS,
+        ],
+        [  # Ignore pytorch if safetensors are preferred
+            True,
+            [PYTORCH_WEIGHTS_NAME, SAFE_WEIGHTS_NAME],
+            DEFAULT_IGNORE_PATTERNS + [PYTORCH_WEIGHTS_PATTERN],
+        ],
+        [  # Ignore safetensors if pytorch is preferred
+            False,
+            [PYTORCH_WEIGHTS_NAME, SAFE_WEIGHTS_NAME],
+            DEFAULT_IGNORE_PATTERNS + [SAFE_WEIGHTS_PATTERN],
+        ],
+        [  # Ignore pytorch if safetensors are preferred
+            True,
+            [PYTORCH_WEIGHTS_INDEX_NAME, SAFE_WEIGHTS_INDEX_NAME],
+            DEFAULT_IGNORE_PATTERNS + [PYTORCH_WEIGHTS_PATTERN],
+        ],
+        [  # Ignore safetensors if pytorch is preferred
+            False,
+            [PYTORCH_WEIGHTS_NAME, SAFE_WEIGHTS_NAME],
+            DEFAULT_IGNORE_PATTERNS + [SAFE_WEIGHTS_PATTERN],
+        ],
+    ])
 @mock.patch('huggingface_hub.snapshot_download')
 @mock.patch('huggingface_hub.list_repo_files')
-def test_download_from_hf_hub_weights_pref(
-    mock_list_repo_files: MagicMock,
-    mock_snapshot_download: MagicMock,
-    prefer_safetensors: bool,
-    repo_files: List[str],
-    expected_ignore_patterns: List[str]
-):
+def test_download_from_hf_hub_weights_pref(mock_list_repo_files: MagicMock,
+                                           mock_snapshot_download: MagicMock,
+                                           prefer_safetensors: bool,
+                                           repo_files: List[str],
+                                           expected_ignore_patterns: List[str]):
     test_repo_id = 'test_repo_id'
     mock_list_repo_files.return_value = repo_files
 
@@ -189,11 +182,9 @@ SUBFOLDER_HTML = b"""
 @mock.patch.object(requests.Session, 'get')
 @mock.patch('os.makedirs')
 @mock.patch('builtins.open')
-def test_download_from_cache_server(
-    mock_open: MagicMock,
-    mock_makedirs: MagicMock,
-    mock_get: MagicMock
-):
+def test_download_from_cache_server(mock_open: MagicMock,
+                                    mock_makedirs: MagicMock,
+                                    mock_get: MagicMock):
     cache_url = 'https://cache.com/'
     model_name = 'model'
     formatted_model_name = 'models--model'
@@ -208,7 +199,8 @@ def test_download_from_cache_server(
             return MagicMock(status_code=HTTPStatus.OK)
         elif url == urljoin(cache_url, f'{formatted_model_name}/blobs/folder/'):
             return MagicMock(status_code=HTTPStatus.OK, content=SUBFOLDER_HTML)
-        elif url == urljoin(cache_url, f'{formatted_model_name}/blobs/folder/file2'):
+        elif url == urljoin(cache_url,
+                            f'{formatted_model_name}/blobs/folder/file2'):
             return MagicMock(status_code=HTTPStatus.OK)
         else:
             return MagicMock(status_code=HTTPStatus.NOT_FOUND)
@@ -217,11 +209,13 @@ def test_download_from_cache_server(
     download_from_cache_server(model_name, cache_url, 'save_dir/')
 
     mock_open.assert_has_calls([
-        mock.call(os.path.join(
-            save_dir, formatted_model_name, 'blobs/file1'), 'wb'),
-        mock.call(os.path.join(save_dir, formatted_model_name,
-                  'blobs/folder/file2'), 'wb'),
-    ], any_order=True)
+        mock.call(os.path.join(save_dir, formatted_model_name, 'blobs/file1'),
+                  'wb'),
+        mock.call(
+            os.path.join(save_dir, formatted_model_name, 'blobs/folder/file2'),
+            'wb'),
+    ],
+                               any_order=True)
 
 
 @mock.patch.object(requests.Session, 'get')

--- a/tests/test_model_download_utils.py
+++ b/tests/test_model_download_utils.py
@@ -1,0 +1,125 @@
+# Copyright 2023 MosaicML LLM Foundry authors
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import List
+
+import unittest.mock as mock
+from unittest.mock import MagicMock
+
+import pytest
+
+from llmfoundry.utils.model_download_utils import (
+    download_from_cache_server,
+    download_from_hf_hub,
+    PYTORCH_WEIGHTS_NAME,
+    PYTORCH_WEIGHTS_INDEX_NAME,
+    SAFE_WEIGHTS_NAME,
+    SAFE_WEIGHTS_INDEX_NAME,
+    DEFAULT_IGNORE_PATTERNS,
+    PYTORCH_WEIGHTS_PATTERN,
+    SAFE_WEIGHTS_PATTERN
+)
+
+
+@pytest.mark.parametrize(['prefer_safetensors', 'repo_files', 'expected_ignore_patterns'], [
+    [   # Should use default ignore if only safetensors available
+        True,
+        [SAFE_WEIGHTS_NAME],
+        DEFAULT_IGNORE_PATTERNS,
+    ],
+    [
+        # Should use default ignore if only safetensors available
+        False,
+        [SAFE_WEIGHTS_NAME],
+        DEFAULT_IGNORE_PATTERNS,
+    ],
+    [   # Should use default ignore if only sharded safetensors available
+        True,
+        [SAFE_WEIGHTS_INDEX_NAME],
+        DEFAULT_IGNORE_PATTERNS,
+    ],
+    [
+        # Should use default ignore if only sharded safetensors available
+        False,
+        [SAFE_WEIGHTS_INDEX_NAME],
+        DEFAULT_IGNORE_PATTERNS,
+    ],
+    [
+        # Should use default ignore if only pytorch available
+        True,
+        [PYTORCH_WEIGHTS_NAME],
+        DEFAULT_IGNORE_PATTERNS,
+    ],
+    [
+        # Should use default ignore if only pytorch available
+        False,
+        [PYTORCH_WEIGHTS_NAME],
+        DEFAULT_IGNORE_PATTERNS,
+    ],
+    [
+        # Should use default ignore if only sharded pytorch available
+        True,
+        [PYTORCH_WEIGHTS_INDEX_NAME],
+        DEFAULT_IGNORE_PATTERNS,
+    ],
+    [
+        # Should use default ignore if only sharded pytorch available
+        False,
+        [PYTORCH_WEIGHTS_INDEX_NAME],
+        DEFAULT_IGNORE_PATTERNS,
+    ],
+    [   # Ignore pytorch if safetensors are preferred
+        True,
+        [PYTORCH_WEIGHTS_NAME, SAFE_WEIGHTS_NAME],
+        DEFAULT_IGNORE_PATTERNS + [PYTORCH_WEIGHTS_PATTERN],
+    ],
+    [   # Ignore safetensors if pytorch is preferred
+        False,
+        [PYTORCH_WEIGHTS_NAME, SAFE_WEIGHTS_NAME],
+        DEFAULT_IGNORE_PATTERNS + [SAFE_WEIGHTS_PATTERN],
+    ],
+    [   # Ignore pytorch if safetensors are preferred
+        True,
+        [PYTORCH_WEIGHTS_INDEX_NAME, SAFE_WEIGHTS_INDEX_NAME],
+        DEFAULT_IGNORE_PATTERNS + [PYTORCH_WEIGHTS_PATTERN],
+    ],
+    [   # Ignore safetensors if pytorch is preferred
+        False,
+        [PYTORCH_WEIGHTS_NAME, SAFE_WEIGHTS_NAME],
+        DEFAULT_IGNORE_PATTERNS + [SAFE_WEIGHTS_PATTERN],
+    ],
+])
+@mock.patch('huggingface_hub.snapshot_download')
+@mock.patch('huggingface_hub.list_repo_files')
+def test_download_from_hf_hub_weights_pref(
+    mock_list_repo_files: MagicMock,
+    mock_snapshot_download: MagicMock,
+    prefer_safetensors: bool,
+    repo_files: List[str],
+    expected_ignore_patterns: List[str]
+):
+    test_repo_id = 'test_repo_id'
+    mock_list_repo_files.return_value = repo_files
+
+    download_from_hf_hub(test_repo_id, prefer_safetensors=prefer_safetensors)
+    mock_snapshot_download.assert_called_once_with(
+        test_repo_id,
+        cache_dir=None,
+        ignore_patterns=expected_ignore_patterns,
+        token=None,
+    )
+
+
+@mock.patch('huggingface_hub.snapshot_download')
+@mock.patch('huggingface_hub.list_repo_files')
+def test_download_from_hf_hub_no_weights(
+    mock_list_repo_files: MagicMock,
+    mock_snapshot_download: MagicMock,
+):
+    test_repo_id = 'test_repo_id'
+    mock_list_repo_files.return_value = []
+
+    with pytest.raises(ValueError):
+        download_from_hf_hub(test_repo_id)
+
+    mock_snapshot_download.assert_not_called()


### PR DESCRIPTION
This script can be used to download Hugging Face model files, either directly from Hugging Face Hub or from a server that hosts the model files in the same structure as the [HF Hub cache system](https://huggingface.co/docs/huggingface_hub/guides/manage-cache)