### PR TITLE
Permit 2.3 nightlies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ install_requires = [
     'accelerate>=0.25,<0.26',  # for HF inference `device_map`
     'transformers>=4.40,<4.41',
     'mosaicml-streaming>=0.7.5,<0.8',
-    'torch>=2.2.1,<2.3',
+    'torch>=2.2.1,<2.3.1',  # TODO: tighten before release
     'datasets>=2.16,<2.17',
     'fsspec==2023.6.0',  # newer version results in a bug in datasets that duplicates data
     'sentencepiece==0.1.97',


### PR DESCRIPTION
Now that we have more frequent releases, I think we can allow for torch nightly versions on main. Releases should tighten the pin to released versions of torch.