### PR TITLE
Add use_tokenizer_eos option to convert text to mds script

### DIFF
--- a/scripts/data_prep/convert_text_to_mds.py
+++ b/scripts/data_prep/convert_text_to_mds.py
@@ -47,18 +47,21 @@ def parse_args() -> Namespace:
         '--compression',
         type=str,
         default='zstd',
+        required=False,
         help='The compression algorithm to use for MDS writing',
     )
 
     parser.add_argument(
         '--concat_tokens',
         type=int,
+        required=True,
         help='Convert text to tokens and concatenate up to this many tokens',
     )
 
     parser.add_argument(
         '--tokenizer',
         type=str,
+        required=True,
         help='The name of the tokenizer to use',
     )
     parser.add_argument(
@@ -77,6 +80,12 @@ def parse_args() -> Namespace:
         help=
         'The text to append to each example to separate concatenated examples',
     )
+
+    parser.add_argument('--use_tokenizer_eos',
+                        type=bool,
+                        required=False,
+                        default=False,
+                        help='Use the EOS text from the tokenizer.')
     parser.add_argument(
         '--no_wrap',
         default=False,
@@ -103,11 +112,15 @@ def parse_args() -> Namespace:
 
     parsed = parser.parse_args()
 
-    # Make sure we have needed concat options
-    if (parsed.concat_tokens is not None and
-            isinstance(parsed.concat_tokens, int) and parsed.tokenizer is None):
-        parser.error(
-            'When setting --concat_tokens, you must specify a --tokenizer')
+    # Set eos token.
+    if parsed.use_tokenizer_eos:
+        # Ensure that eos text is not specified twice.
+        if parsed.eos_text is not None:
+            parser.error(
+                'Cannot set --eos_text with --use_tokenizer_eos. Please specify one.'
+            )
+        tokenizer = AutoTokenizer.from_pretrained(parsed.tokenizer)
+        parsed.eos_text = tokenizer.eos_token
 
     # now that we have validated them, change BOS/EOS to strings
     if parsed.bos_text is None:

--- a/scripts/data_prep/convert_text_to_mds.py
+++ b/scripts/data_prep/convert_text_to_mds.py
@@ -80,12 +80,13 @@ def parse_args() -> Namespace:
         help=
         'The text to append to each example to separate concatenated examples',
     )
-
-    parser.add_argument('--use_tokenizer_eos',
-                        type=bool,
-                        required=False,
-                        default=False,
-                        help='Use the EOS text from the tokenizer.')
+    parser.add_argument(
+        '--use_tokenizer_eos',
+        required=False,
+        action='store_true',
+        default=False,
+        help='Use the EOS text from the tokenizer.',
+    )
     parser.add_argument(
         '--no_wrap',
         default=False,


### PR DESCRIPTION
# Manual Test
(1) Make some test files
```
import os
os.mkdir('in')
for i in range(5):
    with open(f'in/file{i}.txt', 'w') as f:
        f.write(f' HELLO{i} ' * 250)
```
(2) Run conversion with `--use_tokenizer_eos`
```
`python convert_text_to_mds.py --input_folder in --output_folder out --concat_tokens 2048 --tokenizer mosaicml/mpt-7b --use_tokenizer_eos --processes 1`
```
(3) Print out 0th sample to see the `<|endoftext|>` token between text sequences
```
    tokenizer = AutoTokenizer.from_pretrained('mosaicml/mpt-7b')
    dataset = StreamingDataset(local='out', num_canonical_nodes=1)
    sample = dataset[0]
    tokens = np.frombuffer(sample['tokens'], dtype=int)
    decoded = tokenizer.decode(tokens)
    print(decoded)
```

