### PR TITLE
Warn instead of error on tokenizer-only download with http

### DIFF
--- a/scripts/misc/download_model.py
+++ b/scripts/misc/download_model.py
@@ -90,8 +90,9 @@ if __name__ == '__main__':
 
     if download_from == 'http':
         if args.tokenizer_only:
-            raise ValueError(
-                'tokenizer-only is not currently supported for http.')
+            log.warning(
+                'tokenizer-only is not currently supported for http. Downloading all files instead.'
+            )
         try:
             download_from_http_fileserver(args.url, args.save_dir,
                                           args.ignore_cert)


### PR DESCRIPTION
When download from HTTP is specified with `tokenizer-only`, let's just warn that all files will be downloaded from the file server path rather than erroring out entirely.