### PR TITLE
Create HF checkpointer model on meta device

### DIFF
--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -237,9 +237,13 @@ class HuggingFaceCheckpointer(Callback):
                     copied_config.init_device = 'cpu'
 
                 log.debug(f'Creating new model instance')
+                # First create the model instance on meta device to avoid the
+                # initialization cost.
                 with init_empty_weights():
                     new_model_instance = type(original_model)(copied_config)
 
+                # Then load the state dict in with "assign" so that the state dict
+                # is loaded properly even though the model is initially on meta device.
                 new_model_instance.load_state_dict(state_dict, assign=True)
                 del state_dict
 

--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -218,8 +218,6 @@ class HuggingFaceCheckpointer(Callback):
                     copied_config.attn_config['attn_impl'] = 'torch'
                     copied_config.init_device = 'cpu'
 
-                # TODO: after torch 2.1, we can load a state dict into a meta model
-                # and skip the extra model init
                 log.debug(f'Creating new model instance')
                 with init_empty_weights():
                     new_model_instance = type(original_model)(copied_config)

--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -22,6 +22,7 @@ from composer.utils.misc import create_interval_scheduler
 from transformers import PreTrainedModel, PreTrainedTokenizerBase
 
 from llmfoundry.models.mpt import MPTConfig, MPTForCausalLM
+from llmfoundry.models.utils import init_empty_weights
 from llmfoundry.utils.huggingface_hub_utils import \
     edit_files_for_hf_compatibility
 
@@ -220,9 +221,10 @@ class HuggingFaceCheckpointer(Callback):
                 # TODO: after torch 2.1, we can load a state dict into a meta model
                 # and skip the extra model init
                 log.debug(f'Creating new model instance')
-                new_model_instance = type(original_model)(copied_config)
-                new_model_instance.to(dtype=self.dtype)
-                new_model_instance.load_state_dict(state_dict)
+                with init_empty_weights():
+                    new_model_instance = type(original_model)(copied_config)
+
+                new_model_instance.load_state_dict(state_dict, assign=True)
                 del state_dict
 
                 log.debug('Saving Hugging Face checkpoint to disk')


### PR DESCRIPTION
With torch 2.1, `load_state_dict` supports the `assign` arg, which allows us to initially create the model on meta, and then load the state dict into it. This speeds things up dramatically because the model does not need to be constructed an extra time.

e.g.
```
In [1]: import torch

In [2]: l1 = torch.nn.Linear(4, 4)

In [3]: sd = l1.state_dict()

In [4]: for k, v in sd.items():
   ...:     sd[k] = v.to(torch.bfloat16)
   ...:

In [5]: from llmfoundry.models.utils import init_empty_weights

In [6]: with init_empty_weights():
   ...:     l2 = torch.nn.Linear(4,4)
   ...:

In [7]: l2.load_state_dict(sd, assign=True)
Out[7]: <All keys matched successfully>

In [8]: l1.weight
Out[8]:
Parameter containing:
tensor([[ 0.1214, -0.0533, -0.2310,  0.3706],
        [-0.3985,  0.4402, -0.4656, -0.0259],
        [-0.2442, -0.2221,  0.1724,  0.4553],
        [-0.1352, -0.3936,  0.1702,  0.4925]], requires_grad=True)

In [9]: l2.weight
Out[9]:
Parameter containing:
tensor([[ 0.1216, -0.0532, -0.2305,  0.3711],
        [-0.3984,  0.4395, -0.4648, -0.0259],
        [-0.2441, -0.2217,  0.1729,  0.4551],
        [-0.1348, -0.3945,  0.1699,  0.4922]], dtype=torch.bfloat16,
       requires_grad=True)

In [10]: l1.weight.dtype
Out[10]: torch.float32

In [11]: l2.weight.dtype
Out[11]: torch.bfloat16
```

before
```
2024-01-27 01:57:51,953: rank0[785][MainThread]: INFO: llmfoundry.callbacks.hf_checkpointer: Saving HuggingFace formatted checkpoint
2024-01-27 01:57:51,954: rank0[785][MainThread]: DEBUG: llmfoundry.callbacks.hf_checkpointer: Gathering state dict
2024-01-27 01:58:09,987: rank0[785][MainThread]: DEBUG: llmfoundry.callbacks.hf_checkpointer: Saving Hugging Face checkpoint in global rank 0
2024-01-27 01:58:09,988: rank0[785][MainThread]: DEBUG: llmfoundry.callbacks.hf_checkpointer: Creating new model instance
2024-01-27 01:59:19,318: rank0[785][MainThread]: DEBUG: llmfoundry.callbacks.hf_checkpointer: Saving Hugging Face checkpoint to disk
```

after
```
2024-01-27 02:03:57,698: rank0[785][MainThread]: INFO: llmfoundry.callbacks.hf_checkpointer: Saving HuggingFace formatted checkpoint
2024-01-27 02:03:57,700: rank0[785][MainThread]: DEBUG: llmfoundry.callbacks.hf_checkpointer: Gathering state dict
2024-01-27 02:04:14,842: rank0[785][MainThread]: DEBUG: llmfoundry.callbacks.hf_checkpointer: Saving Hugging Face checkpoint in global rank 0
2024-01-27 02:04:14,843: rank0[785][MainThread]: DEBUG: llmfoundry.callbacks.hf_checkpointer: Creating new model instance
2024-01-27 02:04:16,727: rank0[785][MainThread]: DEBUG: llmfoundry.callbacks.hf_checkpointer: Saving Hugging Face checkpoint to disk
```