### PR TITLE
add transformer engine fp8 attention

### DIFF
--- a/llmfoundry/models/layers/attention.py
+++ b/llmfoundry/models/layers/attention.py
@@ -837,3 +837,10 @@ ATTN_CLASS_REGISTRY = {
     'multiquery_attention': MultiQueryAttention,
     'grouped_query_attention': GroupedQueryAttention
 }
+
+try:
+    import transformer_engine.pytorch as te
+
+    ATTN_CLASS_REGISTRY['te_multihead_attention'] = te.MultiheadAttention
+except:
+    pass


### PR DESCRIPTION
This PR adds the TransformerEngine fp8 attention implemention. https://github.com/NVIDIA/TransformerEngine/blob/main/transformer_engine/pytorch/attention.py.

To enable it, set the below fields in the yaml config. 
```
precision: amp_fp8
model:
  attn_config:
    attn_type: te_multihead_attention
    kv_n_heads: 8
  fc_type: te
```