### PR TITLE
Fix overwriting FP8 act ckpt flag in the train script

### DIFF
--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -80,14 +80,14 @@ def validate_config(cfg: DictConfig):
         fsdp_config = cfg.get('fsdp_config', None)
         act_ckpt = fsdp_config.get('activation_checkpointing', False)
         act_ckpt_reentrant = fsdp_config.get(
-            'activation_checkpointing_reentrant', True)
-        if fsdp_config is not None and act_ckpt == True and act_ckpt_reentrant == False:
+            'activation_checkpointing_reentrant', False)
+        if fsdp_config is not None and act_ckpt == True and act_ckpt_reentrant == True:
             warnings.warn(
                 '`te.Linear` layers do not support activation_checkpointing with '
-                + '`activation_checkpointing_reentrant = False`. ' +
-                'Setting cfg.fsdp_config.activation_checkpointing_reentrant=True.'
+                + '`activation_checkpointing_reentrant = True`. ' +
+                'Setting cfg.fsdp_config.activation_checkpointing_reentrant=False.'
             )
-            cfg.fsdp_config.activation_checkpointing_reentrant = True
+            cfg.fsdp_config.activation_checkpointing_reentrant = False
 
     if cfg.model.get('ffn_config', {}).get('ffn_type', 'mptmlp') == 'te_ln_mlp':
         warnings.warn(


### PR DESCRIPTION
The current activation checkpointing with FP8 TE requires using the non-reentrant implementation from TE. The  fsdp_config for activation checkpointing with TE FP8 is
```
  fsdp_config:
    activation_checkpointing: true
    activation_checkpointing_reentrant: false
    activation_cpu_offload: false
    te_checkpoint_wrapper: true
```
The activation_checkpointing_reentrant param in yaml get overwritten in the [train.py](https://github.com/mosaicml/llm-foundry-private/blob/main/scripts/train/train.py#L78-L90) script due to legacy reasons. Need to rewrite the check.