### PR TITLE
Torch 2.2 upgrade - Part 1

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -23,6 +23,12 @@ jobs:
         - name: "2.1.2_cu121_flash2_aws"
           base_image: mosaicml/pytorch:2.1.2_cu121-python3.10-ubuntu20.04-aws
           dep_groups: "[gpu-flash2]"
+        - name: "2.2.0_cu121_flash2"
+          base_image: mosaicml/pytorch:2.2.0_cu121-python3.11-ubuntu20.04
+          dep_groups: "[gpu-flash2]"
+        - name: "2.2.0_cu121_flash2_aws"
+          base_image: mosaicml/pytorch:2.2.0_cu121-python3.11-ubuntu20.04-aws
+          dep_groups: "[gpu-flash2]"
     steps:
     - name: Maximize Build Space on Worker
       uses: easimon/maximize-build-space@v4

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ install_requires = [
     'accelerate>=0.25,<0.26',  # for HF inference `device_map`
     'transformers>=4.37,<4.38',
     'mosaicml-streaming>=0.7.4,<0.8',
-    'torch>=2.1,<2.2',
+    'torch>=2.1,<2.3',
     'datasets>=2.16,<2.17',
     'fsspec==2023.6.0',  # newer version results in a bug in datasets that duplicates data
     'sentencepiece==0.1.97',


### PR DESCRIPTION
This PR just adds 2.2 images so they build. A follow on PR will add them to the tests and bump the foundry torch version.