### PR TITLE
use current year in license

### DIFF
--- a/.github/mcp/mcp_pytest.py
+++ b/.github/mcp/mcp_pytest.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 """Run pytest using MCP."""

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,7 @@ repos:
   - id: mixed-line-ending
   - id: trailing-whitespace
 - repo: https://github.com/Lucas-C/pre-commit-hooks
-  rev: v1.3.1
+  rev: v1.5.4
   hooks:
   - id: insert-license
     args:
@@ -65,6 +65,7 @@ repos:
     - .ci/FILE_HEADER
     - --comment-style
     - '#'
+    - --use-current-year
     types: [python]
 - repo: https://github.com/PyCQA/docformatter
   rev: v1.5.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,7 @@ repos:
   - id: mixed-line-ending
   - id: trailing-whitespace
 - repo: https://github.com/Lucas-C/pre-commit-hooks
-  rev: v1.5.4
+  rev: v1.5.0
   hooks:
   - id: insert-license
     args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,7 +66,6 @@ repos:
     - --comment-style
     - '#'
     - --use-current-year
-    - --allow-past-years
     types: [python]
 - repo: https://github.com/PyCQA/docformatter
   rev: v1.5.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,7 @@ repos:
   - id: mixed-line-ending
   - id: trailing-whitespace
 - repo: https://github.com/Lucas-C/pre-commit-hooks
-  rev: v1.5.0
+  rev: v1.5.4
   hooks:
   - id: insert-license
     args:
@@ -66,6 +66,7 @@ repos:
     - --comment-style
     - '#'
     - --use-current-year
+    - --allow-past-years
     types: [python]
 - repo: https://github.com/PyCQA/docformatter
   rev: v1.5.0

--- a/llmfoundry/__init__.py
+++ b/llmfoundry/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/llmfoundry/callbacks/__init__.py
+++ b/llmfoundry/callbacks/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 try:

--- a/llmfoundry/callbacks/async_eval_callback.py
+++ b/llmfoundry/callbacks/async_eval_callback.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 """Run the eval loop asynchronously as part of a MosaicML platform run.

--- a/llmfoundry/callbacks/eval_gauntlet_callback.py
+++ b/llmfoundry/callbacks/eval_gauntlet_callback.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 """Aggregate ICL evals into composite scores."""

--- a/llmfoundry/callbacks/fdiff_callback.py
+++ b/llmfoundry/callbacks/fdiff_callback.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 """Monitor rate of change of loss."""

--- a/llmfoundry/callbacks/generate_callback.py
+++ b/llmfoundry/callbacks/generate_callback.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 """Deprecated Generate callback.

--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import contextlib

--- a/llmfoundry/callbacks/model_gauntlet_callback.py
+++ b/llmfoundry/callbacks/model_gauntlet_callback.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 from composer.core import Callback

--- a/llmfoundry/callbacks/monolithic_ckpt_callback.py
+++ b/llmfoundry/callbacks/monolithic_ckpt_callback.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import contextlib

--- a/llmfoundry/callbacks/resumption_callbacks.py
+++ b/llmfoundry/callbacks/resumption_callbacks.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/llmfoundry/callbacks/scheduled_gc_callback.py
+++ b/llmfoundry/callbacks/scheduled_gc_callback.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import gc

--- a/llmfoundry/data/__init__.py
+++ b/llmfoundry/data/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 from llmfoundry.data.data import ConcatTokensDataset, NoConcatDataset

--- a/llmfoundry/data/data.py
+++ b/llmfoundry/data/data.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 """Datasets for converting to MDS Shards."""

--- a/llmfoundry/data/dataloader.py
+++ b/llmfoundry/data/dataloader.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 """Dataloader builder utilities."""

--- a/llmfoundry/data/denoising.py
+++ b/llmfoundry/data/denoising.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 """Streaming dataloader for (mixture of) denoising task(s)."""

--- a/llmfoundry/data/finetuning/__init__.py
+++ b/llmfoundry/data/finetuning/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 from llmfoundry.data.finetuning.collator import Seq2SeqFinetuningCollator

--- a/llmfoundry/data/finetuning/collator.py
+++ b/llmfoundry/data/finetuning/collator.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/llmfoundry/data/finetuning/dataloader.py
+++ b/llmfoundry/data/finetuning/dataloader.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 import logging
 import os

--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 """Includes code for task-specific seq-to-seq data formatting.

--- a/llmfoundry/data/packing.py
+++ b/llmfoundry/data/packing.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/llmfoundry/data/text_data.py
+++ b/llmfoundry/data/text_data.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 """Build a StreamingTextDataset dataset and dataloader for training."""

--- a/llmfoundry/models/__init__.py
+++ b/llmfoundry/models/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 from llmfoundry.models.hf import (ComposerHFCausalLM, ComposerHFPrefixLM,

--- a/llmfoundry/models/hf/__init__.py
+++ b/llmfoundry/models/hf/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 from llmfoundry.models.hf.hf_causal_lm import ComposerHFCausalLM

--- a/llmfoundry/models/hf/hf_causal_lm.py
+++ b/llmfoundry/models/hf/hf_causal_lm.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 """Implements a Hugging Causal LM wrapped inside a :class:`.ComposerModel`."""

--- a/llmfoundry/models/hf/hf_fsdp.py
+++ b/llmfoundry/models/hf/hf_fsdp.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 # helper functions from https://github.com/CarperAI/trlx/blob/main/trlx/utils/modeling.py

--- a/llmfoundry/models/hf/hf_prefix_lm.py
+++ b/llmfoundry/models/hf/hf_prefix_lm.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 """Implements a Hugging Prefix LM wrapped inside a :class:`.ComposerModel`."""

--- a/llmfoundry/models/hf/hf_t5.py
+++ b/llmfoundry/models/hf/hf_t5.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 """Implements a Hugging Face T5 wrapped inside a :class:`.ComposerModel`."""

--- a/llmfoundry/models/hf/model_wrapper.py
+++ b/llmfoundry/models/hf/model_wrapper.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 """Re-usable :class:`.ComposerModel` for LLM HF Models."""

--- a/llmfoundry/models/inference_api_wrapper/__init__.py
+++ b/llmfoundry/models/inference_api_wrapper/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 from llmfoundry.models.inference_api_wrapper.interface import \

--- a/llmfoundry/models/inference_api_wrapper/interface.py
+++ b/llmfoundry/models/inference_api_wrapper/interface.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, Optional

--- a/llmfoundry/models/inference_api_wrapper/openai_causal_lm.py
+++ b/llmfoundry/models/inference_api_wrapper/openai_causal_lm.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 """Implements a OpenAI chat and causal LM inference API wrappers."""

--- a/llmfoundry/models/layers/__init__.py
+++ b/llmfoundry/models/layers/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 from llmfoundry.models.layers.attention import (

--- a/llmfoundry/models/layers/attention.py
+++ b/llmfoundry/models/layers/attention.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 """Attention layers."""

--- a/llmfoundry/models/layers/blocks.py
+++ b/llmfoundry/models/layers/blocks.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 """GPT Blocks used for the GPT Model."""

--- a/llmfoundry/models/layers/custom_embedding.py
+++ b/llmfoundry/models/layers/custom_embedding.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import torch.nn as nn

--- a/llmfoundry/models/layers/fc.py
+++ b/llmfoundry/models/layers/fc.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 from torch import nn

--- a/llmfoundry/models/layers/ffn.py
+++ b/llmfoundry/models/layers/ffn.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 """MPT Blocks used for the MPT Model."""

--- a/llmfoundry/models/layers/llama_attention_monkeypatch.py
+++ b/llmfoundry/models/layers/llama_attention_monkeypatch.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 # This file is copied and modified from

--- a/llmfoundry/models/layers/norm.py
+++ b/llmfoundry/models/layers/norm.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Dict, List, Optional, Type, Union

--- a/llmfoundry/models/model_registry.py
+++ b/llmfoundry/models/model_registry.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 from llmfoundry.models.hf import (ComposerHFCausalLM, ComposerHFPrefixLM,

--- a/llmfoundry/models/mpt/__init__.py
+++ b/llmfoundry/models/mpt/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 from llmfoundry.models.mpt.configuration_mpt import MPTConfig

--- a/llmfoundry/models/mpt/configuration_mpt.py
+++ b/llmfoundry/models/mpt/configuration_mpt.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 """A HuggingFace-style model configuration."""

--- a/llmfoundry/models/mpt/modeling_mpt.py
+++ b/llmfoundry/models/mpt/modeling_mpt.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 """A simple, flexible implementation of a GPT model.

--- a/llmfoundry/models/utils/__init__.py
+++ b/llmfoundry/models/utils/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 from llmfoundry.models.utils.adapt_tokenizer import (

--- a/llmfoundry/models/utils/adapt_tokenizer.py
+++ b/llmfoundry/models/utils/adapt_tokenizer.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any

--- a/llmfoundry/models/utils/hf_prefixlm_converter.py
+++ b/llmfoundry/models/utils/hf_prefixlm_converter.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 """Converts Huggingface Causal LM to Prefix LM.

--- a/llmfoundry/models/utils/meta_init_context.py
+++ b/llmfoundry/models/utils/meta_init_context.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 # Copyright 2022 The HuggingFace Team. All rights reserved.

--- a/llmfoundry/models/utils/param_init_fns.py
+++ b/llmfoundry/models/utils/param_init_fns.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/llmfoundry/optim/__init__.py
+++ b/llmfoundry/optim/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 from llmfoundry.optim.adaptive_lion import DecoupledAdaLRLion, DecoupledClipLion

--- a/llmfoundry/optim/adaptive_lion.py
+++ b/llmfoundry/optim/adaptive_lion.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/llmfoundry/optim/lion.py
+++ b/llmfoundry/optim/lion.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/llmfoundry/optim/lion8b.py
+++ b/llmfoundry/optim/lion8b.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Callable, Dict, Iterable, Optional, Tuple, Union

--- a/llmfoundry/optim/outlier_detection.py
+++ b/llmfoundry/optim/outlier_detection.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import collections

--- a/llmfoundry/optim/scheduler.py
+++ b/llmfoundry/optim/scheduler.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 """Experimental learning rate schedulers used for training LLMs."""

--- a/llmfoundry/tokenizers/__init__.py
+++ b/llmfoundry/tokenizers/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 from llmfoundry.tokenizers.tiktoken import TiktokenTokenizerWrapper

--- a/llmfoundry/tokenizers/tiktoken.py
+++ b/llmfoundry/tokenizers/tiktoken.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 from functools import lru_cache
 from typing import Any, Dict, List, Optional, Tuple

--- a/llmfoundry/utils/__init__.py
+++ b/llmfoundry/utils/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 try:

--- a/llmfoundry/utils/builders.py
+++ b/llmfoundry/utils/builders.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import functools

--- a/llmfoundry/utils/checkpoint_conversion_helpers.py
+++ b/llmfoundry/utils/checkpoint_conversion_helpers.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 """Helper methods for the checkpoint conversion scripts.

--- a/llmfoundry/utils/config_utils.py
+++ b/llmfoundry/utils/config_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import contextlib

--- a/llmfoundry/utils/data_prep_utils.py
+++ b/llmfoundry/utils/data_prep_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import json

--- a/llmfoundry/utils/huggingface_hub_utils.py
+++ b/llmfoundry/utils/huggingface_hub_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import ast

--- a/llmfoundry/utils/logging_utils.py
+++ b/llmfoundry/utils/logging_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/llmfoundry/utils/model_download_utils.py
+++ b/llmfoundry/utils/model_download_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 """Utility functions for downloading models."""

--- a/llmfoundry/utils/prompt_files.py
+++ b/llmfoundry/utils/prompt_files.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/scripts/data_prep/convert_dataset_hf.py
+++ b/scripts/data_prep/convert_dataset_hf.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 """Streaming dataset conversion scripts for C4 and The Pile."""

--- a/scripts/data_prep/convert_dataset_json.py
+++ b/scripts/data_prep/convert_dataset_json.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 """Streaming dataset conversion scripts for json files."""

--- a/scripts/data_prep/convert_finetuning_dataset.py
+++ b/scripts/data_prep/convert_finetuning_dataset.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/scripts/data_prep/convert_text_to_mds.py
+++ b/scripts/data_prep/convert_text_to_mds.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/scripts/eval/eval.py
+++ b/scripts/eval/eval.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import copy

--- a/scripts/inference/__init__.py
+++ b/scripts/inference/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 __all__ = []

--- a/scripts/inference/benchmarking/benchmark.py
+++ b/scripts/inference/benchmarking/benchmark.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import sys

--- a/scripts/inference/convert_composer_mpt_to_ft.py
+++ b/scripts/inference/convert_composer_mpt_to_ft.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 # Note: This script is specifically for converting MPT Composer checkpoints to FasterTransformer format.

--- a/scripts/inference/convert_composer_to_hf.py
+++ b/scripts/inference/convert_composer_to_hf.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/scripts/inference/convert_hf_mpt_to_ft.py
+++ b/scripts/inference/convert_hf_mpt_to_ft.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 # Copyright (c) 2021-2023, NVIDIA CORPORATION.  All rights reserved.

--- a/scripts/inference/convert_hf_to_onnx.py
+++ b/scripts/inference/convert_hf_to_onnx.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 """Basic HuggingFace -> ONNX export script.

--- a/scripts/inference/endpoint_generate.py
+++ b/scripts/inference/endpoint_generate.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 """Batch generate text completion results from an endpoint.

--- a/scripts/inference/hf_chat.py
+++ b/scripts/inference/hf_chat.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import time

--- a/scripts/inference/hf_generate.py
+++ b/scripts/inference/hf_generate.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 import itertools
 import random

--- a/scripts/inference/run_mpt_with_ft.py
+++ b/scripts/inference/run_mpt_with_ft.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 # Copyright (c) 2021-2023, NVIDIA CORPORATION.  All rights reserved.

--- a/scripts/misc/convert_examples_ckpt.py
+++ b/scripts/misc/convert_examples_ckpt.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/scripts/misc/download_hf_model.py
+++ b/scripts/misc/download_hf_model.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 """Script to download model weights from Hugging Face Hub or a cache server."""

--- a/scripts/misc/profile_packing.py
+++ b/scripts/misc/profile_packing.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 """Script to profile example packing."""

--- a/scripts/misc/update_hub_code.py
+++ b/scripts/misc/update_hub_code.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/scripts/train/benchmarking/collect_results.py
+++ b/scripts/train/benchmarking/collect_results.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/scripts/train/benchmarking/submit_benchmarks.py
+++ b/scripts/train/benchmarking/submit_benchmarks.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 import argparse
 import math

--- a/scripts/train/benchmarking/sweep.py
+++ b/scripts/train/benchmarking/sweep.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/scripts/train/finetune_example/preprocessing.py
+++ b/scripts/train/finetune_example/preprocessing.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 r"""Example custom preprocessing function.

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 import copy
 import gc

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ install_requires = [
 extra_deps = {}
 
 extra_deps['dev'] = [
-    'pre-commit>=3.2.0,<3',
+    'pre-commit>=3.2.0,<4',
     'pytest>=7.2.1,<8',
     'pytest_codeblocks>=0.16.1,<0.17',
     'pytest-cov>=4,<5',

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,6 @@
+# Copyright 2024 MosaicML LLM Foundry authors
+# SPDX-License-Identifier: Apache-2.0
+
 """MosaicML LLM Foundry package setup."""
 
 import os
@@ -73,7 +76,7 @@ install_requires = [
 extra_deps = {}
 
 extra_deps['dev'] = [
-    'pre-commit>=2.18.1,<3',
+    'pre-commit>=3.2.0,<3',
     'pytest>=7.2.1,<8',
     'pytest_codeblocks>=0.16.1,<0.17',
     'pytest-cov>=4,<5',

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ install_requires = [
 extra_deps = {}
 
 extra_deps['dev'] = [
-    'pre-commit>=3.2.0,<4',
+    'pre-commit>=2.18.1,<3',
     'pytest>=7.2.1,<8',
     'pytest_codeblocks>=0.16.1,<0.17',
     'pytest-cov>=4,<5',

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0

--- a/tests/a_scripts/__init__.py
+++ b/tests/a_scripts/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 # TODO: This test directory is called "a_scripts" to enforce that these tests are run

--- a/tests/a_scripts/data_prep/__init__.py
+++ b/tests/a_scripts/data_prep/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0

--- a/tests/a_scripts/data_prep/test_convert_dataset_hf.py
+++ b/tests/a_scripts/data_prep/test_convert_dataset_hf.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/tests/a_scripts/data_prep/test_convert_dataset_json.py
+++ b/tests/a_scripts/data_prep/test_convert_dataset_json.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/tests/a_scripts/data_prep/test_convert_text_to_mds.py
+++ b/tests/a_scripts/data_prep/test_convert_text_to_mds.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/tests/a_scripts/eval/__init__.py
+++ b/tests/a_scripts/eval/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0

--- a/tests/a_scripts/eval/test_eval.py
+++ b/tests/a_scripts/eval/test_eval.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import copy

--- a/tests/a_scripts/eval/test_eval_inputs.py
+++ b/tests/a_scripts/eval/test_eval_inputs.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 import copy
 import os

--- a/tests/a_scripts/inference/__init__.py
+++ b/tests/a_scripts/inference/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0

--- a/tests/a_scripts/inference/test_convert_composer_to_hf.py
+++ b/tests/a_scripts/inference/test_convert_composer_to_hf.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/tests/a_scripts/train/__init__.py
+++ b/tests/a_scripts/train/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0

--- a/tests/a_scripts/train/test_train.py
+++ b/tests/a_scripts/train/test_train.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 import copy
 import pathlib

--- a/tests/a_scripts/train/test_train_inputs.py
+++ b/tests/a_scripts/train/test_train_inputs.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 import copy
 import json

--- a/tests/callbacks/__init__.py
+++ b/tests/callbacks/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0

--- a/tests/callbacks/test_async_eval_callback.py
+++ b/tests/callbacks/test_async_eval_callback.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import datetime

--- a/tests/callbacks/test_eval_gauntlet_callback.py
+++ b/tests/callbacks/test_eval_gauntlet_callback.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0

--- a/tests/data/test_dataloader.py
+++ b/tests/data/test_dataloader.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 import contextlib
 import os

--- a/tests/data/test_icl_datasets.py
+++ b/tests/data/test_icl_datasets.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import pathlib

--- a/tests/data/test_packing.py
+++ b/tests/data/test_packing.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 from pathlib import Path

--- a/tests/data_utils.py
+++ b/tests/data_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import json

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0

--- a/tests/fixtures/autouse.py
+++ b/tests/fixtures/autouse.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import gc

--- a/tests/fixtures/data.py
+++ b/tests/fixtures/data.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 from pathlib import Path

--- a/tests/fixtures/models.py
+++ b/tests/fixtures/models.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Callable

--- a/tests/horrible_strings.py
+++ b/tests/horrible_strings.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 # taken from https://github.com/explosion/spaCy/blob/8f0d6b0a8c42e4852bf6e24cdf629043f2f39361/spacy/tests/tokenizer/test_naughty_strings.py#L7

--- a/tests/models/__init__.py
+++ b/tests/models/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0

--- a/tests/models/hf/__init__.py
+++ b/tests/models/hf/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0

--- a/tests/models/hf/test_hf_config.py
+++ b/tests/models/hf/test_hf_config.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/tests/models/hf/test_hf_mpt_gen.py
+++ b/tests/models/hf/test_hf_mpt_gen.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Callable

--- a/tests/models/hf/test_hf_v_mpt.py
+++ b/tests/models/hf/test_hf_v_mpt.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 import warnings
 from typing import Optional

--- a/tests/models/inference_api_wrapper/__init__.py
+++ b/tests/models/inference_api_wrapper/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0

--- a/tests/models/inference_api_wrapper/test_inference_api_eval_wrapper.py
+++ b/tests/models/inference_api_wrapper/test_inference_api_eval_wrapper.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/tests/models/layers/__init__.py
+++ b/tests/models/layers/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0

--- a/tests/models/layers/test_flash_attn.py
+++ b/tests/models/layers/test_flash_attn.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/tests/models/layers/test_flash_triton_torch.py
+++ b/tests/models/layers/test_flash_triton_torch.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/models/layers/test_huggingface_flash.py
+++ b/tests/models/layers/test_huggingface_flash.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import contextlib

--- a/tests/models/test_fsdp_act_checkpoint.py
+++ b/tests/models/test_fsdp_act_checkpoint.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Union

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 import contextlib
 import copy

--- a/tests/models/test_mpt_gen.py
+++ b/tests/models/test_mpt_gen.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Callable, List, Optional, Tuple

--- a/tests/models/test_onnx.py
+++ b/tests/models/test_onnx.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import pathlib

--- a/tests/models/test_rope_dail_vs_hf.py
+++ b/tests/models/test_rope_dail_vs_hf.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/models/utils/__init__.py
+++ b/tests/models/utils/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0

--- a/tests/models/utils/test_param_init_fns.py
+++ b/tests/models/utils/test_param_init_fns.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 import math
 from collections import OrderedDict

--- a/tests/optim/__init__.py
+++ b/tests/optim/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0

--- a/tests/optim/test_lion8b.py
+++ b/tests/optim/test_lion8b.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/tests/optim/test_scheduler.py
+++ b/tests/optim/test_scheduler.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import List

--- a/tests/test_smoketest.py
+++ b/tests/test_smoketest.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 from llmfoundry import callbacks, data, models, optim, tokenizers, utils

--- a/tests/tokenizers/__init__.py
+++ b/tests/tokenizers/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0

--- a/tests/tokenizers/test_tiktoken.py
+++ b/tests/tokenizers/test_tiktoken.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import pathlib

--- a/tests/tokenizers/test_tokenizer.py
+++ b/tests/tokenizers/test_tokenizer.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 from omegaconf import OmegaConf as om

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0

--- a/tests/utils/test_builders.py
+++ b/tests/utils/test_builders.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import re

--- a/tests/utils/test_huggingface_hub_utils.py
+++ b/tests/utils/test_huggingface_hub_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import ast

--- a/tests/utils/test_model_download_utils.py
+++ b/tests/utils/test_model_download_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/tests/utils/test_prompt_files.py
+++ b/tests/utils/test_prompt_files.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML LLM Foundry authors
+# Copyright 2022-2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
 from pathlib import Path


### PR DESCRIPTION
Not finding exactly what I want from this pre-commit hook, there were a few options here:
a. update the license header file with 2024 and don't mess with insert-license configuration
   * Updates all files with 2024. Would require us to update this file every year manually if we want to automatically keep it up to date

b. update insert-license to include --use-current-year
   * Updates all files with 2022-2024. Whoever makes the first commit of 2025 will change every single file with the pre commit hook
   * I can't seem to find any difference between --use-current-year by itself and --use-current-year + --allow-past-years  https://github.com/Lucas-C/pre-commit-hooks?tab=readme-ov-file#handling-years-flexibly

Went with (b) to have this be a little more automated 🤷‍♀️ 