### PR TITLE
Better error message when test does not complete

### DIFF
--- a/.github/mcp/mcp_pytest.py
+++ b/.github/mcp/mcp_pytest.py
@@ -130,7 +130,7 @@ if __name__ == '__main__':
         print(line, end='')
 
     print('[GHA] Run completed. Waiting for run to finish...')
-    run = wait_for_run_status(run, status='completed')
+    run = wait_for_run_status(run, status=RunStatus.COMPLETED)
 
-    # Fail if command exited with non-zero exit code or timed out
-    assert run.status == RunStatus.COMPLETED
+    # Fail if command exited with non-zero exit code or timed out (didn't reach COMPLETED)
+    assert run.status == RunStatus.COMPLETED, f'Run did not complete: {run.status} ({run.reason})'


### PR DESCRIPTION
Annoyed at how unhelpful this is 😛  https://github.com/mosaicml/llm-foundry/actions/runs/7053781482/job/19204813223?pr=768

Also nit: should probably have required reviewers for `.github/**`?