### PR TITLE
add act checkpoint at sub layer level

### DIFF
--- a/llmfoundry/models/mpt/modeling_mpt.py
+++ b/llmfoundry/models/mpt/modeling_mpt.py
@@ -707,14 +707,15 @@ class MPTForCausalLM(MPTPreTrainedModel):
 
     # Activation Checkpointing
     def activation_checkpointing_fn(self, module: nn.Module) -> bool:
-        if not hasattr(self.config, 'activation_checkpointing_target'):
+        if not hasattr(self.config, 'activation_checkpointing_target'
+                      ) or self.config.activation_checkpointing_target is None:
             log.info(
                 f'activation checkpointing MPTBlock as activation_checkpointing_target is not set in model_config'
             )
             return isinstance(module, MPTBlock)
-        act_ckpt_list = self.config.activation_checkpointing_target
-        if act_ckpt_list:
-            if 'MPTBlock' in act_ckpt_list or 'mptblock' in act_ckpt_list:
+        else:
+            act_ckpt_list = self.config.activation_checkpointing_target
+            if 'MPTBlock' in act_ckpt_list:
                 act_ckpt_list = ['MPTBlock']
                 warnings.warn(
                     f'activation checkpointing MPTBlock, ignoring other sub-block modules if specified'

--- a/llmfoundry/models/mpt/modeling_mpt.py
+++ b/llmfoundry/models/mpt/modeling_mpt.py
@@ -715,7 +715,7 @@ class MPTForCausalLM(MPTPreTrainedModel):
             if 'MPTBlock' in act_ckpt_lst or 'mptblock' in act_ckpt_lst:
                 act_ckpt_lst = ['MPTBlock']
             for mod_name in act_ckpt_lst:
-                if mod_name in ['MPTBlock', 'mptblock']:
+                if mod_name.lower() == 'mptblock':
                     mod_type = MPTBlock
                 elif mod_name in ATTN_CLASS_REGISTRY:
                     mod_type = ATTN_CLASS_REGISTRY[mod_name]

--- a/llmfoundry/models/mpt/modeling_mpt.py
+++ b/llmfoundry/models/mpt/modeling_mpt.py
@@ -710,9 +710,9 @@ class MPTForCausalLM(MPTPreTrainedModel):
         if not hasattr(self.config, 'activation_checkpointing_target'):
             return isinstance(module, MPTBlock)
         act_ckpt_str = self.config.activation_checkpointing_target
-        act_ckpt_lst = act_ckpt_str.replace(' ', '').split(',')
-        if act_ckpt_lst:
-            if 'MPTBlock' in act_ckpt_lst or 'mptblock' in act_ckpt_lst:
+        act_ckpt_list = act_ckpt_str.replace(' ', '').split(',')
+        if act_ckpt_list:
+            if 'MPTBlock' in act_ckpt_list or 'mptblock' in act_ckpt_list:
                 act_ckpt_lst = ['MPTBlock']
             for mod_name in act_ckpt_lst:
                 if mod_name.lower() == 'mptblock':
@@ -724,6 +724,9 @@ class MPTForCausalLM(MPTPreTrainedModel):
                 elif mod_name in NORM_CLASS_REGISTRY:
                     mod_type = NORM_CLASS_REGISTRY[mod_name]
                 else:
+                    warnings.warn(
+                        f'module name specified in activation_checkpointing_target ({mod_name}) not recognized, available options are names in ATTN_CLASS_REGISTRY, FFN_CLASS_REGISTRY, NORM_CLASS_REGISTRY, or MPTBlock.'
+                    )
                     continue
                 return isinstance(module, mod_type)
 

--- a/llmfoundry/models/mpt/modeling_mpt.py
+++ b/llmfoundry/models/mpt/modeling_mpt.py
@@ -708,6 +708,9 @@ class MPTForCausalLM(MPTPreTrainedModel):
     # Activation Checkpointing
     def activation_checkpointing_fn(self, module: nn.Module) -> bool:
         if not hasattr(self.config, 'activation_checkpointing_target'):
+            log.info(
+                f'activation checkpointing MPTBlock as activation_checkpointing_target is not set in model_config'
+            )
             return isinstance(module, MPTBlock)
         act_ckpt_list = self.config.activation_checkpointing_target
         if act_ckpt_list:

--- a/llmfoundry/models/mpt/modeling_mpt.py
+++ b/llmfoundry/models/mpt/modeling_mpt.py
@@ -711,9 +711,10 @@ class MPTForCausalLM(MPTPreTrainedModel):
                                 None) or ['MPTBlock']
 
         if 'MPTBlock' in act_ckpt_list or 'mptblock' in act_ckpt_list:
-            log.info(
-                'Activation checkpointing MPTBlock only (ignoring other sub-block modules if specified in activation_checkpointing_target).'
-            )
+            if len(act_ckpt_list) > 1:
+                log.info(
+                    'Activation checkpointing MPTBlock only (ignoring other sub-block modules specified in activation_checkpointing_target).'
+                )
             return isinstance(module, MPTBlock)
 
         mod_types = ()
@@ -727,8 +728,12 @@ class MPTForCausalLM(MPTPreTrainedModel):
             elif mod_name in NORM_CLASS_REGISTRY:
                 mod_types += (NORM_CLASS_REGISTRY[mod_name],)
             else:
+                msg = ', '.join(
+                    list(ATTN_CLASS_REGISTRY.keys()) +
+                    list(FFN_CLASS_REGISTRY.keys()) +
+                    list(NORM_CLASS_REGISTRY.keys()) + ['MPTBlock'])
                 raise ValueError(
-                    f'{mod_name=} (specified in activation_checkpointing_target) is not a recognized option, available options are names in ATTN_CLASS_REGISTRY, FFN_CLASS_REGISTRY, NORM_CLASS_REGISTRY, or MPTBlock.'
+                    f'{mod_name} (specified in activation_checkpointing_target) is not a recognized option, available options are {msg}.'
                 )
         return isinstance(module, mod_types)
 

--- a/llmfoundry/models/mpt/modeling_mpt.py
+++ b/llmfoundry/models/mpt/modeling_mpt.py
@@ -733,7 +733,7 @@ class MPTForCausalLM(MPTPreTrainedModel):
                     list(FFN_CLASS_REGISTRY.keys()) +
                     list(NORM_CLASS_REGISTRY.keys()) + ['MPTBlock'])
                 raise ValueError(
-                    f'{mod_name} (specified in activation_checkpointing_target) is not a recognized option, available options are {msg}.'
+                    f'{mod_name} (specified in activation_checkpointing_target) is not a recognized option out of available options {msg}.'
                 )
         return isinstance(module, mod_types)
 

--- a/tests/test_fsdp_act_checkpoint.py
+++ b/tests/test_fsdp_act_checkpoint.py
@@ -11,7 +11,6 @@ from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import \
 from llmfoundry.models.mpt.modeling_mpt import ComposerMPTCausalLM
 
 
-# python3 -m composer.cli.launcher -n 2 --master_port 26000 -m pytest -m gpu tests/test_fsdp_act_checkpoint.py::test_fsdp_act_checkpoint  # noqa
 @pytest.mark.world_size(2)
 @pytest.mark.gpu
 @pytest.mark.parametrize('activation_checkpointing', [True, False])

--- a/tests/test_fsdp_act_checkpoint.py
+++ b/tests/test_fsdp_act_checkpoint.py
@@ -1,0 +1,74 @@
+# Copyright 2022 MosaicML LLM Foundry authors
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from composer import Trainer
+from composer.utils import get_device
+from omegaconf import OmegaConf as om
+from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import \
+    CheckpointWrapper
+
+from llmfoundry.models.mpt.modeling_mpt import ComposerMPTCausalLM
+
+
+# python3 -m composer.cli.launcher -n 2 --master_port 26000 -m pytest -m gpu tests/test_fsdp_act_checkpoint.py::test_fsdp_act_checkpoint  # noqa
+@pytest.mark.world_size(2)
+@pytest.mark.gpu
+@pytest.mark.parametrize('activation_checkpointing', [True, False])
+@pytest.mark.parametrize(
+    'activation_checkpointing_target',
+    [[], ['grouped_query_attention'], ['mptblock', 'grouped_query_attention']])
+def test_fsdp_act_checkpoint(activation_checkpointing: bool,
+                             activation_checkpointing_target: list):
+    device = get_device('gpu')
+    model_cfg = {
+        'name': 'mpt_causal_lm',
+        'd_model': 128,
+        'n_heads': 4,
+        'n_layers': 2,
+        'expansion_ratio': 1,
+        'max_seq_len': 16,
+        'vocab_size': 50368,
+        'attn_config': {
+            'attn_type': 'grouped_query_attention',
+            'kv_n_heads': 2,
+        },
+        'activation_checkpointing_target': activation_checkpointing_target
+    }
+    model_cfg = om.create(model_cfg)
+
+    fsdp_config = {
+        'activation_checkpointing': activation_checkpointing,
+        'activation_checkpointing_reentrant': False,
+        'activation_cpu_offload': False,
+    }
+
+    model = ComposerMPTCausalLM(model_cfg)
+    model = device.module_to_device(model)
+
+    trainer = Trainer(
+        model=model,
+        device='gpu',
+        fsdp_config=fsdp_config,
+    )
+
+    assert trainer.state.fsdp_enabled
+    if not activation_checkpointing:
+        assert not isinstance(
+            trainer.state.model.model._fsdp_wrapped_module.transformer.
+            blocks[0], CheckpointWrapper)
+    elif (not activation_checkpointing_target
+         ) or activation_checkpointing_target == [
+             'mptblock', 'grouped_query_attention'
+         ]:
+        assert isinstance(
+            trainer.state.model.model._fsdp_wrapped_module.transformer.
+            blocks[0]._fsdp_wrapped_module, CheckpointWrapper)
+    elif activation_checkpointing_target == ['grouped_query_attention']:
+        assert isinstance(
+            trainer.state.model.model._fsdp_wrapped_module.transformer.
+            blocks[0]._fsdp_wrapped_module.attn, CheckpointWrapper)
+    else:
+        raise ValueError(
+            f'Unknown activation_checkpointing_target: {activation_checkpointing_target}'
+        )


### PR DESCRIPTION
This PR allows users to specify what module to do activation checkpoint through fsdp when `activation_checkpointing` is `true` in fsdp_config. It checks the field `activation_checkpointing_target ` in `model_config`, if nothing is specified but `activation_checkpointing` is set to `true`, then `MPTBLOCK` is act checkpointed. To checkpoint the submodules in ATTN_CLASS_REGISTRY, FFN_CLASS_REGISTRY,NORM_CLASS_REGISTRY, add the corresponding names to `activation_checkpointing_target`.
For example, 
```
activation_checkpointing_target: 
    - grouped_query_attention
```
checkpoints the activation of GroupedQueryAttention.
If multiple submodules are up for act checkpointing, add their names to activation_checkpointing_target

