### PR TITLE
Remove torch compile from GLU

### DIFF
--- a/llmfoundry/models/layers/ffn.py
+++ b/llmfoundry/models/layers/ffn.py
@@ -144,7 +144,6 @@ class MPTGLU(MPTMLP):
             **self.fc_kwargs,
         )
 
-    @torch.compile
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.down_proj(self.act(self.gate_proj(x)) * self.up_proj(x))
 


### PR DESCRIPTION
We are hitting Torch Dynamo errors in a few places, so I think the safest choice is to revert this optimization until we perform more thorough testing