### PR TITLE
Dbrx finetune yaml requires save folder specified to enable autoresume

### DIFF
--- a/scripts/train/yamls/finetune/dbrx-full-ft.yaml
+++ b/scripts/train/yamls/finetune/dbrx-full-ft.yaml
@@ -86,7 +86,6 @@ seed: 17
 device_train_microbatch_size: 1
 device_eval_batch_size: 1
 precision: amp_bf16
-autoresume: true
 dist_timeout: 3600
 expandable_segments: true
 

--- a/scripts/train/yamls/finetune/dbrx-lora-ft.yaml
+++ b/scripts/train/yamls/finetune/dbrx-lora-ft.yaml
@@ -94,7 +94,6 @@ seed: 17
 device_train_microbatch_size: 1
 device_eval_batch_size: 1
 precision: amp_bf16
-autoresume: true
 dist_timeout: 3600
 expandable_segments: true
 


### PR DESCRIPTION
Dbrx finetune yaml requires save folder specified to enable autoresume. As title. Otherwise yaml errors out of box