### PR TITLE
Run HF dataset processing on local rank 0 first

### DIFF
--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -38,6 +38,7 @@ import warnings
 from typing import Any, Callable, Dict, List, Optional, Union
 
 import datasets as hf_datasets
+from composer.utils import dist
 from omegaconf import DictConfig
 from streaming import StreamingDataset
 from transformers import PreTrainedTokenizerBase
@@ -340,7 +341,9 @@ class DatasetConstructor:
             return _tokenize_formatted_example(example, tokenizer)
 
         detected_cpu_count = os.cpu_count() or 1
-        num_cpus_to_use = max(1, detected_cpu_count - 4)
+        detected_cpus_with_margin = detected_cpu_count - 4
+        cpus_per_rank = detected_cpus_with_margin // dist.get_world_size()
+        num_cpus_to_use = max(1, cpus_per_rank)
 
         columns_to_remove = list(dataset[0].keys())
         tokenized_dataset = dataset.map(

--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -367,7 +367,7 @@ class DatasetConstructor:
         empty_examples_dropped_dataset = prompt_length_filtered_dataset.filter(
             lambda example: len(example['input_ids']) > 0 and len(example[
                 'labels']) > 0 and any(token_id != tokenizer.pad_token_id
-                                       for token_id in example['labels']))
+                                       for token_id in example['labels']), num_proc=num_cpus_to_use)
         empty_examples_removed = len(prompt_length_filtered_dataset) - len(
             empty_examples_dropped_dataset)
         if empty_examples_removed > 0:

--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -342,7 +342,7 @@ class DatasetConstructor:
 
         detected_cpu_count = os.cpu_count() or 1
         detected_cpus_with_margin = detected_cpu_count - 4
-        cpus_per_rank = detected_cpus_with_margin // dist.get_world_size()
+        cpus_per_rank = detected_cpus_with_margin // dist.get_local_world_size()
         num_cpus_to_use = max(1, cpus_per_rank)
 
         columns_to_remove = list(dataset[0].keys())

--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -372,12 +372,16 @@ class DatasetConstructor:
                 f'Dropped {examples_removed} examples where the prompt was longer than {max_seq_len}.'
             )
 
+        pad_token_id = tokenizer.pad_token_id
         empty_examples_dropped_dataset = prompt_length_filtered_dataset.filter(
             lambda example: len(example['input_ids']) > 0 and len(example[
-                'labels']) > 0 and any(token_id != tokenizer.pad_token_id
+                'labels']) > 0 and any(token_id != pad_token_id
                                        for token_id in example['labels']),
             num_proc=num_cpus_to_use,
             desc='Filtering out empty examples')
+
+        log.debug("Done tokenizing and filtering examples.")
+
         empty_examples_removed = len(prompt_length_filtered_dataset) - len(
             empty_examples_dropped_dataset)
         if empty_examples_removed > 0:

--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -341,7 +341,7 @@ class DatasetConstructor:
             return _tokenize_formatted_example(example, tokenizer)
 
         detected_cpu_count = os.cpu_count() or 1
-        detected_cpus_with_margin = detected_cpu_count - 4
+        detected_cpus_with_margin = detected_cpu_count - 8
         num_cpus_to_use = max(1, detected_cpus_with_margin)
 
         signal_file_path = f'.node_{dist.get_node_rank()}_local_rank0_data_prep_completed'

--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -344,7 +344,7 @@ class DatasetConstructor:
         detected_cpus_with_margin = detected_cpu_count - 4
         num_cpus_to_use = max(1, detected_cpus_with_margin)
 
-        signal_file_path = f'.node_{dist.get_node_rank()}_local_rank0_completed'
+        signal_file_path = f'.node_{dist.get_node_rank()}_local_rank0_data_prep_completed'
 
         if dist.get_local_rank() != 0:
             with dist.local_rank_zero_download_and_wait(signal_file_path):
@@ -386,7 +386,7 @@ class DatasetConstructor:
 
         if dist.get_local_rank() == 0:
             with open(signal_file_path, 'wb') as f:
-                f.write(b'local_rank0_completed_download')
+                f.write(b'local_rank0_completed_data_prep')
 
             dist.barrier()
             os.remove(signal_file_path)

--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -347,6 +347,7 @@ class DatasetConstructor:
         signal_file_path = f'.node_{dist.get_node_rank()}_local_rank0_data_prep_completed'
 
         if dist.get_local_rank() != 0:
+            log.debug("Waiting for local_rank 0 to finish data prep")
             with dist.local_rank_zero_download_and_wait(signal_file_path):
                 dist.barrier()
 
@@ -385,12 +386,14 @@ class DatasetConstructor:
                 + 'or the response was only padding tokens.')
 
         if dist.get_local_rank() == 0:
+            log.debug("Local rank 0 finished data prep")
             with open(signal_file_path, 'wb') as f:
                 f.write(b'local_rank0_completed_data_prep')
 
             dist.barrier()
             os.remove(signal_file_path)
 
+        log.debug("All ranks finished data prep")
         return empty_examples_dropped_dataset
 
     def build_from_streaming(self, *args: Any,

--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -380,7 +380,7 @@ class DatasetConstructor:
             num_proc=num_cpus_to_use,
             desc='Filtering out empty examples')
 
-        log.debug("Done tokenizing and filtering examples.")
+        log.debug('Done tokenizing and filtering examples.')
 
         empty_examples_removed = len(prompt_length_filtered_dataset) - len(
             empty_examples_dropped_dataset)

--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -338,7 +338,7 @@ class DatasetConstructor:
         if dist.get_local_rank() != 0:
             log.debug('Waiting for local_rank 0 to finish data prep')
             with dist.local_rank_zero_download_and_wait(signal_file_path):
-                dist.barrier()
+                pass
 
         dataset = hf_datasets.load_dataset(dataset_name, split=split, **kwargs)
 
@@ -394,7 +394,9 @@ class DatasetConstructor:
             with open(signal_file_path, 'wb') as f:
                 f.write(b'local_rank0_completed_data_prep')
 
-            dist.barrier()
+        dist.barrier()
+
+        if dist.get_local_rank() == 0:
             os.remove(signal_file_path)
 
         log.debug('All ranks finished data prep')

--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -367,7 +367,8 @@ class DatasetConstructor:
         empty_examples_dropped_dataset = prompt_length_filtered_dataset.filter(
             lambda example: len(example['input_ids']) > 0 and len(example[
                 'labels']) > 0 and any(token_id != tokenizer.pad_token_id
-                                       for token_id in example['labels']), num_proc=num_cpus_to_use)
+                                       for token_id in example['labels']),
+            num_proc=num_cpus_to_use)
         empty_examples_removed = len(prompt_length_filtered_dataset) - len(
             empty_examples_dropped_dataset)
         if empty_examples_removed > 0:

--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -336,7 +336,7 @@ class DatasetConstructor:
         signal_file_path = f'.node_{dist.get_node_rank()}_local_rank0_data_prep_completed'
 
         if dist.get_local_rank() != 0:
-            log.debug("Waiting for local_rank 0 to finish data prep")
+            log.debug('Waiting for local_rank 0 to finish data prep')
             with dist.local_rank_zero_download_and_wait(signal_file_path):
                 dist.barrier()
 
@@ -386,14 +386,14 @@ class DatasetConstructor:
                 + 'or the response was only padding tokens.')
 
         if dist.get_local_rank() == 0:
-            log.debug("Local rank 0 finished data prep")
+            log.debug('Local rank 0 finished data prep')
             with open(signal_file_path, 'wb') as f:
                 f.write(b'local_rank0_completed_data_prep')
 
             dist.barrier()
             os.remove(signal_file_path)
 
-        log.debug("All ranks finished data prep")
+        log.debug('All ranks finished data prep')
         return empty_examples_dropped_dataset
 
     def build_from_streaming(self, *args: Any,

--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -351,10 +351,12 @@ class DatasetConstructor:
             batched=False,
             remove_columns=columns_to_remove,
             num_proc=num_cpus_to_use,
+            desc='Tokenizing dataset',
         )
         prompt_length_filtered_dataset = tokenized_dataset.filter(
             lambda example: len(example['input_ids']) < max_seq_len,
             num_proc=num_cpus_to_use,
+            desc='Filtering out long prompts',
         )
 
         examples_removed = len(tokenized_dataset) - len(
@@ -368,7 +370,8 @@ class DatasetConstructor:
             lambda example: len(example['input_ids']) > 0 and len(example[
                 'labels']) > 0 and any(token_id != tokenizer.pad_token_id
                                        for token_id in example['labels']),
-            num_proc=num_cpus_to_use)
+            num_proc=num_cpus_to_use,
+            desc='Filtering out empty examples')
         empty_examples_removed = len(prompt_length_filtered_dataset) - len(
             empty_examples_dropped_dataset)
         if empty_examples_removed > 0:


### PR DESCRIPTION
Adjust the HF dataset processing code to only process the data on local rank 0. Other ranks will use the cached arrow dataset. This is both _much_ faster than processing on all ranks, and seems to resolve various hangs and crashed we have seen for large datasets.

Manual test that this doesn't affect loss curve in anyway
<img width="1013" alt="Screenshot 2023-11-06 at 1 26 25 PM" src="https://github.com/mosaicml/llm-foundry/assets/43149077/58360d51-1875-43b1-a70f-12aa3280c550">
