### PR TITLE
Gate the dist calls in build_tokenizer

### DIFF
--- a/llmfoundry/utils/builders.py
+++ b/llmfoundry/utils/builders.py
@@ -190,9 +190,10 @@ def build_tokenizer(
 
     signal_file_path = f'.node_{dist.get_node_rank()}_local_rank0_completed_tokenizer_setup'
 
-    # Make sure the tokenizer files are downloaded and cached first by local rank 0
-    with dist.local_rank_zero_download_and_wait(signal_file_path):
-        pass
+    if dist.is_available() and dist.is_initialized() and dist.get_world_size() > 1:
+        # Make sure the tokenizer files are downloaded and cached first by local rank 0
+        with dist.local_rank_zero_download_and_wait(signal_file_path):
+            pass
 
     if tokenizer_name.startswith('tiktoken'):
         tokenizer = TiktokenTokenizerWrapper(**tokenizer_kwargs)
@@ -208,14 +209,15 @@ def build_tokenizer(
             int(1e30),
         )
 
-    if dist.get_local_rank() == 0:
-        with open(signal_file_path, 'wb') as f:
-            f.write(b'local_rank0_completed_tokenizer_setup')
+    if dist.is_available() and dist.is_initialized() and dist.get_world_size() > 1:
+        if dist.get_local_rank() == 0:
+            with open(signal_file_path, 'wb') as f:
+                f.write(b'local_rank0_completed_tokenizer_setup')
 
-    dist.barrier()
+        dist.barrier()
 
-    if dist.get_local_rank() == 0:
-        os.remove(signal_file_path)
+        if dist.get_local_rank() == 0:
+            os.remove(signal_file_path)
 
     return tokenizer
 

--- a/llmfoundry/utils/builders.py
+++ b/llmfoundry/utils/builders.py
@@ -190,7 +190,8 @@ def build_tokenizer(
 
     signal_file_path = f'.node_{dist.get_node_rank()}_local_rank0_completed_tokenizer_setup'
 
-    if dist.is_available() and dist.is_initialized() and dist.get_world_size() > 1:
+    if dist.is_available() and dist.is_initialized(
+    ) and dist.get_world_size() > 1:
         # Make sure the tokenizer files are downloaded and cached first by local rank 0
         with dist.local_rank_zero_download_and_wait(signal_file_path):
             pass
@@ -209,7 +210,8 @@ def build_tokenizer(
             int(1e30),
         )
 
-    if dist.is_available() and dist.is_initialized() and dist.get_world_size() > 1:
+    if dist.is_available() and dist.is_initialized(
+    ) and dist.get_world_size() > 1:
         if dist.get_local_rank() == 0:
             with open(signal_file_path, 'wb') as f:
                 f.write(b'local_rank0_completed_tokenizer_setup')


### PR DESCRIPTION
The failing regression test now makes it past the point it failed at (`elastic-resumption-2-to-1-node-JoTmuj`). It still fails, but because I don't have my OCI credentials set up, not because of the dist error. And here is a normal manual run on this PR (`no-dist-1-6mxV5j`).

We don't have a CI setup that can run non in an environment with WORLD_SIZE > 1 and dist not initialized, but I tested this combination of settings manually and confirmed that it failed before this PR, and works after.