### PR TITLE
Fix eval.py with lora

### DIFF
--- a/llmfoundry/models/hf/hf_causal_lm.py
+++ b/llmfoundry/models/hf/hf_causal_lm.py
@@ -256,7 +256,7 @@ class ComposerHFCausalLM(HuggingFaceModelWithZLoss):
                     'PEFT is not installed, but lora_id_or_path was passed. Please install LLM Foundry with the peft extra to use lora_id_or_path.'
                 )
             from peft import PeftModelForCausalLM
-            model = PeftModelForCausalLM(model, lora_id_or_path)
+            model = PeftModelForCausalLM.from_pretrained(model, lora_id_or_path)
 
         super().__init__(
             model=model,

--- a/llmfoundry/models/hf/hf_causal_lm.py
+++ b/llmfoundry/models/hf/hf_causal_lm.py
@@ -70,6 +70,7 @@ class ComposerHFCausalLM(HuggingFaceModelWithZLoss):
     def __init__(self, om_model_config: DictConfig,
                  tokenizer: PreTrainedTokenizerBase):
         pretrained_model_name_or_path = om_model_config.pretrained_model_name_or_path
+        lora_id_or_path = om_model_config.get('lora_id_or_path', None)
 
         if not om_model_config.get(
                 'trust_remote_code', True
@@ -248,6 +249,14 @@ class ComposerHFCausalLM(HuggingFaceModelWithZLoss):
         peft_config = None
         if peft_config_dict is not None:
             peft_config = self._get_peft_config(peft_config_dict)
+
+        if lora_id_or_path is not None:
+            if not peft_installed:
+                raise ValueError(
+                    'PEFT is not installed, but lora_id_or_path was passed. Please install LLM Foundry with the peft extra to use lora_id_or_path.'
+                )
+            from peft import PeftModelForCausalLM
+            model = PeftModelForCausalLM(model, lora_id_or_path)
 
         super().__init__(
             model=model,

--- a/llmfoundry/models/hf/hf_fsdp.py
+++ b/llmfoundry/models/hf/hf_fsdp.py
@@ -10,6 +10,8 @@ from typing import TYPE_CHECKING, Any, Iterable, List, Optional, Union
 from transformers import PreTrainedModel
 from transformers.models.opt.modeling_opt import OPTDecoder
 
+from composer.models.huggingface import maybe_get_underlying_model
+
 if TYPE_CHECKING:
     from peft import PeftModel
 
@@ -142,7 +144,8 @@ def prepare_hf_causal_lm_model_for_fsdp(model: Union[PreTrainedModel,
 
     # OPT has an extra layer of wrapping, so special case here
     if isinstance(causal_base_model, OPTDecoder):
-        model.model._fsdp_wrap = False
+        underlying_model = maybe_get_underlying_model(model)
+        underlying_model.model._fsdp_wrap = False
     model_block = hf_get_hidden_layers(causal_base_model)
     lm_head = model.get_output_embeddings()
     # some models (OPT) implement .get_input_embeddings for the causal subclass

--- a/llmfoundry/models/hf/hf_fsdp.py
+++ b/llmfoundry/models/hf/hf_fsdp.py
@@ -7,10 +7,9 @@
 import functools
 from typing import TYPE_CHECKING, Any, Iterable, List, Optional, Union
 
+from composer.models.huggingface import maybe_get_underlying_model
 from transformers import PreTrainedModel
 from transformers.models.opt.modeling_opt import OPTDecoder
-
-from composer.models.huggingface import maybe_get_underlying_model
 
 if TYPE_CHECKING:
     from peft import PeftModel

--- a/scripts/eval/eval.py
+++ b/scripts/eval/eval.py
@@ -19,11 +19,9 @@ from composer.utils import dist, get_device, reproducibility
 from omegaconf import DictConfig, ListConfig
 from omegaconf import OmegaConf as om
 from rich.traceback import install
-from transformers import (AutoModelForCausalLM, PreTrainedTokenizerBase,
-                          T5ForConditionalGeneration)
+from transformers import PreTrainedTokenizerBase
 
 install()
-from llmfoundry.models import MPTForCausalLM
 from llmfoundry.models.model_registry import COMPOSER_MODEL_REGISTRY
 from llmfoundry.utils.builders import (add_metrics_to_eval_loaders,
                                        build_evaluators, build_logger,
@@ -32,52 +30,6 @@ from llmfoundry.utils.config_utils import (log_config, pop_config,
                                            process_init_device)
 
 log = logging.getLogger(__name__)
-
-
-def load_peft_model(model_cfg: DictConfig, tokenizer: PreTrainedTokenizerBase,
-                    num_retries: int) -> ComposerModel:
-    try:
-        from peft import PeftModel
-    except ImportError as e:
-        raise ImportError(
-            f'Error importing from peft. Run `pip install -e .[gpu,peft]`. \n {e}'
-        )
-
-    model_registry = {
-        'mpt_causal_lm': MPTForCausalLM,
-        'hf_causal_lm': AutoModelForCausalLM,
-        'hf_prefix_lm': AutoModelForCausalLM,
-        'hf_t5': T5ForConditionalGeneration,
-    }
-
-    retries = 0
-    composer_model_wrapper = None
-    while retries < num_retries and composer_model_wrapper is None:
-        try:
-            trust_remote_code = model_cfg.get('trust_remote_code', True)
-            use_auth_token = model_cfg.get('use_auth_token', False)
-            model = model_registry[model_cfg.name].from_pretrained(
-                model_cfg.pretrained_model_name_or_path,
-                trust_remote_code=trust_remote_code,
-                use_auth_token=use_auth_token,
-            )
-
-            peft_model = PeftModel.from_pretrained(
-                model, model_cfg.pretrained_lora_id_or_path)
-
-            composer_model_wrapper = COMPOSER_MODEL_REGISTRY[model_cfg.name](
-                peft_model, tokenizer)
-        except Exception as e:
-            retries += 1
-            if retries >= num_retries:
-                raise e
-            else:
-                log.info(
-                    f'Got exception {str(e)} while loading model {model_cfg.name}. {num_retries-retries} retries remaining'
-                )
-
-    assert composer_model_wrapper is not None
-    return composer_model_wrapper
 
 
 def load_model(model_cfg: DictConfig, tokenizer: PreTrainedTokenizerBase,

--- a/scripts/eval/eval.py
+++ b/scripts/eval/eval.py
@@ -127,7 +127,7 @@ def evaluate_model(
             'Hugging Face models in 8bit.')
 
     composer_model = load_model(model_cfg.model, tokenizer, fsdp_config,
-                                    num_retries)
+                                num_retries)
 
     # Now add the eval metrics
     if eval_loader_config is not None:

--- a/scripts/eval/eval.py
+++ b/scripts/eval/eval.py
@@ -126,11 +126,7 @@ def evaluate_model(
             'The FSDP config block is not supported when loading ' +
             'Hugging Face models in 8bit.')
 
-    if hasattr(model_cfg.model, 'pretrained_lora_id_or_path'):
-        composer_model = load_peft_model(model_cfg.model, tokenizer,
-                                         num_retries)
-    else:
-        composer_model = load_model(model_cfg.model, tokenizer, fsdp_config,
+    composer_model = load_model(model_cfg.model, tokenizer, fsdp_config,
                                     num_retries)
 
     # Now add the eval metrics
@@ -156,6 +152,7 @@ def evaluate_model(
     assert composer_model is not None
 
     log.info(f'Building trainer for {model_cfg.model_name}...')
+
     trainer = Trainer(
         run_name=run_name,
         seed=seed,

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -502,13 +502,16 @@ def test_loss_fn():
 
 @pytest.mark.parametrize('peft_config', [
     None,
-    {'peft_type': 'LORA', 'task_type': 'CAUSAL_LM'},
+    {
+        'peft_type': 'LORA',
+        'task_type': 'CAUSAL_LM'
+    },
 ])
-def test_opt_wrapping(peft_config: Optional[dict]):
+def test_opt_wrapping(peft_config: Optional[dict[str, str]]):
     if peft_config is not None:
         _ = pytest.importorskip('peft')
 
-    conf = {
+    conf: dict[str, dict[str, Union[str, dict]]] = {
         'model': {
             'name': 'hf_causal_lm',
             'pretrained_model_name_or_path': 'facebook/opt-125m',


### PR DESCRIPTION
Missed `eval.py` completely in the LoRA refactor. `eval.py` should work with lora weights from HF now.