### PR TITLE
Fix llama attention patch

### DIFF
--- a/llmfoundry/models/layers/llama_attention_monkeypatch.py
+++ b/llmfoundry/models/layers/llama_attention_monkeypatch.py
@@ -67,6 +67,7 @@ def apply_rotary_pos_emb(
             k have the shape [batch_size, heads, seq_len, head_dim], then setting unsqueeze_dim=1 makes
             cos[position_ids] and sin[position_ids] broadcastable to the shapes of q and k. Similarly, if q and k have
             the shape [batch_size, seq_len, heads, head_dim], then set unsqueeze_dim=2.
+    
     Returns:
         `tuple(torch.Tensor)` comprising of the query and key tensors rotated using the Rotary Position Embedding.
     """

--- a/llmfoundry/models/layers/llama_attention_monkeypatch.py
+++ b/llmfoundry/models/layers/llama_attention_monkeypatch.py
@@ -67,7 +67,7 @@ def apply_rotary_pos_emb(
             k have the shape [batch_size, heads, seq_len, head_dim], then setting unsqueeze_dim=1 makes
             cos[position_ids] and sin[position_ids] broadcastable to the shapes of q and k. Similarly, if q and k have
             the shape [batch_size, seq_len, heads, head_dim], then set unsqueeze_dim=2.
-    
+
     Returns:
         `tuple(torch.Tensor)` comprising of the query and key tensors rotated using the Rotary Position Embedding.
     """

--- a/tests/models/layers/test_huggingface_flash.py
+++ b/tests/models/layers/test_huggingface_flash.py
@@ -76,10 +76,13 @@ def test_patch_equivalence(patch_fn_name: str, explicit_mask: bool,
     causal_mask = causal_mask[None,
                               None, :, :].expand(batch_size, 1, sequence_length,
                                                  sequence_length)
+    position_ids = torch.arange(sequence_length, dtype=torch.long, device=device)
+    position_ids = position_ids[None, :].expand(batch_size, sequence_length)
+    
     attn_output, _, _ = attention(
         hidden_states=hidden_states,
         attention_mask=causal_mask if explicit_mask else None,
-        position_ids=None,
+        position_ids=position_ids,
         past_key_value=None,
         use_cache=False,
     )
@@ -91,7 +94,7 @@ def test_patch_equivalence(patch_fn_name: str, explicit_mask: bool,
         new_output, _, _ = attention(
             hidden_states=hidden_states,
             attention_mask=causal_mask if explicit_mask else None,
-            position_ids=None,
+            position_ids=position_ids,
             past_key_value=None,
             use_cache=False,
         )

--- a/tests/models/layers/test_huggingface_flash.py
+++ b/tests/models/layers/test_huggingface_flash.py
@@ -76,9 +76,11 @@ def test_patch_equivalence(patch_fn_name: str, explicit_mask: bool,
     causal_mask = causal_mask[None,
                               None, :, :].expand(batch_size, 1, sequence_length,
                                                  sequence_length)
-    position_ids = torch.arange(sequence_length, dtype=torch.long, device=device)
+    position_ids = torch.arange(sequence_length,
+                                dtype=torch.long,
+                                device=device)
     position_ids = position_ids[None, :].expand(batch_size, sequence_length)
-    
+
     attn_output, _, _ = attention(
         hidden_states=hidden_states,
         attention_mask=causal_mask if explicit_mask else None,


### PR DESCRIPTION
Missed in the latest release (its deprecated so probably won't do a patch, but fixing on main anyway)

Tests pass locally: `10 passed, 12 deselected, 12 warnings in 7.35s`
Full train run comparison:
<img width="468" alt="Screenshot 2024-03-14 at 4 53 24 PM" src="https://github.com/mosaicml/llm-foundry/assets/43149077/70a71e66-551f-447e-8044-794a45c4ad56">
