### PR TITLE
Add explicit packing ratio of 1 for profiling

### DIFF
--- a/llmfoundry/data/packing.py
+++ b/llmfoundry/data/packing.py
@@ -383,7 +383,7 @@ def profile_packing(
 
     # Turn off packing for the dataloader (we want raw, pre-packed examples)
     dataloader_cfg = copy.deepcopy(dataloader_cfg)
-    dataloader_cfg.dataset.packing_ratio = None
+    dataloader_cfg.dataset.packing_ratio = 1.0
     dataloader_cfg.drop_last = False
     dataloader_cfg.num_workers = 0
     dataloader_cfg.prefetch_factor = None


### PR DESCRIPTION
Prevents running into this error while profiling with max_leftovers_to_keep: https://github.com/mosaicml/llm-foundry/blob/main/llmfoundry/data/finetuning/dataloader.py#L449