### PR TITLE
Fix token counting to use attention mask instead of ids

### DIFF
--- a/llmfoundry/data/denoising.py
+++ b/llmfoundry/data/denoising.py
@@ -527,7 +527,6 @@ def build_text_denoising_dataloader(
     )
 
     token_counting_func = get_tokens_per_batch_func(
-        pad_token_id=tokenizer.pad_token_id,
         decoder_only=cfg.mixture_of_denoisers.decoder_only_format)
 
     return DataSpec(dataloader=dl, get_num_tokens_in_batch=token_counting_func)

--- a/llmfoundry/data/finetuning/dataloader.py
+++ b/llmfoundry/data/finetuning/dataloader.py
@@ -216,8 +216,7 @@ def build_finetuning_dataloader(cfg: DictConfig,
             timeout=cfg.get('timeout', 0),
         )
 
-    token_counting_func = get_tokens_per_batch_func(
-        pad_token_id=tokenizer.pad_token_id)
+    token_counting_func = get_tokens_per_batch_func()
 
     return DataSpec(dataloader=dl, get_num_tokens_in_batch=token_counting_func)
 

--- a/tests/data/test_dataloader.py
+++ b/tests/data/test_dataloader.py
@@ -605,11 +605,11 @@ def test_malformed_data(
 @pytest.mark.parametrize('model_max_length', [1024, 2048])
 @pytest.mark.parametrize('padding_side', ['left', 'right'])
 @pytest.mark.parametrize('add_decoder_input_ids', [True, False])
-def test_token_counting_func(pad_token_id: Optional[int], batch_size: int,
+def test_token_counting_func(pad_token_id: int, batch_size: int,
                              model_max_length: int, padding_side: str,
                              add_decoder_input_ids: bool):
     gptt = transformers.AutoTokenizer.from_pretrained('gpt2')
-    gptt.pad_token_id = pad_token_id if pad_token_id is not None else gptt.eos_token_id
+    gptt.pad_token_id = pad_token_id
     gptt.model_max_length = model_max_length
     gptt.padding_side = padding_side
 

--- a/tests/data/test_dataloader.py
+++ b/tests/data/test_dataloader.py
@@ -605,11 +605,11 @@ def test_malformed_data(
 @pytest.mark.parametrize('model_max_length', [1024, 2048])
 @pytest.mark.parametrize('padding_side', ['left', 'right'])
 @pytest.mark.parametrize('add_decoder_input_ids', [True, False])
-def test_token_counting_func(pad_token_id: int, batch_size: int,
+def test_token_counting_func(pad_token_id: Optional[int], batch_size: int,
                              model_max_length: int, padding_side: str,
                              add_decoder_input_ids: bool):
     gptt = transformers.AutoTokenizer.from_pretrained('gpt2')
-    gptt.pad_token_id = pad_token_id
+    gptt.pad_token_id = pad_token_id if pad_token_id is not None else gptt.eos_token_id
     gptt.model_max_length = model_max_length
     gptt.padding_side = padding_side
 
@@ -630,12 +630,12 @@ def test_token_counting_func(pad_token_id: int, batch_size: int,
             decoder_batch_strings.append(' '.join(['hello'] * sample_length))
             decoder_expected_token_count += sample_length
             expected_token_count += sample_length
-        batch_tokenized['decoder_input_ids'] = gptt(
+        batch_tokenized['decoder_attention_mask'] = gptt(
             decoder_batch_strings, padding=True,
-            return_tensors='pt')['input_ids']
+            return_tensors='pt')['attention_mask']
 
     token_counting_func = get_tokens_per_batch_func(
-        pad_token_id, decoder_only=not add_decoder_input_ids)
+        decoder_only=not add_decoder_input_ids)
 
     actual_token_count = token_counting_func(batch_tokenized)
 
@@ -654,7 +654,7 @@ def test_token_counting_func_dataloader_setting(
         model_max_length: int, padding_side: str,
         monkeypatch: pytest.MonkeyPatch):
     gptt = transformers.AutoTokenizer.from_pretrained('gpt2')
-    gptt.pad_token_id = pad_token_id
+    gptt.pad_token_id = pad_token_id if pad_token_id is not None else gptt.eos_token_id
     gptt.model_max_length = model_max_length
     gptt.padding_side = padding_side
 
@@ -662,19 +662,25 @@ def test_token_counting_func_dataloader_setting(
     expected_token_count = 0
     for _ in range(batch_size):
         sample_length = random.randint(
-            1,
-            model_max_length) if pad_token_id is not None else model_max_length
+            1, model_max_length //
+            4) if pad_token_id is not None else model_max_length // 4
         batch_strings.append(' '.join(['hello'] * sample_length))
         expected_token_count += sample_length
 
-    batch_tokenized = gptt(batch_strings,
-                           padding=True if pad_token_id is not None else False,
-                           return_tensors='pt')
+    batch_tokenized = [
+        gptt(b, padding=True if pad_token_id is not None else False)
+        for b in batch_strings
+    ]
 
     if dataloader_type == 'denoising':
-        batch_tokenized['decoder_input_ids'] = batch_tokenized[
-            'input_ids'].clone()
+        expected_token_count += 2 * batch_size  # for the two eos tokens
+        expected_token_count += 5 * batch_size  # for the corruption prefix tokens
+
+    if dataloader_type in {'finetuning-hf', 'finetuning-streaming'}:
+        for b in batch_tokenized:
+            b['labels'] = b['input_ids'].copy()
         expected_token_count *= 2
+        expected_token_count += 1 * batch_size  # for the eos token
 
     common_args = {
         'drop_last': False,
@@ -735,8 +741,10 @@ def test_token_counting_func_dataloader_setting(
             },
             **common_args
         })
+        ds_mock = MagicMock()
+        ds_mock.tokenizer = gptt
         monkeypatch.setattr('llmfoundry.data.text_data.StreamingTextDataset',
-                            lambda *args, **kwargs: MagicMock())
+                            lambda *args, **kwargs: ds_mock)
         dl = build_text_dataloader(cfg, gptt, batch_size)
     elif dataloader_type == 'denoising':
         cfg = DictConfig({
@@ -754,7 +762,7 @@ def test_token_counting_func_dataloader_setting(
             },
             'mixture_of_denoisers': {
                 'decoder_only_format': False,
-                'span_mean_lengths_and_ratios': [[3, .15], [8, .5]],
+                'span_mean_lengths_and_ratios': None,
                 'sequence_mask_ratios': 0.25,
             },
             **common_args
@@ -767,7 +775,8 @@ def test_token_counting_func_dataloader_setting(
 
     cfg = om.create(cfg)
 
-    actual_token_count = dl.get_num_tokens_in_batch(batch_tokenized)
+    batch_collated = dl.dataloader.collate_fn(batch_tokenized)  # type: ignore
+    actual_token_count = dl.get_num_tokens_in_batch(batch_collated)
 
     assert actual_token_count == expected_token_count
 


### PR DESCRIPTION
This fixes off by one errors when pad token and eos token are the same thing.

Manual test compare to before, there are 1440 more tokens counted for a run of length 30 batches * 48 samples per batch, as expected, because there is one eos token per sample.
<img width="337" alt="Screenshot 2023-12-13 at 4 24 13 PM" src="https://github.com/mosaicml/llm-foundry/assets/43149077/c65a0cd5-f686-4139-80ce-dc8077b862af">
