### PR TITLE
Checking if attention mask is present for ignoring pad tokens in ffn.

### DIFF
--- a/llmfoundry/models/layers/blocks.py
+++ b/llmfoundry/models/layers/blocks.py
@@ -221,11 +221,11 @@ class MPTBlock(nn.Module):
         """
         batch_size, seq_len = m.size()[:2]
         indices = None
-        if not self.use_pad_tok_in_ffn:
+        if not self.use_pad_tok_in_ffn and attention_mask is not None:
             assert unpad_input is not None
             m, indices, _, _ = unpad_input(m, attention_mask)
         n = self.ffn(m)
-        if not self.use_pad_tok_in_ffn:
+        if not self.use_pad_tok_in_ffn and attention_mask is not None:
             assert pad_input is not None
             n = pad_input(n, indices, batch_size, seq_len)
         return n


### PR DESCRIPTION
If `attention_mask` is `None`, that means we do not have padding tokens, and hence we do not need to unpad the input. Currently, if `attention_mask` is `None` then `unpad_input(m, attention_mask)` throws an error. 