### PR TITLE
Upgrade `datasets` version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ install_requires = [
     'transformers>=4.36,<4.37',
     'mosaicml-streaming>=0.7.2,<0.8',
     'torch>=2.1,<2.1.1',
-    'datasets==2.15.0',
+    'datasets>=2.16,<2.17',
     'fsspec==2023.6.0',  # newer version results in a bug in datasets that duplicates data
     'sentencepiece==0.1.97',
     'einops==0.7.0',


### PR DESCRIPTION
Same loss before and after:
<img width="488" alt="Screenshot 2024-01-21 at 5 29 50 PM" src="https://github.com/mosaicml/llm-foundry/assets/43149077/b887940a-86b3-4931-9d4c-8bb85a4fee59">

Same throughput before and after:
<img width="443" alt="Screenshot 2024-01-21 at 5 29 37 PM" src="https://github.com/mosaicml/llm-foundry/assets/43149077/1f31fb20-d853-4fdd-80b8-5848e9a13f03">
