### PR TITLE
catch misconfigured hf dataset

### DIFF
--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -841,7 +841,7 @@ class DatasetConstructor:
             os.remove(signal_file_path)
 
         if isinstance(error, hf_exceptions.DatasetGenerationError):
-            log.error('Huggingface DatasetGenerationError during data prep')
+            log.error('Huggingface DatasetGenerationError during data prep.')
             raise MisconfiguredHfDatasetError(dataset_name=dataset_name,
                                               split=split)
         if error is not None:

--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -52,7 +52,6 @@ from transformers import PreTrainedTokenizerBase
 from llmfoundry.data.finetuning.collator import (_HF_IGNORE_INDEX,
                                                  stitch_turns_decoder_only,
                                                  stitch_turns_encoder_decoder)
-from llmfoundry.utils import exceptions as foundry_exceptions
 # yapf: disable
 from llmfoundry.utils.exceptions import (ConsecutiveRepeatedChatRolesError,
                                          IncorrectMessageKeyQuantityError,
@@ -63,6 +62,7 @@ from llmfoundry.utils.exceptions import (ConsecutiveRepeatedChatRolesError,
                                          InvalidPromptTypeError,
                                          InvalidResponseTypeError,
                                          InvalidRoleError,
+                                         MisconfiguredHfDatasetError,
                                          NotEnoughChatDataError,
                                          TooManyKeysInExampleError,
                                          UnableToProcessPromptResponseError,
@@ -842,8 +842,8 @@ class DatasetConstructor:
 
         if isinstance(error, hf_exceptions.DatasetGenerationError):
             log.error('Huggingface DatasetGenerationError during data prep')
-            raise foundry_exceptions.MisconfiguredHfDatasetError(
-                dataset_name=dataset_name, split=split)
+            raise MisconfiguredHfDatasetError(dataset_name=dataset_name,
+                                              split=split)
         if error is not None:
             log.error('Error during data prep')
             raise error

--- a/llmfoundry/utils/exceptions.py
+++ b/llmfoundry/utils/exceptions.py
@@ -212,5 +212,5 @@ class MisconfiguredHfDatasetError(ValueError):
     def __init__(self, dataset_name: str, split: str) -> None:
         self.dataset_name = dataset_name
         self.split = split
-        message = f'Your dataset (name={dataset_name}, split={split}) is misconfigured. Please check your dataset config.'
+        message = f'Your dataset (name={dataset_name}, split={split}) is misconfigured. Please check your dataset format and make sure you can load your dataset locally.'
         super().__init__(message)

--- a/llmfoundry/utils/exceptions.py
+++ b/llmfoundry/utils/exceptions.py
@@ -204,3 +204,13 @@ class OutputFolderNotEmptyError(FileExistsError):
         self.output_folder = output_folder
         message = f'{output_folder} is not empty. Please remove or empty it and retry.'
         super().__init__(message)
+
+
+class MisconfiguredHfDatasetError(ValueError):
+    """Error thrown when a HuggingFace dataset is misconfigured."""
+
+    def __init__(self, dataset_name: str, split: str) -> None:
+        self.dataset_name = dataset_name
+        self.split = split
+        message = f'Your dataset (name={dataset_name}, split={split}) is misconfigured. Please check your dataset config.'
+        super().__init__(message)

--- a/tests/data/test_dataloader.py
+++ b/tests/data/test_dataloader.py
@@ -277,8 +277,8 @@ def test_invalid_jsonl_data():
     cfg = {
         'name': 'finetuning',
         'dataset': {
-            'hf_name': 'iamroot/chat_formatted_examples',
-            'split': 'train_corrupted',
+            'hf_name': 'iamroot/chat_malformatted_examples',
+            'split': 'train',
             'max_seq_len': max_seq_len,
             'decoder_only_format': decoder_only_format,
             'allow_pad_trimming': allow_pad_trimming,

--- a/tests/data/test_dataloader.py
+++ b/tests/data/test_dataloader.py
@@ -21,7 +21,6 @@ from omegaconf import DictConfig
 from omegaconf import OmegaConf as om
 from streaming import MDSWriter
 
-import llmfoundry.utils.exceptions as llmfoundry_exceptions
 from llmfoundry import build_finetuning_dataloader
 from llmfoundry.data import build_dataloader
 from llmfoundry.data.finetuning.collator import (_HF_IGNORE_INDEX,
@@ -43,6 +42,7 @@ from llmfoundry.utils.exceptions import (ConsecutiveRepeatedChatRolesError,
                                          InvalidPromptTypeError,
                                          InvalidResponseTypeError,
                                          InvalidRoleError,
+                                         MisconfiguredHfDatasetError,
                                          NotEnoughDatasetSamplesError,
                                          TooManyKeysInExampleError,
                                          UnknownExampleTypeError)
@@ -305,7 +305,7 @@ def test_invalid_jsonl_data():
     if not decoder_only_format:
         expected_keys += ['decoder_attention_mask', 'decoder_input_ids']
 
-    with pytest.raises(llmfoundry_exceptions.MisconfiguredHfDatasetError):
+    with pytest.raises(MisconfiguredHfDatasetError):
         build_finetuning_dataloader(cfg, tokenizer,
                                     device_batch_size).dataloader
 

--- a/tests/data/test_dataloader.py
+++ b/tests/data/test_dataloader.py
@@ -21,6 +21,7 @@ from omegaconf import DictConfig
 from omegaconf import OmegaConf as om
 from streaming import MDSWriter
 
+import llmfoundry.utils.exceptions as llmfoundry_exceptions
 from llmfoundry import build_finetuning_dataloader
 from llmfoundry.data import build_dataloader
 from llmfoundry.data.finetuning.collator import (_HF_IGNORE_INDEX,
@@ -266,6 +267,47 @@ def test_sequence_id_wrapper(eos_token_id: Optional[int],
                            torch.Tensor([[0, 0, 0, 1, 1, 1, 2, 2, 2]]))
     else:
         raise NotImplementedError()
+
+
+def test_invalid_jsonl_data():
+    max_seq_len = 2
+    decoder_only_format = True
+    packing_ratio = 'auto'
+    allow_pad_trimming = False
+    cfg = {
+        'name': 'finetuning',
+        'dataset': {
+            'hf_name': 'iamroot/chat_formatted_examples',
+            'split': 'train_corrupted',
+            'max_seq_len': max_seq_len,
+            'decoder_only_format': decoder_only_format,
+            'allow_pad_trimming': allow_pad_trimming,
+            'packing_ratio': packing_ratio,
+            'shuffle': True,
+        },
+        'drop_last': False,
+        'num_workers': 0,
+        'pin_memory': False,
+        'prefetch_factor': None,
+        'persistent_workers': False,
+        'timeout': 0
+    }
+
+    cfg = om.create(cfg)
+
+    tokenizer = build_tokenizer(
+        tokenizer_name='gpt2',
+        tokenizer_kwargs={'model_max_length': max_seq_len})
+
+    device_batch_size = 2
+
+    expected_keys = ['input_ids', 'attention_mask', 'labels']
+    if not decoder_only_format:
+        expected_keys += ['decoder_attention_mask', 'decoder_input_ids']
+
+    with pytest.raises(llmfoundry_exceptions.MisconfiguredHfDatasetError):
+        build_finetuning_dataloader(cfg, tokenizer,
+                                    device_batch_size).dataloader
 
 
 @pytest.mark.parametrize('use_chat_formatting', [True, False])


### PR DESCRIPTION
Catches misconfigured hf dataset and wraps error in an llmfoundry exception that can be surfaced to users.