### PR TITLE
Update README to use train/val splits

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ cd scripts
 # Convert C4 dataset to StreamingDataset format
 python data_prep/convert_dataset_hf.py \
   --dataset c4 --data_subset en \
-  --out_root my-copy-c4 --splits train_small val_small \
+  --out_root my-copy-c4 --splits train val \
   --concat_tokens 2048 --tokenizer EleutherAI/gpt-neox-20b --eos_text '<|endoftext|>'
 
 # Train an MPT-125m model for 10 batches


### PR DESCRIPTION
Update README to use train/val splits. By default, the YAMLs used for MPT have train/val as split names. This errors if split is named train_small/val_small