### PR TITLE
Use `sync_module_states: True` when using HSDP

### DIFF
--- a/llmfoundry/utils/config_utils.py
+++ b/llmfoundry/utils/config_utils.py
@@ -120,13 +120,14 @@ def process_init_device(model_cfg: DictConfig, fsdp_config: Optional[Dict]):
             # Set defaults for mixed initialization
             fsdp_config.setdefault('use_orig_params', False)
             fsdp_config.setdefault('load_monolith_rank0_only', True)
-        # Always set `sync_module_states` to True when using hybrid sharding
-        if fsdp_config.get('sharding_strategy', 'FULL_SHARD') in ['HYBRID_SHARD', '_HYBRID_SHARD_ZERO2'] \
-                and not fsdp_config.get('sync_module_states', False):
-            warnings.warn((
-                'Setting `sync_module_states = True` for FSDP. This is required '
-                'when using hybrid sharding.'))
-            fsdp_config['sync_module_states'] = True
+    # Always set `sync_module_states` to True when using hybrid sharding
+    if fsdp_config is not None and \
+            fsdp_config.get('sharding_strategy', 'FULL_SHARD') in ['HYBRID_SHARD', '_HYBRID_SHARD_ZERO2'] \
+            and not fsdp_config.get('sync_module_states', False):
+        warnings.warn(
+            ('Setting `sync_module_states = True` for FSDP. This is required '
+             'when using hybrid sharding.'))
+        fsdp_config['sync_module_states'] = True
 
     # no mixed precision needed for weights when they're already 16 bits
     master_dtype = model_cfg.get('master_weights_dtype')

--- a/llmfoundry/utils/config_utils.py
+++ b/llmfoundry/utils/config_utils.py
@@ -120,6 +120,13 @@ def process_init_device(model_cfg: DictConfig, fsdp_config: Optional[Dict]):
             # Set defaults for mixed initialization
             fsdp_config.setdefault('use_orig_params', False)
             fsdp_config.setdefault('load_monolith_rank0_only', True)
+        # Always set `sync_module_states` to True when using hybrid sharding
+        if fsdp_config.get('sharding_strategy', 'FULL_SHARD') in ['HYBRID_SHARD', '_HYBRID_SHARD_ZERO2'] \
+                and not fsdp_config.get('sync_module_states', False):
+            warnings.warn((
+                'Setting `sync_module_states = True` for FSDP. This is required '
+                'when using hybrid sharding.'))
+            fsdp_config['sync_module_states'] = True
 
     # no mixed precision needed for weights when they're already 16 bits
     master_dtype = model_cfg.get('master_weights_dtype')


### PR DESCRIPTION
If a user is training from scratch with one of the HSDP hybrid sharding strategies, they must use `sync_module_states: True` otherwise the different data replicas will start with different randomly initialized weights.