### PR TITLE
Always initialize dist 

### DIFF
--- a/tests/a_scripts/eval/test_eval.py
+++ b/tests/a_scripts/eval/test_eval.py
@@ -71,7 +71,6 @@ def test_icl_eval(eval_cfg: Union[om.ListConfig, om.DictConfig], capfd: Any,
     assert expected_results in out
 
 
-@pytest.mark.gpu
 def test_loader_eval(capfd: Any, mock_saved_model_path: Any,
                      tmp_path: pathlib.Path):
 

--- a/tests/fixtures/autouse.py
+++ b/tests/fixtures/autouse.py
@@ -17,9 +17,6 @@ sys.path.append(REPO_DIR)
 @pytest.fixture(autouse=True)
 def initialize_dist(request: pytest.FixtureRequest):
     """Initialize the default PyTorch distributed process group for tests."""
-    # should we just always initialize dist like in train.py?
-    _default = pytest.mark.world_size(1).mark
-    world_size = request.node.get_closest_marker('world_size', _default).args[0]
     gpu = request.node.get_closest_marker('gpu')
     dist.initialize_dist(get_device('gpu' if gpu is not None else 'cpu'))
 

--- a/tests/fixtures/autouse.py
+++ b/tests/fixtures/autouse.py
@@ -21,8 +21,7 @@ def initialize_dist(request: pytest.FixtureRequest):
     _default = pytest.mark.world_size(1).mark
     world_size = request.node.get_closest_marker('world_size', _default).args[0]
     gpu = request.node.get_closest_marker('gpu')
-    if world_size > 1:
-        dist.initialize_dist(get_device('gpu' if gpu is not None else 'cpu'))
+    dist.initialize_dist(get_device('gpu' if gpu is not None else 'cpu'))
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Always initialize dist since Composer now has to initialize dist for `state_dict` in torch 2.2. This will break tests since on GPU foundry tests initialize with GLOO by accident instead of NCCL