### PR TITLE
Bump HF version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ install_requires = [
     'onnx==1.14.0',
     'onnxruntime==1.15.1',
     'boto3>=1.21.45,<2',
-    'huggingface-hub>=0.17.0,<1.0',
+    'huggingface-hub>=0.19.0,<1.0',
     'beautifulsoup4>=4.12.2,<5',  # required for model download utils
     'tenacity>=8.2.3,<9',
     'catalogue>=2,<3',


### PR DESCRIPTION
This file which gets imported through `llmfoundry/data/__init__.py` isn't available until 0.19.0 on huggingface_hub.
https://github.com/huggingface/huggingface_hub/blob/v0.19.0/src/huggingface_hub/utils/insecure_hashlib.py

Stack trace:
```
(mosaicml_venv) root@c3b3495a-cd8c-4e0f-a4da-f6bb0dea0f08-0:/mnt/workdisk/brian/llm-foundry# python llmfoundry/data/__init__.py
Traceback (most recent call last):
  File "/mnt/workdisk/brian/llm-foundry/llmfoundry/data/__init__.py", line 4, in <module>
    from llmfoundry.data.data import ConcatTokensDataset, NoConcatDataset
  File "/mnt/workdisk/brian/llm-foundry/llmfoundry/__init__.py", line 12, in <module>
    from llmfoundry.utils.logging_utils import SpecificWarningFilter
  File "/mnt/workdisk/brian/llm-foundry/llmfoundry/utils/__init__.py", line 4, in <module>
    from llmfoundry.utils.builders import (build_algorithm, build_callback,
  File "/mnt/workdisk/brian/llm-foundry/llmfoundry/utils/builders.py", line 29, in <module>
    from llmfoundry.data.dataloader import build_dataloader
  File "/mnt/workdisk/brian/llm-foundry/llmfoundry/data/__init__.py", line 4, in <module>
    from llmfoundry.data.data import ConcatTokensDataset, NoConcatDataset
  File "/mnt/workdisk/brian/llm-foundry/llmfoundry/data/data.py", line 9, in <module>
    import datasets as hf_datasets
  File "/mnt/workdisk/brian/mosaicml_venv/lib/python3.10/site-packages/datasets/__init__.py", line 22, in <module>
    from .arrow_dataset import Dataset
  File "/mnt/workdisk/brian/mosaicml_venv/lib/python3.10/site-packages/datasets/arrow_dataset.py", line 66, in <module>
    from .arrow_reader import ArrowReader
  File "/mnt/workdisk/brian/mosaicml_venv/lib/python3.10/site-packages/datasets/arrow_reader.py", line 30, in <module>
    from .download.download_config import DownloadConfig
  File "/mnt/workdisk/brian/mosaicml_venv/lib/python3.10/site-packages/datasets/download/__init__.py", line 9, in <module>
    from .download_manager import DownloadManager, DownloadMode
  File "/mnt/workdisk/brian/mosaicml_venv/lib/python3.10/site-packages/datasets/download/download_manager.py", line 31, in <module>
    from ..utils import tqdm as hf_tqdm
  File "/mnt/workdisk/brian/mosaicml_venv/lib/python3.10/site-packages/datasets/utils/__init__.py", line 19, in <module>
    from .info_utils import VerificationMode
  File "/mnt/workdisk/brian/mosaicml_venv/lib/python3.10/site-packages/datasets/utils/info_utils.py", line 5, in <module>
    from huggingface_hub.utils import insecure_hashlib
ImportError: cannot import name 'insecure_hashlib' from 'huggingface_hub.utils' (/mnt/workdisk/brian/mosaicml_venv/lib/python3.10/site-packages/huggingface_hub/utils/__init__.py)
```