### PR TITLE
Add big bench hard

### DIFF
--- a/mcli/mcli-hf-eval.yaml
+++ b/mcli/mcli-hf-eval.yaml
@@ -1,7 +1,7 @@
 integrations:
 - integration_type: git_repo
   git_repo: mosaicml/llm-foundry
-  git_branch: v0.4.0
+  git_branch: add_bbh # v0.4.0
   # git_commit:  # OR use your commit hash
   pip_install: -e ".[gpu]"
   ssh_clone: false  # Should be true if using a private repo
@@ -11,10 +11,10 @@ command: |
   composer eval/eval.py /mnt/config/parameters.yaml
 
 # Mosaic Cloud will use run_name (with a unique suffix) to populate the env var $RUN_NAME
-run_name: mpt-eval
+name: mpt-eval
 gpu_num: 8
-# gpu_type:
-# cluster:  # replace with your cluster here!
+gpu_type: a100_80gb
+cluster: r1z1 # replace with your cluster here!
 
 image: mosaicml/llm-foundry:2.1.0_cu121_flash2-latest
 
@@ -50,5 +50,5 @@ parameters:
     limit_all_gathers: True
 
 
-  icl_tasks: "eval/yamls/tasks_v0.3.yaml"
-  eval_gauntlet: "eval/yamls/eval_gauntlet_v0.3.yaml"
+  icl_tasks: "eval/yamls/big_bench_hard.yaml"
+  # eval_gauntlet: "eval/yamls/eval_gauntlet_v0.3.yaml"

--- a/scripts/eval/yamls/big_bench_hard.yaml
+++ b/scripts/eval/yamls/big_bench_hard.yaml
@@ -8,6 +8,7 @@ icl_tasks:
   continuation_delimiter: " "
   question_prelimiter: ""
   do_normalization: false
+  has_categories: true
   early_stopping_criteria:
   - "\n\n\n\n"
   - "Q:"

--- a/scripts/eval/yamls/big_bench_hard.yaml
+++ b/scripts/eval/yamls/big_bench_hard.yaml
@@ -4,11 +4,12 @@ icl_tasks:
   dataset_uri: eval/local_data/bbh/bbh.jsonl
   num_fewshot: [0]
   icl_task_type: question_answering
-  cot_delimiter: "So the answer is "
+  cot_delimiter: "the answer is"
   continuation_delimiter: " "
   question_prelimiter: ""
   do_normalization: false
   has_categories: true
   early_stopping_criteria:
-  - "\n\n\n\n"
-  - "Q:"
+    - "</s>"
+    - "Q:"
+    - "\n\n"

--- a/scripts/eval/yamls/big_bench_hard.yaml
+++ b/scripts/eval/yamls/big_bench_hard.yaml
@@ -1,0 +1,13 @@
+icl_tasks:
+-
+  label: bigbench_hard
+  dataset_uri: eval/local_data/bbh/bbh.jsonl
+  num_fewshot: [0]
+  icl_task_type: question_answering
+  cot_delimiter: "So the answer is "
+  continuation_delimiter: " "
+  question_prelimiter: ""
+  do_normalization: false
+  early_stopping_criteria:
+  - "\n\n\n\n"
+  - "Q:"


### PR DESCRIPTION
Adding Big Bench Hard subset as a set of combined CoT tasks, formatted according to the specification in [this repo](https://github.com/suzgunmirac/BIG-Bench-Hard/tree/main).

These tasks are quite large and quite slow. I don't recommend including in all gauntlet runs, though it might be useful to include for some ad-hoc IFT runs. 

We can calibrate them later to add to gauntlet. 

Testing MPT7B: `mpt-eval-cStFsb`