### PR TITLE
Fix logging verbosity in HF model download script and repair symlinks 

### DIFF
--- a/llmfoundry/utils/model_download_utils.py
+++ b/llmfoundry/utils/model_download_utils.py
@@ -6,16 +6,16 @@ import copy
 import logging
 import os
 import time
+import warnings
 from http import HTTPStatus
 from typing import Optional
 from urllib.parse import urljoin
-import warnings
 
-from bs4 import BeautifulSoup
 import huggingface_hub as hf_hub
 import requests
-from requests.packages.urllib3.exceptions import InsecureRequestWarning
 import tenacity
+from bs4 import BeautifulSoup
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
 from transformers.utils import SAFE_WEIGHTS_INDEX_NAME, SAFE_WEIGHTS_NAME
 from transformers.utils import WEIGHTS_INDEX_NAME as PYTORCH_WEIGHTS_INDEX_NAME
 from transformers.utils import WEIGHTS_NAME as PYTORCH_WEIGHTS_NAME
@@ -33,8 +33,8 @@ log = logging.getLogger(__name__)
 
 @tenacity.retry(retry=tenacity.retry_if_not_exception_type(
     (ValueError, hf_hub.utils.RepositoryNotFoundError)),
-    stop=tenacity.stop_after_attempt(3),
-    wait=tenacity.wait_exponential(min=1, max=10))
+                stop=tenacity.stop_after_attempt(3),
+                wait=tenacity.wait_exponential(min=1, max=10))
 def download_from_hf_hub(
     repo_id: str,
     save_dir: Optional[str] = None,
@@ -181,8 +181,8 @@ def _recursive_download(
 
 @tenacity.retry(retry=tenacity.retry_if_not_exception_type(
     (PermissionError, ValueError)),
-    stop=tenacity.stop_after_attempt(3),
-    wait=tenacity.wait_exponential(min=1, max=10))
+                stop=tenacity.stop_after_attempt(3),
+                wait=tenacity.wait_exponential(min=1, max=10))
 def download_from_cache_server(
     model_name: str,
     cache_base_url: str,
@@ -214,14 +214,13 @@ def download_from_cache_server(
 
         download_start = time.time()
 
-        # Only downloads the blobs in order to avoid downloading model files twice due to the
-        # symlnks in the Hugging Face cache structure:
+        # Temporarily suppress noisy SSL certificate verification warnings if ignore_cert is set to True
         with warnings.catch_warnings():
-            # Disable noisy SSL certificate verification warnings if ignore_cert is set to True
             if ignore_cert:
-                warnings.simplefilter(
-                    'ignore', category=InsecureRequestWarning)
+                warnings.simplefilter('ignore', category=InsecureRequestWarning)
 
+            # Only downloads the blobs in order to avoid downloading model files twice due to the
+            # symlnks in the Hugging Face cache structure:
             _recursive_download(
                 session,
                 cache_base_url,

--- a/scripts/misc/download_hf_model.py
+++ b/scripts/misc/download_hf_model.py
@@ -14,7 +14,8 @@ from llmfoundry.utils.model_download_utils import (download_from_cache_server,
 
 HF_TOKEN_ENV_VAR = 'HUGGING_FACE_HUB_TOKEN'
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(format=f'%(asctime)s: %(levelname)s: %(name)s: %(message)s',
+                    level=logging.INFO)
 log = logging.getLogger(__name__)
 
 if __name__ == '__main__':
@@ -61,12 +62,13 @@ if __name__ == '__main__':
             log.info('Repairing Hugging Face cache symlinks')
 
             # Hide some noisy logs that aren't important for just the symlink repair.
-            old_level = log.level
-            log.setLevel(logging.WARNING)
+            old_level = logging.getLogger().level
+            logging.getLogger().setLevel(logging.ERROR)
             download_from_hf_hub(args.model,
                                  save_dir=args.save_dir,
                                  token=args.token)
-            log.setLevel(old_level)  # Restore the original log level
+            logging.getLogger().setLevel(old_level)
+
         except PermissionError:
             log.error(f'Not authorized to download {args.model}.')
         except Exception as e:

--- a/scripts/misc/download_hf_model.py
+++ b/scripts/misc/download_hf_model.py
@@ -35,7 +35,7 @@ if __name__ == '__main__':
     argparser.add_argument(
         '--fallback',
         action='store_true',
-        default=False,
+        default=True,
         help=
         'Whether to fallback to downloading from Hugging Face if download from cache fails',
     )
@@ -54,11 +54,24 @@ if __name__ == '__main__':
                 token=args.token,
                 ignore_cert=args.ignore_cert,
             )
+
+            # A little hacky: run the Hugging Face download just to repair the symlinks in the HF cache file structure.
+            # This shouldn't actually download any files if the cache server download was successful, but should address
+            # a non-deterministic bug where the symlinks aren't repaired properly by the time the model is initialized.
+            log.info('Repairing Hugging Face cache symlinks')
+
+            # Hide some noisy logs that aren't important for just the symlink repair.
+            old_level = log.level
+            log.setLevel(logging.WARNING)
+            download_from_hf_hub(args.model,
+                                 save_dir=args.save_dir,
+                                 token=args.token)
+            log.setLevel(old_level)  # Restore the original log level
         except PermissionError:
             log.error(f'Not authorized to download {args.model}.')
         except Exception as e:
             if args.fallback:
-                log.warn(
+                log.warning(
                     f'Failed to download {args.model} from cache server. Falling back to Hugging Face Hub. Error: {e}'
                 )
                 download_from_hf_hub(args.model,

--- a/scripts/misc/download_hf_model.py
+++ b/scripts/misc/download_hf_model.py
@@ -14,6 +14,7 @@ from llmfoundry.utils.model_download_utils import (download_from_cache_server,
 
 HF_TOKEN_ENV_VAR = 'HUGGING_FACE_HUB_TOKEN'
 
+logging.basicConfig(level=logging.INFO)
 log = logging.getLogger(__name__)
 
 if __name__ == '__main__':
@@ -35,8 +36,7 @@ if __name__ == '__main__':
         '--fallback',
         action='store_true',
         default=False,
-        help=
-        'Whether to fallback to downloading from Hugging Face if download from cache fails',
+        help='Whether to fallback to downloading from Hugging Face if download from cache fails',
     )
 
     args = argparser.parse_args(sys.argv[1:])

--- a/scripts/misc/download_hf_model.py
+++ b/scripts/misc/download_hf_model.py
@@ -36,7 +36,8 @@ if __name__ == '__main__':
         '--fallback',
         action='store_true',
         default=False,
-        help='Whether to fallback to downloading from Hugging Face if download from cache fails',
+        help=
+        'Whether to fallback to downloading from Hugging Face if download from cache fails',
     )
 
     args = argparser.parse_args(sys.argv[1:])


### PR DESCRIPTION
This PR temporarily suppresses `InvalidCertWarning` when downloading a HF model from a cache server with `ignore_cert=True`, as the warnings are quite noisy. In addition, it also sets the default log level to `INFO` in the download script so the logging is actually visible.

Also modifies the script to call `download_from_hf_hub` even after a successful cache download for the purpose of repairing the Hugging Face symlinks to address a non-deterministic bug where the symlinks aren't properly repaired by the time composer loads the model.

Tested a run downloading MPT-7B from a cache server using the new commit `94eff5bae6210865e0a7ee60fe2ec7eba4750522`. Note the no-op for `Fetching 24 files` resulting from the download from HF after:
<img width="936" alt="image" src="https://github.com/mosaicml/llm-foundry/assets/12127839/a363c719-5349-469b-bcb3-a45073ccb0a8">

And successful model initialization:
<img width="953" alt="image" src="https://github.com/mosaicml/llm-foundry/assets/12127839/09ae4c91-2a60-413a-85c9-bf225edf40c2">

