### PR TITLE
change default overwrite to True

### DIFF
--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -53,7 +53,7 @@ class HuggingFaceCheckpointer(Callback):
         save_interval: Union[str, int, Time],
         huggingface_folder_name: str = 'ba{batch}',
         precision: str = 'float32',
-        overwrite: bool = False,
+        overwrite: bool = True,
         mlflow_registered_model_name: Optional[str] = None,
         mlflow_logging_config: Optional[dict] = None,
     ):


### PR DESCRIPTION
I'd like to change the default for `overwrite` to `True` in the `HuggingFaceCheckpointer`. The main usage of this callback is to save HF format checkpoints at a different interval from composer checkpoints (or if its at the same interval, the HF checkpoint is saved before the composer checkpoint. This means that if something fails your run is basically not able to be resumed (unless you go change the `overwrite` param), because it will try to HF checkpoint again to the same location. Let me know if you think there is a better way to resolve this though.