### PR TITLE
rm new_group todo

### DIFF
--- a/llmfoundry/models/utils/config_moe_args.py
+++ b/llmfoundry/models/utils/config_moe_args.py
@@ -18,12 +18,6 @@ def create_process_group_ranks(ranks: tuple[int]):
     Used in create_set_process_group and create_mod_process_group methods below.
 
     This function is an alternative to `distributed.new_group(ranks)`.
-    When working with FSDP in torch1.13.1, using `distributed.new_group(ranks)`
-    resulted in an error but this method worked.
-
-    TODO(GRT-2416): When composer no longer has support for torch1.13.1, we should
-    consider using `distributed.new_group(ranks)` here and in composer's FSDP
-    custom process group init.
 
     Args:
         ranks (tuple[int]): Tuple of ranks of group members.


### PR DESCRIPTION
https://github.com/mosaicml/llm-foundry/pull/1111 needed to revert https://github.com/mosaicml/llm-foundry/pull/1104 because the #1104 PR caused issues. Removing TODO and marking Jira with wont-do.