### PR TITLE
Combine filters into one, to avoid datasets error

### DIFF
--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -377,7 +377,8 @@ class DatasetConstructor:
             filtered_dataset)
         if examples_removed > 0:
             warnings.warn(
-                f'Dropped {examples_removed} examples where the prompt was longer than {max_seq_len}.'
+                f'Dropped {examples_removed} examples where the prompt was longer than {max_seq_len}, ' + 
+                'the prompt or response was empty, or the response was all padding tokens.'
             )
 
         # Now local rank 0 indicates to the other ranks that it is done

--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -374,7 +374,7 @@ class DatasetConstructor:
         )
 
         examples_removed = len(tokenized_dataset) - len(
-            prompt_length_filtered_dataset)
+            filtered_dataset)
         if examples_removed > 0:
             warnings.warn(
                 f'Dropped {examples_removed} examples where the prompt was longer than {max_seq_len}.'

--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -400,11 +400,11 @@ class DatasetConstructor:
         #         f'Dropped {empty_examples_removed} examples where the prompt or response was empty, '
         #         + 'or the response was only padding tokens.')
 
-        # # Now local rank 0 indicates to the other ranks that it is done
-        # if dist.get_local_rank() == 0:
-        #     log.debug('Local rank 0 finished data prep')
-        #     with open(signal_file_path, 'wb') as f:
-        #         f.write(b'local_rank0_completed_data_prep')
+        # Now local rank 0 indicates to the other ranks that it is done
+        if dist.get_local_rank() == 0:
+            log.debug('Local rank 0 finished data prep')
+            with open(signal_file_path, 'wb') as f:
+                f.write(b'local_rank0_completed_data_prep')
 
         # All ranks sync up at this barrier, having completed data processing
         dist.barrier()

--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -379,32 +379,32 @@ class DatasetConstructor:
                 f'Dropped {examples_removed} examples where the prompt was longer than {max_seq_len}.'
             )
 
-        pad_token_id = tokenizer.pad_token_id
+        # pad_token_id = tokenizer.pad_token_id
 
-        def filter_empty_examples(example: Dict) -> bool:
-            return len(example['input_ids']) > 0 and len(
-                example['labels']) > 0 and any(
-                    token_id != pad_token_id for token_id in example['labels'])
+        # def filter_empty_examples(example: Dict) -> bool:
+        #     return len(example['input_ids']) > 0 and len(
+        #         example['labels']) > 0 and any(
+        #             token_id != pad_token_id for token_id in example['labels'])
 
-        empty_examples_dropped_dataset = prompt_length_filtered_dataset.filter(
-            filter_empty_examples,
-            num_proc=num_cpus_to_use,
-            desc='Filtering out empty examples')
+        # empty_examples_dropped_dataset = prompt_length_filtered_dataset.filter(
+        #     filter_empty_examples,
+        #     num_proc=num_cpus_to_use,
+        #     desc='Filtering out empty examples')
 
-        log.debug('Done tokenizing and filtering examples.')
+        # log.debug('Done tokenizing and filtering examples.')
 
-        empty_examples_removed = len(prompt_length_filtered_dataset) - len(
-            empty_examples_dropped_dataset)
-        if empty_examples_removed > 0:
-            warnings.warn(
-                f'Dropped {empty_examples_removed} examples where the prompt or response was empty, '
-                + 'or the response was only padding tokens.')
+        # empty_examples_removed = len(prompt_length_filtered_dataset) - len(
+        #     empty_examples_dropped_dataset)
+        # if empty_examples_removed > 0:
+        #     warnings.warn(
+        #         f'Dropped {empty_examples_removed} examples where the prompt or response was empty, '
+        #         + 'or the response was only padding tokens.')
 
-        # Now local rank 0 indicates to the other ranks that it is done
-        if dist.get_local_rank() == 0:
-            log.debug('Local rank 0 finished data prep')
-            with open(signal_file_path, 'wb') as f:
-                f.write(b'local_rank0_completed_data_prep')
+        # # Now local rank 0 indicates to the other ranks that it is done
+        # if dist.get_local_rank() == 0:
+        #     log.debug('Local rank 0 finished data prep')
+        #     with open(signal_file_path, 'wb') as f:
+        #         f.write(b'local_rank0_completed_data_prep')
 
         # All ranks sync up at this barrier, having completed data processing
         dist.barrier()
@@ -414,7 +414,7 @@ class DatasetConstructor:
             os.remove(signal_file_path)
 
         log.debug('All ranks finished data prep')
-        return empty_examples_dropped_dataset
+        return prompt_length_filtered_dataset
 
     def build_from_streaming(self, *args: Any,
                              **kwargs: Any) -> StreamingFinetuningDataset:

--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -363,11 +363,12 @@ class DatasetConstructor:
             desc='Tokenizing dataset',
         )
 
-        def filter_long_prompts(example: Dict) -> bool:
-            return len(example['input_ids']) < max_seq_len
+        pad_token_id = tokenizer.pad_token_id
+        def filter_long_or_empty_examples(example: Dict) -> bool:
+            return (len(example['input_ids']) < max_seq_len) and (len(example['input_ids']) > 0 and len(example['labels']) > 0 and any(token_id != pad_token_id for token_id in example['labels']))
 
-        prompt_length_filtered_dataset = tokenized_dataset.filter(
-            filter_long_prompts,
+        filtered_dataset = tokenized_dataset.filter(
+            filter_long_or_empty_examples,
             num_proc=num_cpus_to_use,
             desc='Filtering out long prompts',
         )
@@ -378,27 +379,6 @@ class DatasetConstructor:
             warnings.warn(
                 f'Dropped {examples_removed} examples where the prompt was longer than {max_seq_len}.'
             )
-
-        # pad_token_id = tokenizer.pad_token_id
-
-        # def filter_empty_examples(example: Dict) -> bool:
-        #     return len(example['input_ids']) > 0 and len(
-        #         example['labels']) > 0 and any(
-        #             token_id != pad_token_id for token_id in example['labels'])
-
-        # empty_examples_dropped_dataset = prompt_length_filtered_dataset.filter(
-        #     filter_empty_examples,
-        #     num_proc=num_cpus_to_use,
-        #     desc='Filtering out empty examples')
-
-        # log.debug('Done tokenizing and filtering examples.')
-
-        # empty_examples_removed = len(prompt_length_filtered_dataset) - len(
-        #     empty_examples_dropped_dataset)
-        # if empty_examples_removed > 0:
-        #     warnings.warn(
-        #         f'Dropped {empty_examples_removed} examples where the prompt or response was empty, '
-        #         + 'or the response was only padding tokens.')
 
         # Now local rank 0 indicates to the other ranks that it is done
         if dist.get_local_rank() == 0:
@@ -414,7 +394,7 @@ class DatasetConstructor:
             os.remove(signal_file_path)
 
         log.debug('All ranks finished data prep')
-        return prompt_length_filtered_dataset
+        return filtered_dataset
 
     def build_from_streaming(self, *args: Any,
                              **kwargs: Any) -> StreamingFinetuningDataset:

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -34,9 +34,6 @@ from llmfoundry.utils.config_utils import (log_config, pop_config,
                                            process_init_device,
                                            update_batch_size_info)
 
-import datasets
-datasets.logging.set_verbosity_debug()
-
 
 def validate_config(cfg: DictConfig):
     """Validates compatible model and dataloader selection."""

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -34,6 +34,9 @@ from llmfoundry.utils.config_utils import (log_config, pop_config,
                                            process_init_device,
                                            update_batch_size_info)
 
+import datasets
+datasets.logging.set_verbosity_debug()
+
 
 def validate_config(cfg: DictConfig):
     """Validates compatible model and dataloader selection."""


### PR DESCRIPTION
Combines the two `filter` calls into one `filter` call during data preprocessing. It is not clear to me why, but it resolves the issue I reported to `datasets` (https://github.com/huggingface/datasets/issues/6393). Tested many jobs, both single node and large scale to confirm the issue is resolved.