### PR TITLE
Removing rich install

### DIFF
--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -21,20 +21,16 @@ from composer.profiler import (
 from composer.utils import dist, get_device, reproducibility
 from omegaconf import DictConfig
 from omegaconf import OmegaConf as om
-from rich.traceback import install
 
+from llmfoundry.callbacks import AsyncEval
+from llmfoundry.data.dataloader import build_dataloader
 from llmfoundry.eval.metrics.nlp import InContextLearningMetric
+from llmfoundry.layers_registry import ffns_with_megablocks
 from llmfoundry.utils import (
     find_mosaicml_logger,
     log_train_analytics,
     maybe_create_mosaicml_logger,
 )
-
-install()
-
-from llmfoundry.callbacks import AsyncEval
-from llmfoundry.data.dataloader import build_dataloader
-from llmfoundry.layers_registry import ffns_with_megablocks
 from llmfoundry.utils.builders import (
     add_metrics_to_eval_loaders,
     build_algorithm,


### PR DESCRIPTION
Removing rich install because rich is overriding the custom python excepthook we create in mcloud to catch exceptions.

This does mean that users submitting foundry runs through without mcli may not have rich formatting. However, if the run is submitted through mcli, our excepthook override will maintain rich formatting.

example of a run that maintains rich formatting after we remove the install and enable the mcloud excepthook
<img width="815" alt="image" src="https://github.com/mosaicml/llm-foundry/assets/29712344/cc92f7d1-ece7-441a-b23d-59a0963cb234">
