### PR TITLE
Compile GLU

### DIFF
--- a/llmfoundry/models/layers/ffn.py
+++ b/llmfoundry/models/layers/ffn.py
@@ -144,6 +144,7 @@ class MPTGLU(MPTMLP):
             **self.fc_kwargs,
         )
 
+    @torch.compile
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.down_proj(self.act(self.gate_proj(x)) * self.up_proj(x))
 


### PR DESCRIPTION
This PR adds torch.compile to the MPTGLU layer forward. 

Under a LLaMa-2-7b-like workload (displayed below) adding torch.compile produces an additional ~100 tok/s/gpu with no changes in the loss

<img width="986" alt="image" src="https://github.com/mosaicml/llm-foundry/assets/26491792/86420549-cf3b-43f6-aa28-07546a893995">
