### PR TITLE
Delta to JSONL conversion script cleanup and bug fix

### DIFF
--- a/scripts/data_prep/convert_delta_to_json.py
+++ b/scripts/data_prep/convert_delta_to_json.py
@@ -513,7 +513,7 @@ if __name__ == '__main__':
         required=False,
         type=str,
         default='train-00000-of-00001.jsonl',
-        help='The combined final jsonl that combines all partitioned jsonl')
+        help='The name of the combined final jsonl that combines all partitioned jsonl')
     args = parser.parse_args()
 
     from databricks.sdk import WorkspaceClient

--- a/scripts/data_prep/convert_delta_to_json.py
+++ b/scripts/data_prep/convert_delta_to_json.py
@@ -431,7 +431,7 @@ def validate_and_get_cluster_info(cluster_id: str,
                 sparkSession = DatabricksSession.builder.remote(
                     host=databricks_host,
                     token=databricks_token,
-                    cluster_id=args.cluster_id).getOrCreate()
+                    cluster_id=cluster_id).getOrCreate()
 
         except Exception as e:
             raise RuntimeError(

--- a/scripts/data_prep/convert_delta_to_json.py
+++ b/scripts/data_prep/convert_delta_to_json.py
@@ -382,10 +382,8 @@ def validate_and_get_cluster_info(cluster_id: str,
                                   databricks_token: str,
                                   http_path: Optional[str],
                                   use_serverless: bool = False) -> tuple:
-    """
-    Validate and get cluster info for running the Delta to JSONL
-    conversion.
-    """
+    """Validate and get cluster info for running the Delta to JSONL
+    conversion."""
     method = 'dbsql'
     dbsql = None
     sparkSession = None
@@ -475,6 +473,7 @@ def fetch_DT(args: Namespace) -> None:
         cluster_id=args.cluster_id,
         databricks_host=args.DATABRICKS_HOST,
         databricks_token=args.DATABRICKS_TOKEN,
+        http_path=args.http_path,
         use_serverless=args.use_serverless)
 
     fetch(method, args.delta_table_name, args.json_output_folder,

--- a/scripts/data_prep/convert_delta_to_json.py
+++ b/scripts/data_prep/convert_delta_to_json.py
@@ -382,8 +382,15 @@ def validate_and_get_cluster_info(cluster_id: str,
                                   databricks_token: str,
                                   http_path: Optional[str],
                                   use_serverless: bool = False) -> tuple:
-    """Validate and get cluster info for running the Delta to JSONL
-    conversion."""
+    """Validate and get cluster info for running the Delta to JSONL conversion.
+
+    Args:
+        cluster_id (str): cluster id to validate and fetch additional info for
+        databricks_host (str): databricks host name
+        databricks_token (str): databricks auth token
+        http_path (Optional[str]): http path to use for sql connect
+        use_serverless (bool): whether to use serverless or not
+    """
     method = 'dbsql'
     dbsql = None
     sparkSession = None

--- a/scripts/data_prep/convert_delta_to_json.py
+++ b/scripts/data_prep/convert_delta_to_json.py
@@ -377,8 +377,10 @@ def fetch(
         cursor.close()
 
 
-def validate_and_get_cluster_info(cluster_id: str, use_serverless: bool = False) -> dict:
-    """Validate and get cluster info for running the Delta to JSONL conversion."""
+def validate_and_get_cluster_info(cluster_id: str,
+                                  use_serverless: bool = False) -> tuple:
+    """Validate and get cluster info for running the Delta to JSONL
+    conversion."""
     method = 'dbsql'
     dbsql = None
     sparkSession = None
@@ -392,7 +394,9 @@ def validate_and_get_cluster_info(cluster_id: str, use_serverless: bool = False)
             raise ValueError(
                 f'Cluster id {cluster_id} does not exist. Check cluster id and try again!'
             )
-        stripped_runtime = re.sub(r'[a-zA-Z]', '', res.spark_version.split('-scala')[0].replace('x-snapshot', ''))
+        stripped_runtime = re.sub(
+            r'[a-zA-Z]', '',
+            res.spark_version.split('-scala')[0].replace('x-snapshot', ''))
         runtime_version = re.sub(r'.-+$', '', stripped_runtime)
         if version.parse(runtime_version) < version.parse(
                 MINIMUM_SQ_CONNECT_DBR_VERSION):
@@ -437,7 +441,7 @@ def validate_and_get_cluster_info(cluster_id: str, use_serverless: bool = False)
                 'Failed to create sql connection to db workspace. To use sql connect, you need to provide http_path and cluster_id!'
             ) from e
     return method, dbsql, sparkSession
-    
+
 
 def fetch_DT(args: Namespace) -> None:
     """Fetch UC Delta Table to local as jsonl."""
@@ -462,7 +466,8 @@ def fetch_DT(args: Namespace) -> None:
 
     log.info(f'Directory {args.json_output_folder} created.')
 
-    method, dbsql, sparkSession = validate_and_get_cluster_info(args.cluster_id, args.use_serverless)
+    method, dbsql, sparkSession = validate_and_get_cluster_info(
+        args.cluster_id, args.use_serverless)
 
     fetch(method, args.delta_table_name, args.json_output_folder,
           args.batch_size, args.processes, sparkSession, dbsql)
@@ -523,7 +528,9 @@ if __name__ == '__main__':
         required=False,
         type=str,
         default='train-00000-of-00001.jsonl',
-        help='The name of the combined final jsonl that combines all partitioned jsonl')
+        help=
+        'The name of the combined final jsonl that combines all partitioned jsonl'
+    )
     args = parser.parse_args()
 
     from databricks.sdk import WorkspaceClient


### PR DESCRIPTION
This change includes 2 primary changes:
1. Fix bug in the Delta to JSONL conversion script where the `runtime_version` of the cluster still had alphabetic characters, which failed version parsing i.e. (`14.0.1-photon` instead of `14.0.1`). This change adds more regex to strip the extra alphabetic characters and trailing delineators (`-`, `.`).
2. Add some cleanups to the script to abstract the cluster validation and details into its own separate function. We also don't need the `cluster_id` argument to be mandatory now that we are supporting `serverless`.

I was able to test this e2e with a yaml generated by the finetuning API in the Databricks training environment!
Run name: `test-delta-Udjv3E`