### PR TITLE
Remove unnecessary test workflow

### DIFF
--- a/.github/workflows/pr-gpu.yaml
+++ b/.github/workflows/pr-gpu.yaml
@@ -24,11 +24,6 @@ jobs:
           markers: "gpu"
           pip_deps: "[all]"
           pytest_command: "coverage run -m pytest"
-        - name: "gpu-2.2.1-flash2"
-          container: mosaicml/llm-foundry:2.2.1_cu121_flash2-latest
-          markers: "gpu"
-          pip_deps: "[all-flash2]"
-          pytest_command: "coverage run -m pytest"
     name: ${{ matrix.name }}
     if: github.repository_owner == 'mosaicml'
     with:


### PR DESCRIPTION
gpu and gpu-flash2 are both flash2 now, so remove the extra test workflow