### PR TITLE
Fix error when decoding a token in the id gap (or out of range) in a tiktoken tokenizer

### DIFF
--- a/llmfoundry/tokenizers/tiktoken.py
+++ b/llmfoundry/tokenizers/tiktoken.py
@@ -254,8 +254,8 @@ class TiktokenTokenizerWrapper(PreTrainedTokenizer):
     def _convert_id_to_token(self, index: int) -> Optional[str]:
         """Converts an index (integer) in a token (str) using the vocab."""
         # For tokens in either the gap in ids in the tokenizer, or beyond the range of the tokenizer,
-        # we return empty string. This matches the behavior of some Hugging Face tokenizers (e.g. llama, opt),
-        # but not all (e.g. gpt2 which crashes on out of range ids)
+        # we return empty string. This matches the behavior of Hugging Face fast tokenizers,
+        # but not slow tokenizers.
         return self.decoder.get(index, '')
 
     def convert_tokens_to_string(self, tokens: List[str]) -> str:

--- a/llmfoundry/tokenizers/tiktoken.py
+++ b/llmfoundry/tokenizers/tiktoken.py
@@ -7,6 +7,7 @@ import torch
 from transformers import PreTrainedTokenizer
 
 DEFAULT_SYSTEM_PROMPT = """You are a helpful, respectful and honest assistant. Always answer as helpfully as possible."""
+_DEFAULT_GAP_TOKEN = '<|gaptoken|>'
 
 
 # Taken from
@@ -253,7 +254,17 @@ class TiktokenTokenizerWrapper(PreTrainedTokenizer):
 
     def _convert_id_to_token(self, index: int) -> Optional[str]:
         """Converts an index (integer) in a token (str) using the vocab."""
-        return self.decoder.get(index)
+        # Happy case: index directly points to a token
+        if index in self.decoder:
+            return self.decoder[index]
+        # Gap case: index is in the gap in ids in the tokenizer, so we return either
+        # the unk token or the default gap token
+        elif index < self.encoding.n_vocab:
+            return self.unk_token or _DEFAULT_GAP_TOKEN
+        # Error case: index is outside the range of the tokenizer
+        else:
+            raise ValueError(
+                f'Index {index} is outside of the range of the tokenizer.')
 
     def convert_tokens_to_string(self, tokens: List[str]) -> str:
         """Converts a sequence of tokens (string) in a single string."""

--- a/llmfoundry/utils/huggingface_hub_utils.py
+++ b/llmfoundry/utils/huggingface_hub_utils.py
@@ -59,7 +59,7 @@ def process_file(
     folder_path: str,
     flatten_imports_prefix: Sequence[str],
 ) -> list[str]:
-    with open(file_path, 'r') as f:
+    with open(file_path, 'r', encoding='utf-8') as f:
         source = f.read()
 
     parent_module_name = None

--- a/llmfoundry/utils/huggingface_hub_utils.py
+++ b/llmfoundry/utils/huggingface_hub_utils.py
@@ -102,7 +102,7 @@ def process_file(
     if new_filename == '__init__.py':
         new_filename = file_path.split('/')[-2] + '.py'
     new_file_path = os.path.join(folder_path, new_filename)
-    with open(new_file_path, 'w') as f:
+    with open(new_file_path, 'w', encoding='utf-8') as f:
         assert new_tree is not None
         f.write(ast.unparse(new_tree))
 


### PR DESCRIPTION
Previously, if you tried to decode an invalid token, the tokenizer would crash. For a trained model, this would never be an issue because it would not produce invalid tokens, but for an untrained model, it could randomly produce any token up to the embedding size. This PR has the tokenizer instead return empty string for these invalid tokens.

This behavior matches some Hugging Face fast tokenizers, but not slow tokenizers, which error on out of range indices. Even though the tiktoken wrapper is technically a slow tokenizer, the fast behavior seems better to avoid crashes on random models.

It also adds a utf-8 encoding to two file open calls. See https://github.com/mosaicml/composer/pull/2824 for more details.