### PR TITLE
Bump composer version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ classifiers = [
 ]
 
 install_requires = [
-    'mosaicml[libcloud,wandb,oci,gcs]>=0.17.2,<0.18',
+    'mosaicml[libcloud,wandb,oci,gcs]>=0.18.1,<0.19',
     'mlflow>=2.10,<3',
     'accelerate>=0.25,<0.26',  # for HF inference `device_map`
     'transformers>=4.37,<4.38',


### PR DESCRIPTION
I don't have a reason to prefer 18.1 > 18.0, but maybe @mvpatel2000 @dakinggg you'd have opinions https://github.com/mosaicml/composer/releases/tag/v0.18.1