### PR TITLE
Add Model sharding support with deepspeed

### DIFF
--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -406,14 +406,22 @@ def main(cfg: DictConfig):
 
     # Build Model
     print('Initializing model...')
-    with init_context:
-        if lora_config is not None:  # frozen model + trainable lora modules
-            model: ComposerHFCausalLM = build_composer_peft_model(
-                model_config.pretrained_model_name_or_path, lora_config['args'],
-                tokenizer)
-            print_trainable_parameters(model)  # should not be 100%
-        else:  # standard model
+    if deepspeed_config['zero_optimization']['stage'] == 3:
+        # https://github.com/microsoft/DeepSpeed/blob/f060407829f87da32a267a60d26d13a68dc11c61/deepspeed/runtime/zero/partition_parameters.py#L750
+        # Create a context to enable massive model construction for training with ZeRO-3. Models are automatically partitioned (or, sharded) across the
+        # system and converted to half precision
+        import deepspeed
+        with deepspeed.zero.Init(config_dict_or_path=deepspeed_config):
             model = build_composer_model(model_config, tokenizer)
+    else:
+        with init_context:
+            if lora_config is not None:  # frozen model + trainable lora modules
+                model: ComposerHFCausalLM = build_composer_peft_model(
+                    model_config.pretrained_model_name_or_path, lora_config['args'],
+                    tokenizer)
+                print_trainable_parameters(model)  # should not be 100%
+            else:  # standard model
+                model = build_composer_model(model_config, tokenizer)
 
     # Log number of parameters
     n_params = sum(p.numel() for p in model.parameters())

--- a/scripts/train/yamls/pretrain/mpt-30b-gaudi2.yaml
+++ b/scripts/train/yamls/pretrain/mpt-30b-gaudi2.yaml
@@ -1,0 +1,131 @@
+data_local: ./my-copy-c4
+data_remote: # If blank, files must be present in data_local
+max_seq_len: 2048
+global_seed: 17
+device: hpu
+
+# Run Name
+run_name: # If left blank, will be read from env var $RUN_NAME
+
+# Model
+model:
+  name: mpt_causal_lm
+  init_device: hpu
+  d_model: 7168
+  n_heads: 56
+  n_layers: 48
+  expansion_ratio: 4
+  max_seq_len: ${max_seq_len}
+  vocab_size: 50368
+  attn_config:
+    attn_impl: torch
+  loss_fn: torch_crossentropy
+
+# Tokenizer
+tokenizer:
+  name: EleutherAI/gpt-neox-20b
+  kwargs:
+    model_max_length: ${max_seq_len}
+
+# Dataloaders
+train_loader:
+  name: text
+  dataset:
+    local: ${data_local}
+    remote: ${data_remote}
+    split: train
+    shuffle: true
+    max_seq_len: ${max_seq_len}
+    shuffle_seed: ${global_seed}
+  drop_last: true
+  num_workers: 8
+
+eval_loader:
+  name: text
+  dataset:
+    local: ${data_local}
+    remote: ${data_remote}
+    split: val
+    shuffle: false
+    max_seq_len: ${max_seq_len}
+    shuffle_seed: ${global_seed}
+  drop_last: false
+  num_workers: 8
+
+# Optimization
+scheduler:
+  name: cosine_with_warmup
+  t_warmup: 100ba
+  alpha_f: 0.1
+
+optimizer:
+  name: decoupled_adamw
+  lr: 1.0e-4
+  betas:
+  - 0.9
+  - 0.95
+  eps: 1.0e-08
+  weight_decay: 0.0
+
+algorithms:
+  gradient_clipping:
+    clipping_type: norm
+    clipping_threshold: 1.0
+
+max_duration: 143100ba # ~ 600B tokens
+eval_interval: 10000ba
+eval_first: false
+eval_subset_num_batches: -1
+global_train_batch_size: 512
+
+# System
+seed: ${global_seed}
+device_eval_batch_size: 8
+device_train_microbatch_size: 4
+# device_train_microbatch_size: auto
+precision: amp_bf16
+
+# FSDP
+#fsdp_config:
+#  sharding_strategy: FULL_SHARD
+#  mixed_precision: PURE
+#  activation_checkpointing: true
+#  activation_checkpointing_reentrant: false
+#  activation_cpu_offload: false
+#  limit_all_gathers: true
+#  verbose: false
+deepspeed_config:
+  bf16:
+    enabled: true
+  gradient_clipping: 1.0
+  zero_optimization:
+    stage: 3
+  zero_allow_untested_optimizer: true
+  train_micro_batch_size_per_gpu: 4
+  train_batch_size: 512
+
+
+# Logging
+progress_bar: false
+log_to_console: true
+console_log_interval: 1ba
+
+callbacks:
+  speed_monitor:
+    window_size: 10
+  lr_monitor: {}
+  memory_monitor: {}
+  runtime_estimator: {}
+
+# loggers:
+#   wandb: {}
+
+# Checkpoint to local filesystem or remote object store
+# save_interval: 10000ba
+# save_num_checkpoints_to_keep: 1  # Important, this cleans up checkpoints saved to DISK
+# save_folder: ./{run_name}/checkpoints
+# save_folder: s3://my-bucket/my-folder/{run_name}/checkpoints
+
+# Load from local filesystem or remote object store
+# load_path: ./gpt-30b/checkpoints/latest-rank{rank}.pt
+# load_path: s3://my-bucket/my-folder/gpt-30b/checkpoints/latest-rank{rank}.pt

--- a/scripts/train/yamls/pretrain/mpt-30b-gaudi2.yaml
+++ b/scripts/train/yamls/pretrain/mpt-30b-gaudi2.yaml
@@ -20,6 +20,7 @@ model:
   attn_config:
     attn_impl: torch
   loss_fn: torch_crossentropy
+  ds_activation_checkpointing: 1
 
 # Tokenizer
 tokenizer:
@@ -101,8 +102,8 @@ deepspeed_config:
   zero_optimization:
     stage: 3
   zero_allow_untested_optimizer: true
-  train_micro_batch_size_per_gpu: 4
-  train_batch_size: 512
+  train_micro_batch_size_per_gpu: ${device_train_microbatch_size}
+  train_batch_size: ${global_train_batch_size}
 
 
 # Logging

--- a/scripts/train/yamls/pretrain/mpt-70b-gaudi2.yaml
+++ b/scripts/train/yamls/pretrain/mpt-70b-gaudi2.yaml
@@ -1,0 +1,131 @@
+data_local: ./my-copy-c4
+data_remote: # If blank, files must be present in data_local
+max_seq_len: 2048
+global_seed: 17
+device: hpu
+
+# Run Name
+run_name: # If left blank, will be read from env var $RUN_NAME
+
+# Model
+model:
+  name: mpt_causal_lm
+  init_device: hpu
+  d_model: 8192
+  n_heads: 64
+  n_layers: 80
+  expansion_ratio: 4
+  max_seq_len: ${max_seq_len}
+  vocab_size: 50368
+  attn_config:
+    attn_impl: torch
+  loss_fn: torch_crossentropy
+
+# Tokenizer
+tokenizer:
+  name: EleutherAI/gpt-neox-20b
+  kwargs:
+    model_max_length: ${max_seq_len}
+
+# Dataloaders
+train_loader:
+  name: text
+  dataset:
+    local: ${data_local}
+    remote: ${data_remote}
+    split: train
+    shuffle: true
+    max_seq_len: ${max_seq_len}
+    shuffle_seed: ${global_seed}
+  drop_last: true
+  num_workers: 8
+
+eval_loader:
+  name: text
+  dataset:
+    local: ${data_local}
+    remote: ${data_remote}
+    split: val
+    shuffle: false
+    max_seq_len: ${max_seq_len}
+    shuffle_seed: ${global_seed}
+  drop_last: false
+  num_workers: 8
+
+# Optimization
+scheduler:
+  name: cosine_with_warmup
+  t_warmup: 100ba
+  alpha_f: 0.1
+
+optimizer:
+  name: decoupled_adamw
+  lr: 1.0e-4
+  betas:
+  - 0.9
+  - 0.95
+  eps: 1.0e-08
+  weight_decay: 0.0
+
+algorithms:
+  gradient_clipping:
+    clipping_type: norm
+    clipping_threshold: 1.0
+
+max_duration: 143100ba # ~ 600B tokens
+eval_interval: 10000ba
+eval_first: false
+eval_subset_num_batches: -1
+global_train_batch_size: 512
+
+# System
+seed: ${global_seed}
+device_eval_batch_size: 8
+device_train_microbatch_size: 1
+# device_train_microbatch_size: auto
+precision: amp_bf16
+
+# FSDP
+#fsdp_config:
+#  sharding_strategy: FULL_SHARD
+#  mixed_precision: PURE
+#  activation_checkpointing: true
+#  activation_checkpointing_reentrant: false
+#  activation_cpu_offload: false
+#  limit_all_gathers: true
+#  verbose: false
+deepspeed_config:
+  bf16:
+    enabled: true
+  gradient_clipping: 1.0
+  zero_optimization:
+    stage: 3
+  zero_allow_untested_optimizer: true
+  train_micro_batch_size_per_gpu: 1
+  train_batch_size: 512
+
+
+# Logging
+progress_bar: false
+log_to_console: true
+console_log_interval: 1ba
+
+callbacks:
+  speed_monitor:
+    window_size: 10
+  lr_monitor: {}
+  memory_monitor: {}
+  runtime_estimator: {}
+
+# loggers:
+#   wandb: {}
+
+# Checkpoint to local filesystem or remote object store
+# save_interval: 10000ba
+# save_num_checkpoints_to_keep: 1  # Important, this cleans up checkpoints saved to DISK
+# save_folder: ./{run_name}/checkpoints
+# save_folder: s3://my-bucket/my-folder/{run_name}/checkpoints
+
+# Load from local filesystem or remote object store
+# load_path: ./gpt-30b/checkpoints/latest-rank{rank}.pt
+# load_path: s3://my-bucket/my-folder/gpt-30b/checkpoints/latest-rank{rank}.pt

--- a/scripts/train/yamls/pretrain/mpt-70b-gaudi2.yaml
+++ b/scripts/train/yamls/pretrain/mpt-70b-gaudi2.yaml
@@ -82,7 +82,7 @@ global_train_batch_size: 512
 # System
 seed: ${global_seed}
 device_eval_batch_size: 8
-device_train_microbatch_size: 1
+device_train_microbatch_size: 2
 # device_train_microbatch_size: auto
 precision: amp_bf16
 

--- a/scripts/train/yamls/pretrain/mpt-70b-gaudi2.yaml
+++ b/scripts/train/yamls/pretrain/mpt-70b-gaudi2.yaml
@@ -20,6 +20,7 @@ model:
   attn_config:
     attn_impl: torch
   loss_fn: torch_crossentropy
+  ds_activation_checkpointing: 1  
 
 # Tokenizer
 tokenizer:
@@ -101,9 +102,8 @@ deepspeed_config:
   zero_optimization:
     stage: 3
   zero_allow_untested_optimizer: true
-  train_micro_batch_size_per_gpu: 1
-  train_batch_size: 512
-
+  train_micro_batch_size_per_gpu: ${device_train_microbatch_size}
+  train_batch_size: ${global_train_batch_size}
 
 # Logging
 progress_bar: false


### PR DESCRIPTION
In order to execute large models (MPT-30B, MPT-70B) with Deepspeed Zero-3 only, model parameters need to be sharded across devices during loading itself. Added call to deepspeed.zero.Init() to achieve this parameter sharding.
  