### PR TITLE
Allow EOS token for finetuning

### DIFF
--- a/llmfoundry/data/finetuning/dataloader.py
+++ b/llmfoundry/data/finetuning/dataloader.py
@@ -390,6 +390,7 @@ def _validate_config(
         'allow_pad_trimming',
         'seq_parallel_replication',
         'auto_packing_replication',
+        'eos_token_id',
     }
     if not set(kwargs.keys()).issubset(allowed_additional_kwargs):
         raise ValueError(


### PR DESCRIPTION
This is needed to allow the finetuning dataset to be constructed correctly.