### PR TITLE
Better Kaiming Init

### DIFF
--- a/llmfoundry/models/layers/ffn.py
+++ b/llmfoundry/models/layers/ffn.py
@@ -105,6 +105,7 @@ class MPTMLP(nn.Module):
             ffn_hidden_size,
             **self.fc_kwargs,
         )
+        self.up_proj._precedes_act = True
         self.act = act_fn
         self.down_proj = FC_CLASS_REGISTRY[fc_type](
             ffn_hidden_size,
@@ -143,6 +144,8 @@ class MPTGLU(MPTMLP):
             self.up_proj.out_features,
             **self.fc_kwargs,
         )
+        self.gate_proj._precedes_act = True
+        self.up_proj._precedes_act = False
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.down_proj(self.act(self.gate_proj(x)) * self.up_proj(x))

--- a/llmfoundry/models/mpt/configuration_mpt.py
+++ b/llmfoundry/models/mpt/configuration_mpt.py
@@ -30,7 +30,7 @@ ffn_config_defaults: Dict = {
 init_config_defaults: Dict = {
     'name': 'kaiming_normal_',
     'fan_mode': 'fan_in',
-    'init_nonlinearity': 'relu',
+    'init_nonlinearity': 'linear',
     'init_div_is_residual': True,
     'emb_init_std': None,
     'emb_init_uniform_lim': None,


### PR DESCRIPTION
This PR modifies our param initialization for Linear layers when using Kaiming initialization to use `nonlinearity = 'relu'` for Linears preceding an activation function, and `nonlinearity = 'linear'` for all other linears. It does not affect other param initialization methods which don't take nonlinearities as an argument.

Torch's Kaiming init functions take the following possible nonlinearities --
```
================= ====================================================
nonlinearity      gain
================= ====================================================
Linear / Identity :math:`1`
Conv{1,2,3}D      :math:`1`
Sigmoid           :math:`1`
Tanh              :math:`\frac{5}{3}`
ReLU              :math:`\sqrt{2}`
Leaky Relu        :math:`\sqrt{\frac{2}{1 + \text{negative\_slope}^2}}`
SELU              :math:`\frac{3}{4}`
================= ====================================================
```
For the activation functions we use, the effect on variance is closest to ReLU out of these options. So we choose to use relu as the nonlinearity for kaiming initialization.

This PR is a draft for now, pending further testing/discussion/approval.
