### PR TITLE
Add fc to HF export

### DIFF
--- a/llmfoundry/models/mpt/modeling_mpt.py
+++ b/llmfoundry/models/mpt/modeling_mpt.py
@@ -77,6 +77,7 @@ from llmfoundry.models.utils.param_init_fns import (
     generic_param_init_fn_,  # type: ignore (see note)
 )
 from llmfoundry.models.layers.ffn import resolve_ffn_act_fn  # type: ignore (see note)
+from llmfoundry.models.layers.fc import fcs  # type: ignore (see note)
 
 from llmfoundry.models.utils.act_ckpt import (
     pass_on_block_idx,

--- a/tests/a_scripts/inference/test_convert_composer_to_hf.py
+++ b/tests/a_scripts/inference/test_convert_composer_to_hf.py
@@ -1410,7 +1410,8 @@ def test_mptmoe_huggingface_conversion_callback(
 
 
 def test_mpt_convert_simple(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
 ):
     delete_transformers_cache()
 

--- a/tests/a_scripts/inference/test_convert_composer_to_hf.py
+++ b/tests/a_scripts/inference/test_convert_composer_to_hf.py
@@ -1442,9 +1442,9 @@ def test_mpt_convert_simple(
         cfg=model_cfg,
     )
 
-    original_model.model.save_pretrained(tmp_path)
+    original_model.model.save_pretrained(str(tmp_path))
 
-    edit_files_for_hf_compatibility(tmp_path)
+    edit_files_for_hf_compatibility(str(tmp_path))
 
     monkeypatch.setattr(catalogue, 'REGISTRY', {})
 

--- a/tests/a_scripts/inference/test_convert_composer_to_hf.py
+++ b/tests/a_scripts/inference/test_convert_composer_to_hf.py
@@ -1407,6 +1407,65 @@ def test_mptmoe_huggingface_conversion_callback(
     delete_transformers_cache()
 
 
+# def test_mpt_convert_simple():
+#     delete_transformers_cache()
+
+#     om_cfg = get_config(
+#         conf_path='scripts/train/yamls/pretrain/testing.yaml',
+#     )
+#     om_cfg['model']['init_device'] = 'cpu'
+#     om_cfg['tie_word_embeddings'] = True
+#     tokenizer = transformers.AutoTokenizer.from_pretrained(
+#         om_cfg.tokenizer.name,
+#     )
+#     name = om_cfg.model.pop('name')
+#     original_model = build_composer_model(
+#         name=name,
+#         tokenizer=tokenizer,
+#         cfg=to_dict_container(om_cfg['model']),
+#     )
+#     trainer = Trainer(
+#         model=original_model,
+#         device='cpu',
+#     )
+#     trainer.save_checkpoint('checkpoint.pt')
+
+#     args = Namespace(
+#         composer_path='checkpoint.pt',
+#         hf_output_path='hf-output-folder',
+#         output_precision='fp32',
+#         local_checkpoint_save_location=None,
+#         hf_repo_for_upload=None,
+#         trust_remote_code=False,
+#         test_uploaded_model=False,
+#     )
+#     convert_composer_to_hf(args)
+
+#     loaded_config = transformers.AutoConfig.from_pretrained(
+#         'hf-output-folder',
+#         trust_remote_code=True,
+#     )
+#     loaded_model = transformers.AutoModelForCausalLM.from_pretrained(
+#         'hf-output-folder',
+#         config=loaded_config,
+#         trust_remote_code=True,
+#     )
+#     tokenizer = transformers.AutoTokenizer.from_pretrained(
+#         'hf-output-folder',
+#         trust_remote_code=True,
+#     )
+
+#     device = 'cpu'
+#     precision = torch.float32
+#     original_model.to(device)
+#     original_model.to(precision)
+#     loaded_model.to(device)
+#     loaded_model.to(precision)
+
+#     output = loaded_model.generate(
+#         tokenizer('hello', return_tensors='pt')['input_ids'].
+
+
 @pytest.mark.parametrize(
     'license_file_name',
     ['LICENSE', 'LICENSE.txt', 'license', 'license.md', None],

--- a/tests/a_scripts/inference/test_convert_composer_to_hf.py
+++ b/tests/a_scripts/inference/test_convert_composer_to_hf.py
@@ -1416,6 +1416,8 @@ def test_mpt_convert_simple(
     delete_transformers_cache()
 
     from transformers.models.auto.configuration_auto import CONFIG_MAPPING
+    original_config_auto_class = MPTConfig._auto_class
+    original_model_auto_class = MPTForCausalLM._auto_class
     CONFIG_MAPPING._extra_content['mpt'] = MPTConfig
     MPTConfig.register_for_auto_class()
     MPTForCausalLM.register_for_auto_class('AutoModelForCausalLM')
@@ -1454,6 +1456,10 @@ def test_mpt_convert_simple(
     )
 
     delete_transformers_cache()
+
+    del CONFIG_MAPPING._extra_content['mpt']
+    MPTConfig._auto_class = original_config_auto_class
+    MPTForCausalLM._auto_class = original_model_auto_class
 
 
 @pytest.mark.parametrize(

--- a/tests/eval/test_in_context_learning_datasets.py
+++ b/tests/eval/test_in_context_learning_datasets.py
@@ -12,7 +12,6 @@ import torch
 import transformers
 from composer import Evaluator
 from composer.core import DataSpec
-from composer.datasets.utils import MultiTokenEOSCriteria
 from composer.loggers import InMemoryLogger
 from composer.models import HuggingFaceModel
 from composer.trainer import Trainer
@@ -24,6 +23,7 @@ from llmfoundry.eval.datasets import (
     InContextLearningGenerationTaskWithAnswersDataset,
     InContextLearningMultipleChoiceTaskDataset,
     InContextLearningSchemaTaskDataset,
+    MultiTokenEOSCriteria,
     get_continuation_span,
     get_fewshot_sample_idxs,
     get_icl_task_dataloader,

--- a/tests/models/hf/test_hf_config.py
+++ b/tests/models/hf/test_hf_config.py
@@ -2,16 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-import tempfile
+import shutil
 from copy import deepcopy
-from pathlib import Path
 from typing import Any, Dict, Mapping
 from unittest.mock import Mock, patch
 
 import pytest
-import torch
+from composer.utils import dist
 from omegaconf import OmegaConf as om
-from transformers import AutoModelForCausalLM, PretrainedConfig
+from transformers import PretrainedConfig
 
 from llmfoundry.models.mpt import MPTConfig, MPTForCausalLM
 from llmfoundry.utils import build_tokenizer
@@ -84,6 +83,45 @@ def test_tie_weights(tie_word_embeddings: bool):
         assert mpt.lm_head is not None
 
 
+# TODO(GRT-2435): Change to fixture
+def delete_transformers_cache():
+    # Only delete the files on local rank 0, otherwise race conditions are created
+    if not dist.get_local_rank() == 0:
+        return
+
+    hf_cache_home = os.path.expanduser(
+        os.getenv(
+            'HF_HOME',
+            os.path.join(
+                os.getenv('XDG_CACHE_HOME', '~/.cache'),
+                'huggingface',
+            ),
+        ),
+    )
+    HF_MODULES_CACHE = os.getenv(
+        'HF_MODULES_CACHE',
+        os.path.join(hf_cache_home, 'modules'),
+    )
+    if os.path.exists(HF_MODULES_CACHE) and os.path.isdir(HF_MODULES_CACHE):
+        shutil.rmtree(HF_MODULES_CACHE)
+
+
+# def test_mpt_convert_simple(
+#     monkeypatch: pytest.MonkeyPatch,
+#     tmp_path: pathlib.Path,
+# ):
+#     delete_transformers_cache()
+
+#     from transformers.models.auto.configuration_auto import CONFIG_MAPPING
+#     original_config_auto_class = MPTConfig._auto_class
+#     original_model_auto_class = MPTForCausalLM._auto_class
+#     CONFIG_MAPPING._extra_content['mpt'] = MPTConfig
+#     MPTConfig.register_for_auto_class()
+#     MPTForCausalLM.register_for_auto_class('AutoModelForCausalLM')
+
+#     delete_transformers_cache()
+
+
 @pytest.mark.parametrize(
     'model_cfg_overrides',
     [
@@ -92,7 +130,7 @@ def test_tie_weights(tie_word_embeddings: bool):
         },
         {
             'attn_config': {
-                'attn_impl': 'flash',
+                'attn_pdrop': 1.0,
             },
         },
         {
@@ -103,7 +141,7 @@ def test_tie_weights(tie_word_embeddings: bool):
         {
             'max_seq_len': 1024,
             'attn_config': {
-                'attn_impl': 'flash',
+                'attn_pdrop': 1.0,
             },
             'init_config': {
                 'emb_init_std': 5,
@@ -131,22 +169,8 @@ def test_hf_config_override(
     model_cfg_overrides: Dict[str, Any],
     conf_path: str = 'scripts/train/yamls/pretrain/testing.yaml',
 ):
-    from transformers.models.auto.configuration_auto import CONFIG_MAPPING
-    CONFIG_MAPPING._extra_content['mpt'] = MPTConfig
-    AutoModelForCausalLM.register(MPTConfig, MPTForCausalLM)
-    MPTConfig.register_for_auto_class()
-
     with open(conf_path) as f:
         test_cfg = om.load(f)
-
-    # Build Model
-    # For fast initialization, use `meta` device
-    print('Initializing model...')
-    device = 'cpu'
-    test_cfg.model.init_device = device
-    test_cfg.device = device
-    test_cfg.precision = 'fp16'
-    test_cfg.model.attn_config = {'attn_impl': 'torch', 'alibi': True}
 
     tokenizer_cfg: Dict[str, Any] = om.to_container(
         test_cfg.tokenizer,
@@ -155,26 +179,19 @@ def test_hf_config_override(
     tokenizer_name = tokenizer_cfg['name']
     tokenizer_kwargs = tokenizer_cfg.get('kwargs', {})
     tokenizer = build_tokenizer(tokenizer_name, tokenizer_kwargs)
-    name = test_cfg.model.pop('name')
-    model = build_composer_model(
-        name=name,
-        cfg=to_dict_container(test_cfg.model),
-        tokenizer=tokenizer,
-    )
 
-    # save model
-    tmp_dir = tempfile.TemporaryDirectory()
-    save_path = tmp_dir.name
+    tiny_overrides = {
+        'n_layers': 2,
+        'd_model': 128,
+    }
 
-    tokenizer.save_pretrained(save_path)
-    model.config.save_pretrained(save_path)
-    torch.save(model.state_dict(), Path(save_path) / 'pytorch_model.bin')
+    model_cfg_overrides.update(tiny_overrides)
 
     # load hf causal lm model with config_overrides
     hf_model_config = deepcopy(test_cfg)
     model_cfg = om.create({
         'name': 'hf_causal_lm',
-        'pretrained_model_name_or_path': save_path,
+        'pretrained_model_name_or_path': 'mosaicml/mpt-7b',
         'pretrained': False,
         'config_overrides': model_cfg_overrides,
     })

--- a/tests/models/hf/test_hf_config.py
+++ b/tests/models/hf/test_hf_config.py
@@ -134,6 +134,7 @@ def test_hf_config_override(
     from transformers.models.auto.configuration_auto import CONFIG_MAPPING
     CONFIG_MAPPING._extra_content['mpt'] = MPTConfig
     AutoModelForCausalLM.register(MPTConfig, MPTForCausalLM)
+    MPTConfig.register_for_auto_class()
 
     with open(conf_path) as f:
         test_cfg = om.load(f)


### PR DESCRIPTION
The HF export was missing the fc.py file and the associated register, so would result in an error when trying to load the HF exported model. This PR both fixes the issue, and adds a unit test that would've caught it, which requires clearing the registry for the unit test to simulate a fresh environment.

The move of `MultiTokenEOSCriteria` is just because Composer dev has removed that class, and it is now in foundry.