### PR TITLE
Replace `num_beams` with `generations_per_sample`

### DIFF
--- a/llmfoundry/utils/builders.py
+++ b/llmfoundry/utils/builders.py
@@ -505,7 +505,7 @@ def build_icl_evaluators(
                     'To specify the number of generations per sample please use '
                     f'generations_per_sample: {icl_cfg.num_beams}. To specify '
                     'the number of beams for beam search decoding please use '
-                    f'num_beams: {icl_cfg.num_beams} in generation_kwargs.')
+                    f'num_beams: {icl_cfg.num_beams} in generation_kwargs.'),
                     DeprecationWarning,
                 )
             else:

--- a/llmfoundry/utils/builders.py
+++ b/llmfoundry/utils/builders.py
@@ -497,8 +497,16 @@ def build_icl_evaluators(
             icl_cfg.batch_size = default_batch_size
         if 'pass_at_k' not in icl_cfg:
             icl_cfg.pass_at_k = 1
-        if 'num_beams' not in icl_cfg:
-            icl_cfg.num_beams = 20
+        if 'generations_per_sample' not in icl_cfg:
+            if 'num_beams' in icl_cfg:
+                icl_cfg.generations_per_sample = icl.num_beams
+                warnings.warn(
+                    ('num_beams is deprecated and will be removed in a future release.'
+                     f'Please use generations_per_sample: {icl.num_beams}'),
+                    DeprecationWarning,
+                )
+            else:
+                icl_cfg.generations_per_sample = 20
 
     for icl_cfg in icl_tasks_list:
         assert isinstance(icl_cfg, DictConfig)
@@ -537,7 +545,7 @@ def build_icl_evaluators(
                 question_prelimiter=icl_cfg.get('question_prelimiter', ''),
                 destination_path=destination_path,
                 pass_at_k=icl_cfg.pass_at_k,
-                generations_per_sample=icl_cfg.num_beams,
+                generations_per_sample=icl_cfg.generations_per_sample,
                 has_categories=icl_cfg.get('has_categories', False),
                 cot_delimiter=icl_cfg.get('cot_delimiter', ''),
                 early_stopping_criteria=early_stopping_criteria,

--- a/llmfoundry/utils/builders.py
+++ b/llmfoundry/utils/builders.py
@@ -501,13 +501,12 @@ def build_icl_evaluators(
             if 'num_beams' in icl_cfg:
                 icl_cfg.generations_per_sample = icl_cfg.num_beams
                 warnings.warn(
-                    x = (
-                        'num_beams is deprecated and will be removed in a future release. '
-                        'To specify the number of generations per sample please use '
-                        f'generations_per_sample: {icl_cfg.num_beams}. To specify '
-                        'the number of beams for beam search decoding please use '
-                        f'num_beams: {icl_cfg.num_beams} in generation_kwargs.')
-                        DeprecationWarning,
+                    ('num_beams is deprecated and will be removed in a future release. '
+                    'To specify the number of generations per sample please use '
+                    f'generations_per_sample: {icl_cfg.num_beams}. To specify '
+                    'the number of beams for beam search decoding please use '
+                    f'num_beams: {icl_cfg.num_beams} in generation_kwargs.')
+                    DeprecationWarning,
                 )
             else:
                 icl_cfg.generations_per_sample = 20

--- a/llmfoundry/utils/builders.py
+++ b/llmfoundry/utils/builders.py
@@ -499,11 +499,15 @@ def build_icl_evaluators(
             icl_cfg.pass_at_k = 1
         if 'generations_per_sample' not in icl_cfg:
             if 'num_beams' in icl_cfg:
-                icl_cfg.generations_per_sample = icl.num_beams
+                icl_cfg.generations_per_sample = icl_cfg.num_beams
                 warnings.warn(
-                    ('num_beams is deprecated and will be removed in a future release.'
-                     f'Please use generations_per_sample: {icl.num_beams}'),
-                    DeprecationWarning,
+                    x = (
+                        'num_beams is deprecated and will be removed in a future release. '
+                        'To specify the number of generations per sample please use '
+                        f'generations_per_sample: {icl_cfg.num_beams}. To specify '
+                        'the number of beams for beam search decoding please use '
+                        f'num_beams: {icl_cfg.num_beams} in generation_kwargs.')
+                        DeprecationWarning,
                 )
             else:
                 icl_cfg.generations_per_sample = 20

--- a/scripts/eval/yamls/coding_tasks.yaml
+++ b/scripts/eval/yamls/coding_tasks.yaml
@@ -4,7 +4,7 @@ icl_tasks:
   dataset_uri: eval/local_data/programming/human_eval.jsonl  # ADD YOUR OWN DATASET URI
   num_fewshot: [0]
   pass_at_k: 1
-  num_beams: 5
+  generations_per_sample: 5
   batch_size: 1
   icl_task_type: code_evaluation
 -
@@ -12,7 +12,7 @@ icl_tasks:
   dataset_uri: eval/local_data/programming/processed_human_eval_cpp.jsonl  # ADD YOUR OWN DATASET URI
   num_fewshot: [0]
   pass_at_k: 1
-  num_beams: 5
+  generations_per_sample: 5
   batch_size: 1
   icl_task_type: code_evaluation
 -
@@ -20,7 +20,7 @@ icl_tasks:
   dataset_uri: eval/local_data/programming/processed_human_eval_js.jsonl  # ADD YOUR OWN DATASET URI
   num_fewshot: [0]
   pass_at_k: 1
-  num_beams: 5
+  generations_per_sample: 5
   batch_size: 1
   icl_task_type: code_evaluation
 -
@@ -28,7 +28,7 @@ icl_tasks:
   dataset_uri: eval/local_data/programming/human_eval_return_simple.jsonl  # ADD YOUR OWN DATASET URI
   num_fewshot: [0]
   pass_at_k: 1
-  num_beams: 5
+  generations_per_sample: 5
   batch_size: 1
   icl_task_type: code_evaluation
 -
@@ -36,7 +36,7 @@ icl_tasks:
   dataset_uri: eval/local_data/programming/human_eval_return_complex.jsonl  # ADD YOUR OWN DATASET URI
   num_fewshot: [0]
   pass_at_k: 1
-  num_beams: 5
+  generations_per_sample: 5
   batch_size: 1
   icl_task_type: code_evaluation
 -
@@ -44,7 +44,7 @@ icl_tasks:
   dataset_uri: eval/local_data/programming/human_eval-0.25.jsonl  # ADD YOUR OWN DATASET URI
   num_fewshot: [0]
   pass_at_k: 1
-  num_beams: 5
+  generations_per_sample: 5
   batch_size: 1
   icl_task_type: code_evaluation
 -
@@ -52,7 +52,7 @@ icl_tasks:
   dataset_uri: eval/local_data/programming/human_eval-0.5.jsonl  # ADD YOUR OWN DATASET URI
   num_fewshot: [0]
   pass_at_k: 1
-  num_beams: 5
+  generations_per_sample: 5
   batch_size: 1
   icl_task_type: code_evaluation
 -
@@ -60,6 +60,6 @@ icl_tasks:
   dataset_uri: eval/local_data/programming/human_eval-0.75.jsonl  # ADD YOUR OWN DATASET URI
   num_fewshot: [0]
   pass_at_k: 1
-  num_beams: 5
+  generations_per_sample: 5
   batch_size: 1
   icl_task_type: code_evaluation


### PR DESCRIPTION
In `composer`'s `build_icl_dataloader` function  ([here](https://github.com/eitanturok/composer/blob/39db8483790a8fab6b2f3a08162cf68ba5396c3b/composer/datasets/in_context_learning_evaluation.py#L1167)), we specify the number of generations per sample with the variable `generations_per_sample`.

But when we call `build_icl_dataloader` in `llm-foundry` [here](https://github.com/eitanturok/llm-foundry/blob/96c47079e0db9d3532515f4634662beeadd2f3b8/llmfoundry/utils/builders.py#L521), we specified the number of generations per sample with the variable `num_beams`. This was confusing because 
1. we use different variable names
2. the variable `num_beams` is also used as a parameter for beam search in inference.

To resolve this, I replaced all instances of `num_beams` with `generations_per_sample` in `llm-foundry`. If `generations_per_sample` is not specified in the config and `num_beams` *is* specified, we will use the value set by `num_beams` and raise a warning that `num_beams` is depreciated.

Cheers!