### PR TITLE
Fix typo in expandable_segments

### DIFF
--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -136,9 +136,9 @@ def main(cfg: DictConfig) -> Trainer:
     if max_split_size_mb is not None:
         cuda_alloc_conf.append(f'max_split_size_mb:{max_split_size_mb}')
 
-    # Expandeable segments
-    if cfg.pop('expandeable_segments', False):
-        cuda_alloc_conf.append('expandeable_segments:True')
+    # Expandable segments
+    if cfg.pop('expandable_segments', False):
+        cuda_alloc_conf.append('expandable_segments:True')
 
     if len(cuda_alloc_conf) > 0:
         os.environ['PYTORCH_CUDA_ALLOC_CONF'] = ','.join(cuda_alloc_conf)


### PR DESCRIPTION
Fixes typo from `expandeable_segments` to `expandable_segments` according to the documentation for PyTorch v2.2.0 https://pytorch.org/docs/2.2/notes/cuda.html#memory-management

![firefox_Kf8IT7de6d](https://github.com/mosaicml/llm-foundry/assets/7960706/e13d63da-fe65-4deb-875a-1372a702a39e)
