### PR TITLE
Disable Environment Variable Resolution

### DIFF
--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -635,6 +635,11 @@ def main(cfg: DictConfig) -> Trainer:
 
 if __name__ == '__main__':
     yaml_path, args_list = sys.argv[1], sys.argv[2:]
+
+    # Disable resolving environment variables through omegaconf.
+    om.clear_resolver('oc.env')
+
+    # Load yaml and cli arguments.
     with open(yaml_path) as f:
         yaml_cfg = om.load(f)
     cli_cfg = om.from_cli(args_list)


### PR DESCRIPTION
# Manual tests
## Before
ift-mpt-7b-zmb50m - works as expected
## After (using this branch)
ift-mpt-7b-env-disabled-nr5HmB - fails as expected with omegaconf error
ift-mpt-7b-env-disabled-with-yaml-res-mdubZr - works because only yaml res
