### PR TITLE
No symlinks at all for HF download

### DIFF
--- a/llmfoundry/utils/model_download_utils.py
+++ b/llmfoundry/utils/model_download_utils.py
@@ -108,6 +108,7 @@ def download_from_hf_hub(
     download_start = time.time()
     hf_hub.snapshot_download(model,
                              local_dir=save_dir,
+                             local_dir_use_symlinks=False,
                              ignore_patterns=ignore_patterns,
                              allow_patterns=allow_patterns,
                              token=token)

--- a/tests/utils/test_model_download_utils.py
+++ b/tests/utils/test_model_download_utils.py
@@ -110,6 +110,7 @@ def test_download_from_hf_hub_weights_pref(mock_list_repo_files: MagicMock,
     mock_snapshot_download.assert_called_once_with(
         test_repo_id,
         local_dir=save_dir,
+        local_dir_use_symlinks=False,
         allow_patterns=None,
         ignore_patterns=expected_ignore_patterns,
         token=None)


### PR DESCRIPTION
To stay consistent with ORAS download, disable symlinking for Hugging Face downloads so the save dir contains the real file data. 

This is also necessary if we're using the HF download function to initialize an HTTP fileserver, since they don't always play nicely with symlinks.

Before:
<img width="1671" alt="Screenshot 2024-01-24 at 4 44 27 PM" src="https://github.com/mosaicml/llm-foundry/assets/12127839/f5ed5819-0875-4db9-838b-ef7d47e4ade5">

After:
<img width="1183" alt="image" src="https://github.com/mosaicml/llm-foundry/assets/12127839/87c41b9e-7c9d-44d1-9ccd-f8393f4a7732">
