### PR TITLE
First initialize dist with gloo

### DIFF
--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -194,7 +194,7 @@ def main(cfg: DictConfig) -> Trainer:
 
     # DO NOT MERGE
     if os.environ['RANK'] == '10':
-        os.environ['MASTER_ADDR'] = '127.0.0.1'
+        time.sleep(30)
 
     log.debug('Testing barrier with cpu...')
     dist.barrier()

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -10,7 +10,7 @@ import warnings
 from typing import Any, Dict, List, Optional, Union
 
 import torch
-import torch.distributed as tdist
+import torch.distributed
 from composer import Trainer
 from composer.core.callback import Callback
 from composer.profiler import (JSONTraceHandler, Profiler, TraceHandler,
@@ -132,7 +132,7 @@ def _initialize_gloo_and_nccl(dist_timeout: Union[int, float]):
     log.debug('Testing barrier with cpu...')
     dist.barrier()
     log.debug('Barrier test passed with cpu. Destroying process group...')
-    tdist.destroy_process_group()
+    torch.distributed.destroy_process_group()
     log.debug('Process group destroyed.')
 
     # Now, initialize with the correct device

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -189,22 +189,22 @@ def main(cfg: DictConfig) -> Trainer:
             python_log_level.upper())  # Train script
 
     # First, initialize with a gloo process group and test a barrier
-    # log.debug('Initializing dist with cpu...')
-    # dist.initialize_dist('cpu', timeout=dist_timeout)
-    # log.debug('Testing barrier with cpu...')
-    # dist.barrier()
-    # log.debug('Barrier test passed with cpu. Destroying process group...')
-    # tdist.destroy_process_group()
-    # log.debug('Process group destroyed.')
-
-    # Now, initialize with the correct device
-    log.debug('Initializing dist with device...')
-    dist.initialize_dist(get_device(None), timeout=dist_timeout)
+    log.debug('Initializing dist with cpu...')
+    dist.initialize_dist('cpu', timeout=dist_timeout)
 
     # DO NOT MERGE
     if os.environ['RANK'] == '10':
         os.environ['MASTER_ADDR'] = '127.0.0.1'
 
+    log.debug('Testing barrier with cpu...')
+    dist.barrier()
+    log.debug('Barrier test passed with cpu. Destroying process group...')
+    tdist.destroy_process_group()
+    log.debug('Process group destroyed.')
+
+    # Now, initialize with the correct device
+    log.debug('Initializing dist with device...')
+    dist.initialize_dist(get_device(None), timeout=dist_timeout)
     log.debug('Testing barrier with device...')
     dist.barrier()
     log.debug('Barrier test passed with device.')

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -191,11 +191,6 @@ def main(cfg: DictConfig) -> Trainer:
     # First, initialize with a gloo process group and test a barrier
     log.debug('Initializing dist with cpu...')
     dist.initialize_dist('cpu', timeout=dist_timeout)
-
-    # DO NOT MERGE
-    if os.environ['RANK'] == '10':
-        time.sleep(30)
-
     log.debug('Testing barrier with cpu...')
     dist.barrier()
     log.debug('Barrier test passed with cpu. Destroying process group...')
@@ -205,6 +200,11 @@ def main(cfg: DictConfig) -> Trainer:
     # Now, initialize with the correct device
     log.debug('Initializing dist with device...')
     dist.initialize_dist(get_device(None), timeout=dist_timeout)
+
+    # DO NOT MERGE
+    if os.environ['RANK'] == '10':
+        time.sleep(30)
+
     log.debug('Testing barrier with device...')
     dist.barrier()
     log.debug('Barrier test passed with device.')

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -189,22 +189,22 @@ def main(cfg: DictConfig) -> Trainer:
             python_log_level.upper())  # Train script
 
     # First, initialize with a gloo process group and test a barrier
-    log.debug('Initializing dist with cpu...')
-    dist.initialize_dist('cpu', timeout=dist_timeout)
+    # log.debug('Initializing dist with cpu...')
+    # dist.initialize_dist('cpu', timeout=dist_timeout)
+    # log.debug('Testing barrier with cpu...')
+    # dist.barrier()
+    # log.debug('Barrier test passed with cpu. Destroying process group...')
+    # tdist.destroy_process_group()
+    # log.debug('Process group destroyed.')
+
+    # Now, initialize with the correct device
+    log.debug('Initializing dist with device...')
+    dist.initialize_dist(get_device(None), timeout=dist_timeout)
 
     # DO NOT MERGE
     if os.environ['RANK'] == '10':
         os.environ['MASTER_ADDR'] = '127.0.0.1'
 
-    log.debug('Testing barrier with cpu...')
-    dist.barrier()
-    log.debug('Barrier test passed with cpu. Destroying process group...')
-    tdist.destroy_process_group()
-    log.debug('Process group destroyed.')
-
-    # Now, initialize with the correct device
-    log.debug('Initializing dist with device...')
-    dist.initialize_dist(get_device(None), timeout=dist_timeout)
     log.debug('Testing barrier with device...')
     dist.barrier()
     log.debug('Barrier test passed with device.')

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -116,8 +116,7 @@ def validate_config(cfg: DictConfig):
 
 
 def _initialize_gloo_and_nccl(dist_timeout: Union[int, float]):
-    """Initialize a GLOO process group (immediately destroyed) and a device
-    process group.
+    """Initialize GLOO process group (then destroyed) and device process group.
 
     We have experienced an issue where the first barrier with NCCL does not timeout properly,
     and can hang forever if something is wrong. To attempt to mitigate this, we will first

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -187,14 +187,15 @@ def main(cfg: DictConfig) -> Trainer:
             python_log_level.upper())  # Foundry module
         logging.getLogger(__name__).setLevel(
             python_log_level.upper())  # Train script
-        
-    # DO NOT MERGE
-    if os.environ['RANK'] == '10':
-        os.environ['MASTER_ADDR'] = '127.0.0.1'
 
     # First, initialize with a gloo process group and test a barrier
     log.debug('Initializing dist with cpu...')
     dist.initialize_dist('cpu', timeout=dist_timeout)
+
+    # DO NOT MERGE
+    if os.environ['RANK'] == '10':
+        os.environ['MASTER_ADDR'] = '127.0.0.1'
+
     log.debug('Testing barrier with cpu...')
     dist.barrier()
     log.debug('Barrier test passed with cpu. Destroying process group...')

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -126,7 +126,6 @@ def _initialize_gloo_and_nccl(dist_timeout: Union[int, float]):
     Args:
         dist_timeout (Union[int, float]): Timeout for initializing the process group
     """
-
     # First, initialize with a gloo process group and test a barrier
     log.debug('Initializing dist with cpu...')
     dist.initialize_dist('cpu', timeout=dist_timeout)

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -175,7 +175,7 @@ def main(cfg: DictConfig) -> Trainer:
                                                  'python_log_level',
                                                  must_exist=False,
                                                  default_value='debug')
-    # set logging level
+    # Set logging level
     if python_log_level is not None:
         logging.basicConfig(
             # Example of format string

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -189,7 +189,7 @@ def main(cfg: DictConfig) -> Trainer:
             python_log_level.upper())  # Train script
         
     # DO NOT MERGE
-    if os.environ['RANK'] == '1':
+    if os.environ['RANK'] == '10':
         os.environ['MASTER_ADDR'] = '127.0.0.1'
 
     # First, initialize with a gloo process group and test a barrier

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -187,6 +187,10 @@ def main(cfg: DictConfig) -> Trainer:
             python_log_level.upper())  # Foundry module
         logging.getLogger(__name__).setLevel(
             python_log_level.upper())  # Train script
+        
+    # DO NOT MERGE
+    if os.environ['RANK'] == '1':
+        os.environ['MASTER_ADDR'] = '127.0.0.1'
 
     # First, initialize with a gloo process group and test a barrier
     log.debug('Initializing dist with cpu...')

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -200,11 +200,6 @@ def main(cfg: DictConfig) -> Trainer:
     # Now, initialize with the correct device
     log.debug('Initializing dist with device...')
     dist.initialize_dist(get_device(None), timeout=dist_timeout)
-
-    # DO NOT MERGE
-    if os.environ['RANK'] == '10':
-        time.sleep(30)
-
     log.debug('Testing barrier with device...')
     dist.barrier()
     log.debug('Barrier test passed with device.')


### PR DESCRIPTION
There seems to be an issue with the first nccl barrier, where the timeout does not properly apply. It does apply correctly to a gloo barrier though. So we add a gloo barrier at the start to make sure all ranks are alive, and then proceed with the normal process group intialization.

Run with this that runs successfully: `gloo-baseline-1-cAcvEB`
Run with this change and a rank sleeping in the gloo section (does timeout): `gloo-messed-up-no-gloo-2-CZw9ru` (on https://github.com/mosaicml/llm-foundry/pull/1133/commits/a7616ea5a110faf6c0fa5595b460123af8437ec1)
Run with this change and a rank sleeping in the nccl section (does not timeout): `gloo-messed-up-5-HB6gOH` (on https://github.com/mosaicml/llm-foundry/pull/1133/commits/ac258b93997a189e5e3157397e5d1ccab367ab30)