### PR TITLE
Adding support for QuantizedLinears

### DIFF
--- a/llmfoundry/models/layers/attention.py
+++ b/llmfoundry/models/layers/attention.py
@@ -700,6 +700,7 @@ class MultiheadAttention(GroupedQueryAttention):
         device: Optional[str] = None,
         bias: bool = True,
         sliding_window_size: int = -1,
+        num_input_bits: Optional[int] = None,
     ):
         super().__init__(
             d_model=d_model,
@@ -716,6 +717,7 @@ class MultiheadAttention(GroupedQueryAttention):
             device=device,
             bias=bias,
             sliding_window_size=sliding_window_size,
+            num_input_bits=num_input_bits,
         )
 
 
@@ -741,6 +743,7 @@ class MultiQueryAttention(GroupedQueryAttention):
         device: Optional[str] = None,
         bias: bool = True,
         sliding_window_size: int = -1,
+        num_input_bits: Optional[int] = None,
     ):
         super().__init__(
             d_model=d_model,
@@ -757,6 +760,7 @@ class MultiQueryAttention(GroupedQueryAttention):
             device=device,
             bias=bias,
             sliding_window_size=sliding_window_size,
+            num_input_bits=num_input_bits,
         )
 
 

--- a/llmfoundry/models/layers/attention.py
+++ b/llmfoundry/models/layers/attention.py
@@ -484,6 +484,7 @@ class GroupedQueryAttention(nn.Module):
         device: Optional[str] = None,
         bias: bool = True,
         sliding_window_size: int = -1,
+        num_input_bits: Optional[int] = None,
     ):
         super().__init__()
 
@@ -523,6 +524,15 @@ class GroupedQueryAttention(nn.Module):
             'bias': bias,
         }
         fc_kwargs['device'] = device
+
+        # Pass in num_input_bits to the FC layer if it is specified, for activation quantization
+        if num_input_bits is not None and fc_type == 'quantized':
+            self.fc_kwargs['num_input_bits'] = num_input_bits
+        elif num_input_bits is not None:
+            raise ValueError(
+                f'`num_input_bits` is only supported for `fc_type` "quantized" (not {fc_type}).'
+            )
+        
         self.Wqkv = FC_CLASS_REGISTRY[fc_type](
             self.d_model,
             self.d_model + 2 * self.kv_n_heads * self.head_dim,

--- a/llmfoundry/models/layers/attention.py
+++ b/llmfoundry/models/layers/attention.py
@@ -527,7 +527,7 @@ class GroupedQueryAttention(nn.Module):
 
         # Pass in num_input_bits to the FC layer if it is specified, for activation quantization
         if num_input_bits is not None and fc_type == 'quantized':
-            self.fc_kwargs['num_input_bits'] = num_input_bits
+            fc_kwargs['num_input_bits'] = num_input_bits
         elif num_input_bits is not None:
             raise ValueError(
                 f'`num_input_bits` is only supported for `fc_type` "quantized" (not {fc_type}).'

--- a/llmfoundry/models/layers/fc.py
+++ b/llmfoundry/models/layers/fc.py
@@ -12,3 +12,9 @@ try:
     FC_CLASS_REGISTRY['te'] = te.Linear
 except:
     pass
+
+try:
+    from turbo import QuantizedLinear
+    FC_CLASS_REGISTRY['quantized'] = QuantizedLinear
+except:
+    pass


### PR DESCRIPTION
Adds support for QuantizedLinears ([PR here](https://github.com/mosaicml/turbo/pull/15)) which easily compresses input activations to a linear layer. QuantizedLinear is a drop in replacement for `nn.Linear`.

I still need to add tests for QuantizedLinear on turbo side so this is a draft.