### PR TITLE
allow te to use meta device with deferred init

### DIFF
--- a/llmfoundry/models/layers/attention.py
+++ b/llmfoundry/models/layers/attention.py
@@ -522,8 +522,7 @@ class GroupedQueryAttention(nn.Module):
         fc_kwargs: dict[str, Any] = {
             'bias': bias,
         }
-        if fc_type != 'te':
-            fc_kwargs['device'] = device
+        fc_kwargs['device'] = device
         self.Wqkv = FC_CLASS_REGISTRY[fc_type](
             self.d_model,
             self.d_model + 2 * self.kv_n_heads * self.head_dim,

--- a/llmfoundry/models/layers/ffn.py
+++ b/llmfoundry/models/layers/ffn.py
@@ -97,8 +97,8 @@ class MPTMLP(nn.Module):
         self.fc_kwargs: dict[str, Any] = {
             'bias': bias,
         }
-        if fc_type != 'te':
-            self.fc_kwargs['device'] = device
+
+        self.fc_kwargs['device'] = device
 
         self.up_proj = FC_CLASS_REGISTRY[fc_type](
             d_model,


### PR DESCRIPTION
Specifying the `meta` device (`init_device: meta`) triggers the deferring init (defer module parameter initialization until after FSDP sharding)  in transformer engine repo. This resolves the excessive memory usage problem when using FSDP + te FP8.  The fix goes with the NV te fix https://github.com/NVIDIA/TransformerEngine/pull/596. 