### PR TITLE
Strict key checking for dataset

### DIFF
--- a/llmfoundry/utils/exceptions.py
+++ b/llmfoundry/utils/exceptions.py
@@ -6,10 +6,12 @@ from collections.abc import Mapping
 from typing import Any, Dict, List
 
 __all__ = [
+    'ALLOWED_RESPONSE_KEYS',
+    'ALLOWED_PROMPT_KEYS',
+    'ALLOWED_MESSAGES_KEYS',
     'MissingHuggingFaceURLSplitError',
     'NotEnoughDatasetSamplesError',
     'UnknownExampleTypeError',
-    'TooManyKeysInExampleError',
     'NotEnoughChatDataError',
     'ConsecutiveRepeatedChatRolesError',
     'InvalidLastChatMessageRoleError',
@@ -28,6 +30,10 @@ __all__ = [
     'OutputFolderNotEmptyError',
     'MisconfiguredHfDatasetError',
 ]
+
+ALLOWED_RESPONSE_KEYS = {'response', 'completion'}
+ALLOWED_PROMPT_KEYS = {'prompt'}
+ALLOWED_MESSAGES_KEYS = {'messages'}
 
 
 # Finetuning dataloader exceptions
@@ -68,17 +74,11 @@ class UnknownExampleTypeError(KeyError):
 
     def __init__(self, example: Mapping) -> None:
         self.example = example
-        message = f'Unknown example type {example=}'
-        super().__init__(message)
-
-
-class TooManyKeysInExampleError(ValueError):
-    """Error thrown when a data sample has too many keys."""
-
-    def __init__(self, desired_keys: set[str], keys: set[str]) -> None:
-        self.desired_keys = desired_keys
-        self.keys = keys
-        message = f'Data sample has {len(keys)} keys in `allowed_keys`: {desired_keys} Please specify exactly one. Provided keys: {keys}'
+        message = (
+            f'Found keys {example.keys()} in dataset. Unknown example type. For prompt and response '
+            f'finetuning, the valid prompt keys are {ALLOWED_PROMPT_KEYS} and the valid response keys are '
+            f'{ALLOWED_RESPONSE_KEYS}. For chat finetuning, the allowed keys are {ALLOWED_MESSAGES_KEYS}'
+        )
         super().__init__(message)
 
 

--- a/tests/data/test_dataloader.py
+++ b/tests/data/test_dataloader.py
@@ -43,7 +43,6 @@ from llmfoundry.utils.exceptions import (ConsecutiveRepeatedChatRolesError,
                                          InvalidRoleError,
                                          MisconfiguredHfDatasetError,
                                          NotEnoughDatasetSamplesError,
-                                         TooManyKeysInExampleError,
                                          UnknownExampleTypeError)
 # yapf: enable
 from scripts.data_prep.convert_dataset_hf import main as main_hf
@@ -789,10 +788,10 @@ def test_malformed_data(
                                       match='Expected response to be')
     if add_unknown_example_type:
         error_context = pytest.raises(UnknownExampleTypeError,
-                                      match='Unknown example type')
+                                      match=r'.*Unknown example type')
     if add_too_many_example_keys:
-        error_context = pytest.raises(TooManyKeysInExampleError,
-                                      match='Please specify exactly one.')
+        error_context = pytest.raises(UnknownExampleTypeError,
+                                      match=r'.*Unknown example type')
 
     with error_context:
         dl = build_finetuning_dataloader(cfg, tokenizer,

--- a/tests/data/test_template_tokenization.py
+++ b/tests/data/test_template_tokenization.py
@@ -6,12 +6,12 @@ from unittest.mock import MagicMock
 import pytest
 import transformers
 
-from llmfoundry.data.finetuning.tasks import (_ALLOWED_PROMPT_KEYS,
-                                              _ALLOWED_RESPONSE_KEYS,
-                                              _slice_chat_formatted_example,
+from llmfoundry.data.finetuning.tasks import (_slice_chat_formatted_example,
                                               dataset_constructor,
                                               tokenize_formatted_example)
 from llmfoundry.utils.builders import build_tokenizer
+from llmfoundry.utils.exceptions import (ALLOWED_PROMPT_KEYS,
+                                         ALLOWED_RESPONSE_KEYS)
 
 
 def test_tokenize_chat_example_malformed():
@@ -167,8 +167,8 @@ def test_tokenize_instruct_example_malformed():
 def test_tokenize_instruct_example_well_formed():
     tokenizer = transformers.AutoTokenizer.from_pretrained('gpt2')
 
-    for prompt_key in _ALLOWED_PROMPT_KEYS:
-        for response_key in _ALLOWED_RESPONSE_KEYS:
+    for prompt_key in ALLOWED_PROMPT_KEYS:
+        for response_key in ALLOWED_RESPONSE_KEYS:
 
             example = {prompt_key: 'prompt', response_key: 'response'}
             tokenized_example = tokenize_formatted_example(example, tokenizer)


### PR DESCRIPTION
- Moves global constants to exceptions
- Changes error parameter to string
- Dataset keys must match strict key names
  - only `ALLOWED_MESSAGES_KEYS` OR
  - one of
    - `ALLOWED_RESPONSE_KEYS` AND
    - `ALLOWED_PROMPT_KEYS`