### PR TITLE
Fix saving of generation_config for Llama-3

### DIFF
--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -426,6 +426,9 @@ class HuggingFaceCheckpointer(Callback):
                 # initialization cost.
                 with init_empty_weights():
                     new_model_instance = type(original_model)(copied_config)
+                    new_model_instance.generation_config.update(
+                        **original_model.generation_config.to_dict()
+                    )
 
             # Then load the state dict in with "assign" so that the state dict
             # is loaded properly even though the model is initially on meta device.

--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -427,8 +427,7 @@ class HuggingFaceCheckpointer(Callback):
                 with init_empty_weights():
                     new_model_instance = type(original_model)(copied_config)
                     new_model_instance.generation_config.update(
-                        **original_model.generation_config.to_dict()
-                    )
+                        **original_model.generation_config.to_dict())
 
             # Then load the state dict in with "assign" so that the state dict
             # is loaded properly even though the model is initially on meta device.


### PR DESCRIPTION
The existing version of `HuggingFaceCheckpointer` does not respect model's `generation_config.json` and during saving it initializes it from the `config.json`. In the case of Llama-3 model, there is a discrepancy with `eos_token_id` which is set to  `128001` in `config.json` but to `[128001, 128009]` in `generation_config.json`. This means that Llama-3 models saved with `HuggingFaceCheckpointer` have `"eos_token_id": 128001` instead of `"eos_token_id": [128001, 128009],`.  

This creates problems when we want to use Llama-3 models produced with llm-foundry as they will most likely always generate text until the max number of tokens is exhausted instead of stopping at `128009` token.