### PR TITLE
Fix docker workflow caching

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -88,5 +88,6 @@ jobs:
         cache-from: type=registry,ref=${{ env.IMAGE_CACHE }}
         cache-to: type=registry,ref=${{ env.IMAGE_CACHE }},mode=max
         build-args: |
+          BRANCH_NAME=${{ github.head_ref || github.ref_name }}
           BASE_IMAGE=${{ matrix.base_image }}
           DEP_GROUPS=${{ matrix.dep_groups }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,16 @@
 ARG BASE_IMAGE
 FROM $BASE_IMAGE
 
+ARG BRANCH_NAME
 ARG DEP_GROUPS
 
+# Check for changes in setup.py.
+# If there are changes, the docker cache is invalidated and a fresh pip installation is triggered.
+ADD https://raw.githubusercontent.com/mosaicml/llm-foundry/$BRANCH_NAME/setup.py setup.py
+RUN rm setup.py
+
 # Install and uninstall foundry to cache foundry requirements
-RUN git clone -b main https://github.com/mosaicml/llm-foundry.git
+RUN git clone -b $BRANCH_NAME https://github.com/mosaicml/llm-foundry.git
 RUN pip install --no-cache-dir "./llm-foundry${DEP_GROUPS}"
 RUN pip uninstall -y llm-foundry
 RUN rm -rf llm-foundry


### PR DESCRIPTION
A couple of fixes:
1. Use BRANCH_NAME in `Dockerfile`, such that the docker workflow uses the correct branch. (Previously, it was always using main, even when launched from other branches.)
2. `ADD` setup.py such that changes in setup.py invalidate the docker cache and trigger fresh pip installs. (Previously, our pip installs were cached by docker despite changes to setup.py because [run instructions never invalidate the cache unless the instruction changes](https://stackoverflow.com/questions/34814669/when-does-docker-image-cache-invalidation-occur).)


Manually tested on this draft PR (https://github.com/mosaicml/llm-foundry/pull/929):
[53f7596](https://github.com/mosaicml/llm-foundry/pull/929/commits/53f759682374be8b88fd9f2a1507ee4dc5095a76)  pip install is not cached, Docker image has flash-attn==2.3.2
[62e0770](https://github.com/mosaicml/llm-foundry/pull/929/commits/62e0770f0375ad433727b163e6dde243f9ce78ed) pip install is cached, Docker image has flash-attn==2.3.2
[fea67f1](https://github.com/mosaicml/llm-foundry/pull/929/commits/fea67f17486ef9e17895be330f290c40d8a1c380) updates flash-attn to 2.4.2 in setup.py, pip install is not cached, Docker image has flash-attn==2.4.2

