### PR TITLE
Allow logging metadata

### DIFF
--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -408,9 +408,8 @@ def main(cfg: DictConfig) -> Trainer:
                                                           'compile_config',
                                                           must_exist=False,
                                                           default_value=None)
-    mosaicml_metadata: Optional[Dict[str,
-                                     str]] = pop_config(cfg,
-                                                        'mosaicml_metadata',
+    metadata: Optional[Dict[str, str]] = pop_config(cfg,
+                                                        'metadata',
                                                         must_exist=False,
                                                         default_value=None,
                                                         convert=True)
@@ -491,14 +490,11 @@ def main(cfg: DictConfig) -> Trainer:
             mosaicml_logger = MosaicMLLogger()
             loggers.append(mosaicml_logger)
 
-    if mosaicml_metadata is not None:
-        if mosaicml_logger is None:
-            raise ValueError(
-                'mosaicml_metadata was provided but no MosaicML logger was found.'
-                +
-                ' mosaicml_metadata can only be used on the MosaicML platform.')
-        mosaicml_logger.log_metrics(mosaicml_metadata)
-        mosaicml_logger._flush_metadata(force_flush=True)
+    if metadata is not None:
+        logged_cfg.update(metadata, merge=True)
+        if mosaicml_logger is not None:
+            mosaicml_logger.log_metrics(mosaicml_metadata)
+            mosaicml_logger._flush_metadata(force_flush=True)
 
     # Profiling
     profiler: Optional[Profiler] = None

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -408,11 +408,12 @@ def main(cfg: DictConfig) -> Trainer:
                                                           'compile_config',
                                                           must_exist=False,
                                                           default_value=None)
-    mosaicml_metadata: Optional[Dict[str, str]] = pop_config(cfg,
-                                                            'mosaicml_metadata',
-                                                            must_exist=False,
-                                                            default_value=None,
-                                                            convert=True)
+    mosaicml_metadata: Optional[Dict[str,
+                                     str]] = pop_config(cfg,
+                                                        'mosaicml_metadata',
+                                                        must_exist=False,
+                                                        default_value=None,
+                                                        convert=True)
     # Enable autoresume from model checkpoints if possible
     autoresume_default: bool = False
     if logged_cfg.get('run_name', None) is not None \
@@ -494,8 +495,8 @@ def main(cfg: DictConfig) -> Trainer:
         if mosaicml_logger is None:
             raise ValueError(
                 'mosaicml_metadata was provided but no MosaicML logger was found.'
-                + ' mosaicml_metadata can only be used on the MosaicML platform.'
-            )
+                +
+                ' mosaicml_metadata can only be used on the MosaicML platform.')
         mosaicml_logger.log_metrics(mosaicml_metadata)
         mosaicml_logger._flush_metadata(force_flush=True)
 

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -409,10 +409,10 @@ def main(cfg: DictConfig) -> Trainer:
                                                           must_exist=False,
                                                           default_value=None)
     metadata: Optional[Dict[str, str]] = pop_config(cfg,
-                                                        'metadata',
-                                                        must_exist=False,
-                                                        default_value=None,
-                                                        convert=True)
+                                                    'metadata',
+                                                    must_exist=False,
+                                                    default_value=None,
+                                                    convert=True)
     # Enable autoresume from model checkpoints if possible
     autoresume_default: bool = False
     if logged_cfg.get('run_name', None) is not None \
@@ -493,7 +493,7 @@ def main(cfg: DictConfig) -> Trainer:
     if metadata is not None:
         logged_cfg.update(metadata, merge=True)
         if mosaicml_logger is not None:
-            mosaicml_logger.log_metrics(mosaicml_metadata)
+            mosaicml_logger.log_metrics(metadata)
             mosaicml_logger._flush_metadata(force_flush=True)
 
     # Profiling

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -408,6 +408,11 @@ def main(cfg: DictConfig) -> Trainer:
                                                           'compile_config',
                                                           must_exist=False,
                                                           default_value=None)
+    mosaicml_metadata: Optional[Dict[str, str]] = pop_config(cfg,
+                                                            'mosaicml_metadata',
+                                                            must_exist=False,
+                                                            default_value=None,
+                                                            convert=True)
     # Enable autoresume from model checkpoints if possible
     autoresume_default: bool = False
     if logged_cfg.get('run_name', None) is not None \
@@ -484,6 +489,15 @@ def main(cfg: DictConfig) -> Trainer:
             # Adds mosaicml logger to composer if the run was sent from Mosaic platform, access token is set, and mosaic logger wasn't previously added
             mosaicml_logger = MosaicMLLogger()
             loggers.append(mosaicml_logger)
+
+    if mosaicml_metadata is not None:
+        if mosaicml_logger is None:
+            raise ValueError(
+                'mosaicml_metadata was provided but no MosaicML logger was found.'
+                + ' mosaicml_metadata can only be used on the MosaicML platform.'
+            )
+        mosaicml_logger.log_metrics(mosaicml_metadata)
+        mosaicml_logger._flush_metadata(force_flush=True)
 
     # Profiling
     profiler: Optional[Profiler] = None

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -413,6 +413,7 @@ def main(cfg: DictConfig) -> Trainer:
                                                     must_exist=False,
                                                     default_value=None,
                                                     convert=True)
+
     # Enable autoresume from model checkpoints if possible
     autoresume_default: bool = False
     if logged_cfg.get('run_name', None) is not None \
@@ -491,6 +492,8 @@ def main(cfg: DictConfig) -> Trainer:
             loggers.append(mosaicml_logger)
 
     if metadata is not None:
+        # Flatten the metadata for logging
+        logged_cfg.pop('metadata', None)
         logged_cfg.update(metadata, merge=True)
         if mosaicml_logger is not None:
             mosaicml_logger.log_metrics(metadata)


### PR DESCRIPTION
Adds a new `metadata` field to `train.py` that will log metadata to the Mosaic platform and any experiment trackers present

Tested that a `run_group` key can be added to mosaic, wandb, and mlflow

<img width="265" alt="Screenshot 2023-11-04 at 12 01 08 AM" src="https://github.com/mosaicml/llm-foundry/assets/43149077/98f5b081-4ba7-4f53-ab1b-da78f24d34f9">
<img width="423" alt="Screenshot 2023-11-04 at 12 02 41 AM" src="https://github.com/mosaicml/llm-foundry/assets/43149077/7a2e67eb-c185-4848-8d19-575d637c426b">
<img width="496" alt="Screenshot 2023-11-04 at 12 03 50 AM" src="https://github.com/mosaicml/llm-foundry/assets/43149077/e2999150-32ef-43f3-b7cb-d44853af07cd">
