### PR TITLE
fixing evaluator microbatch size

### DIFF
--- a/llmfoundry/utils/builders.py
+++ b/llmfoundry/utils/builders.py
@@ -104,6 +104,7 @@ def build_eval_loaders(
             # Load the eval data to fail fast. metrics will get added
             # later in add_metrics_to_eval_loaders, after the model is loaded
             metric_names=[],
+            device_eval_microbatch_size=device_eval_batch_size,
         )
         evaluators.append(eval_loader)
     return evaluators


### PR DESCRIPTION
Currently, we do not pass the `device_eval_microbatch_size` to the Evaluator constructor. So, it uses data loader's batch size. See [this](https://github.com/mosaicml/composer/blob/c140dac86f31a85975dce4c37bc1c6f18ce79c06/composer/core/evaluator.py#L97) and [this](https://github.com/mosaicml/composer/blob/c140dac86f31a85975dce4c37bc1c6f18ce79c06/composer/core/evaluator.py#L164C1-L166C59)

This creates a problem because the data loader's batch size is actually the device microbatch size times the packing ratio. See [this](https://github.com/mosaicml/llm-foundry/blob/b81897ac0a3ee9eb58847e0a8645a81ce11c280a/llmfoundry/data/finetuning/dataloader.py#L140C1-L141C43) and [this](https://github.com/mosaicml/llm-foundry/blob/b81897ac0a3ee9eb58847e0a8645a81ce11c280a/llmfoundry/data/finetuning/dataloader.py#L479C1-L480C42)