### PR TITLE
Fix token counting to allow there to be no attention mask

### DIFF
--- a/llmfoundry/data/text_data.py
+++ b/llmfoundry/data/text_data.py
@@ -325,7 +325,8 @@ def get_tokens_per_batch_func(
     """
 
     def get_num_samples_in_batch(batch: Batch) -> int:
-        if not isinstance(batch, Mapping) or 'attention_mask' not in batch:
+        if not isinstance(batch, Mapping) or ('attention_mask' not in batch and
+                                              'input_ids' not in batch):
             raise ValueError(
                 'get_tokens_per_batch_func() requires a batch with an attention_mask key'
             )
@@ -336,7 +337,10 @@ def get_tokens_per_batch_func(
             )
 
         # Count number of non padding tokens in batch
-        input_ids_tokens = int(torch.sum(batch['attention_mask']).item())
+        if 'attention_mask' in batch:
+            input_ids_tokens = int(torch.sum(batch['attention_mask']).item())
+        else:
+            input_ids_tokens = batch['input_ids'].numel()
 
         # For encoder decoder models only
         decoder_input_ids_tokens = 0

--- a/llmfoundry/data/text_data.py
+++ b/llmfoundry/data/text_data.py
@@ -328,7 +328,7 @@ def get_tokens_per_batch_func(
         if not isinstance(batch, Mapping) or ('attention_mask' not in batch and
                                               'input_ids' not in batch):
             raise ValueError(
-                'get_tokens_per_batch_func() requires a batch with an attention_mask key'
+                'get_tokens_per_batch_func() requires a batch with an attention_mask key or an input_ids key'
             )
 
         if not decoder_only and 'decoder_attention_mask' not in batch:


### PR DESCRIPTION
When we pretokenize, we just pass raw tensors to the collator, which does not add an attention mask. This is fine, because we pretokenize without padding, but would crash on the token counting function if your tokenizer had a pad token.

IFT token count same before and after
<img width="414" alt="Screenshot 2023-12-21 at 4 11 02 PM" src="https://github.com/mosaicml/llm-foundry/assets/43149077/e5a7085e-8d86-4bbf-b7a5-0b4810c38028">

pretokenized token count as expected (40x2048x960)
<img width="417" alt="Screenshot 2023-12-21 at 4 11 13 PM" src="https://github.com/mosaicml/llm-foundry/assets/43149077/8065d2f1-e75d-4d71-9c6d-8add10bd5b32">
