### PR TITLE
Remove olmo as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -111,10 +111,6 @@ extra_deps['peft'] = [
     'mosaicml[peft]>=0.21.1,<0.22',
 ]
 
-extra_deps['olmo'] = [
-    'ai2-olmo>0.2.4',
-]
-
 extra_deps['openai'] = [
     'openai==1.3.8',
     'tiktoken==0.4.0',


### PR DESCRIPTION
Removes olmo as a dependency since we don't use it at all, and it requires torch < 2.3.0 which is incompatible with us upgrading.