### PR TITLE
Added torch_dmoe defaults, bug fixes for 2D inputs

### DIFF
--- a/llmfoundry/models/layers/dmoe.py
+++ b/llmfoundry/models/layers/dmoe.py
@@ -1,9 +1,11 @@
 # Copyright 2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Callable, Optional
+from functools import partial
+from typing import Callable, Optional, Union
 
 import torch
+import torch.nn.functional as F
 
 __all__ = [
     'dMoE',
@@ -12,6 +14,8 @@ __all__ = [
     'GLU',
     'DroplessMLP',
 ]
+
+DEFAULT_ACTIVATION_FN = partial(F.gelu, approximate='tanh')
 
 
 # Add option to route tokens uniformly across experts. We use
@@ -36,8 +40,8 @@ class LearnedRouter(torch.nn.Module):
         hidden_size: int,
         moe_num_experts: int,
         moe_top_k: int,
-        moe_jitter_eps: float,
-        moe_normalize_expert_weights: bool,
+        moe_jitter_eps: Optional[float],
+        moe_normalize_expert_weights: Optional[Union[int, float]],
         uniform_expert_assignment: bool,
         device: Optional[torch.device],
     ) -> None:
@@ -45,8 +49,9 @@ class LearnedRouter(torch.nn.Module):
         self.hidden_size: int = hidden_size
         self.moe_num_experts: int = moe_num_experts
         self.moe_top_k: int = moe_top_k
-        self.moe_jitter_eps: float = moe_jitter_eps
-        self.moe_normalize_expert_weights: bool = moe_normalize_expert_weights
+        self.moe_jitter_eps: Optional[float] = moe_jitter_eps
+        self.moe_normalize_expert_weights: Optional[Union[
+            int, float]] = moe_normalize_expert_weights
         self.uniform_expert_assignment: bool = uniform_expert_assignment
 
         self.layer: torch.nn.Module = torch.nn.Linear(
@@ -57,6 +62,7 @@ class LearnedRouter(torch.nn.Module):
         )
 
     def jitter(self, x: torch.Tensor) -> torch.Tensor:
+        assert self.moe_jitter_eps is not None
         low: float = 1.0 - self.moe_jitter_eps
         high: float = 1.0 + self.moe_jitter_eps
         noise: torch.Tensor = torch.rand(
@@ -288,17 +294,17 @@ class dMoE(torch.nn.Module):
 
     def __init__(
         self,
-        hidden_size: int,
-        ffn_hidden_size: int,
-        moe_num_experts: int,
-        moe_top_k: int,
-        mlp_type: str,
-        activation_fn: Callable,
-        moe_jitter_eps: float,
-        moe_normalize_expert_weights: bool,
-        uniform_expert_assignment: bool,
-        bias: bool,
         device: Optional[torch.device],
+        hidden_size: int = 1024,
+        ffn_hidden_size: int = 4096,
+        moe_num_experts: int = 1,
+        moe_top_k: int = 1,
+        mlp_type: str = 'mlp',
+        activation_fn: Callable = DEFAULT_ACTIVATION_FN,
+        moe_jitter_eps: Optional[float] = None,
+        moe_normalize_expert_weights: Optional[Union[int, float]] = None,
+        uniform_expert_assignment: bool = False,
+        bias: bool = True,
     ):
         super().__init__()
 

--- a/llmfoundry/models/layers/dmoe.py
+++ b/llmfoundry/models/layers/dmoe.py
@@ -270,7 +270,14 @@ class DroplessMLP(torch.nn.Module):
         expert_mask = torch.nn.functional.one_hot(
             top_experts,
             num_classes=self.moe_num_experts,
-        ).permute(2, 1, 0)
+        )
+        
+        if expert_mask.dims() == 3:
+            expert_mask = expert_mask.permute(2, 1, 0)
+        elif expert_mask.dims() == 2:
+            expert_mask = expert_mask.t()
+        else:
+            raise ValueError(f'Unexpected expert mask dimensions of {expert_mask.dims()}')
         for expert_idx in range(0, self.moe_num_experts):
             topk_idx, token_idx = torch.where(expert_mask[expert_idx])
             if token_idx.shape[0] == 0:

--- a/llmfoundry/models/layers/dmoe.py
+++ b/llmfoundry/models/layers/dmoe.py
@@ -272,9 +272,9 @@ class DroplessMLP(torch.nn.Module):
             num_classes=self.moe_num_experts,
         )
         
-        if expert_mask.dims() == 3:
+        if expert_mask.dim() == 3:
             expert_mask = expert_mask.permute(2, 1, 0)
-        elif expert_mask.dims() == 2:
+        elif expert_mask.dim() == 2:
             expert_mask = expert_mask.t()
         else:
             raise ValueError(f'Unexpected expert mask dimensions of {expert_mask.dims()}')

--- a/llmfoundry/models/layers/dmoe.py
+++ b/llmfoundry/models/layers/dmoe.py
@@ -74,15 +74,13 @@ class LearnedRouter(torch.nn.Module):
 
     def _top_k(self, scores: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
         if self.moe_top_k == 1:
-            values, indices = scores.max(
-                dim=-1,
-            )  # pyright: ignore[reportGeneralTypeIssues]
+            values, indices = scores.max(dim=-1,)
             return values.unsqueeze(-1), indices.unsqueeze(-1)
         return torch.topk(
             scores,
             self.moe_top_k,
             dim=-1,
-        )  # pyright: ignore[reportGeneralTypeIssues]
+        )
 
     def forward(self, x: torch.Tensor):
         if self.training and self.moe_jitter_eps is not None:

--- a/llmfoundry/models/layers/dmoe.py
+++ b/llmfoundry/models/layers/dmoe.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from functools import partial
-from typing import Callable, Optional, Union
+from typing import Callable, Optional, Tuple, Union
 
 import torch
 import torch.nn.functional as F
@@ -72,7 +72,7 @@ class LearnedRouter(torch.nn.Module):
         )
         return low + noise * (high - low)
 
-    def _top_k(self, scores: torch.Tensor) -> torch.Tensor:
+    def _top_k(self, scores: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
         if self.moe_top_k == 1:
             values, indices = scores.max(
                 dim=-1,

--- a/tests/models/layers/test_dmoe.py
+++ b/tests/models/layers/test_dmoe.py
@@ -65,7 +65,7 @@ def _get_torch_dtype(fp16: bool, bf16: bool) -> Optional[torch.dtype]:
 @pytest.mark.world_size(2)
 @pytest.mark.parametrize('moe_num_experts', [1, 2, 4, 8])
 #@pytest.mark.parametrize('mlp_type', ['glu', 'mlp'])
-@pytest.mark.parametrize('moe_world_size', [1, 2, 4])
+@pytest.mark.parametrize('moe_world_size', [1, 2])
 #@pytest.mark.parametrize('moe_normalize_expert_weights', [1, 2.0])
 #@pytest.mark.parametrize('two_d_input', [True, False])
 @pytest.mark.parametrize('mlp_type', ['mlp'])

--- a/tests/models/layers/test_dmoe.py
+++ b/tests/models/layers/test_dmoe.py
@@ -63,13 +63,15 @@ def _get_torch_dtype(fp16: bool, bf16: bool) -> Optional[torch.dtype]:
 )
 @pytest.mark.gpu
 @pytest.mark.world_size(2)
-@pytest.mark.parametrize('moe_num_experts', [1, 2, 4, 8])
+#@pytest.mark.parametrize('moe_num_experts', [1, 2, 4, 8])
 #@pytest.mark.parametrize('mlp_type', ['glu', 'mlp'])
-@pytest.mark.parametrize('moe_world_size', [1, 2])
+#@pytest.mark.parametrize('moe_world_size', [1, 2])
 #@pytest.mark.parametrize('moe_normalize_expert_weights', [1, 2.0])
 #@pytest.mark.parametrize('two_d_input', [True, False])
 @pytest.mark.parametrize('mlp_type', ['mlp'])
-@pytest.mark.parametrize('moe_normalize_expert_weights', [1])
+@pytest.mark.parametrize('moe_normalize_expert_weights', [None])
+@pytest.mark.parametrize('moe_num_experts', [1])
+@pytest.mark.parametrize('moe_world_size', [1])
 @pytest.mark.parametrize('two_d_input', [True])
 def test_dmoe(
     moe_num_experts: int,
@@ -80,7 +82,7 @@ def test_dmoe(
 ):
     if moe_world_size > moe_num_experts or moe_num_experts % moe_world_size != 0:
         pytest.skip('Mismatch between moe_world_size and moe_num_experts.')
-    moe_top_k = min(2, moe_num_experts)
+    moe_top_k = min(1, moe_num_experts)
     # Generate inputs
     rank = dist.get_rank()
     batch_size = 2

--- a/tests/models/layers/test_dmoe.py
+++ b/tests/models/layers/test_dmoe.py
@@ -75,6 +75,8 @@ def test_dmoe(
     moe_normalize_expert_weights: Union[float, int],
     two_d_input: bool,
 ):
+    if moe_world_size > moe_num_experts or moe_num_experts % moe_world_size != 0:
+        pytest.skip('Mismatch between moe_world_size and moe_num_experts.')
     # Generate inputs
     rank = dist.get_rank()
     batch_size = 2
@@ -207,7 +209,6 @@ def test_dmoe(
 @pytest.mark.world_size(2)
 @pytest.mark.parametrize('two_d_input', [True, False])
 def test_dmoe_defaults(two_d_input: bool,):
-
     rank = dist.get_rank()
     fp16 = False
     bf16 = True
@@ -256,7 +257,7 @@ def test_dmoe_defaults(two_d_input: bool,):
         input_shape = [batch_size * seq_len, hidden_size]
     else:
         input_shape = [batch_size, seq_len, hidden_size]
-    
+
     x = _get_all_inputs(input_shape, dtype)[rank]
 
     # Load mb_dmoe state dict to torch dmoe

--- a/tests/models/layers/test_dmoe.py
+++ b/tests/models/layers/test_dmoe.py
@@ -80,7 +80,7 @@ def test_dmoe(
 ):
     if moe_world_size > moe_num_experts or moe_num_experts % moe_world_size != 0:
         pytest.skip('Mismatch between moe_world_size and moe_num_experts.')
-    moe_top_k = min(2, moe_num_experts)
+    moe_top_k = min(1, moe_num_experts)
     # Generate inputs
     rank = dist.get_rank()
     batch_size = 2

--- a/tests/models/layers/test_dmoe.py
+++ b/tests/models/layers/test_dmoe.py
@@ -87,7 +87,7 @@ def test_dmoe(
     rank = dist.get_rank()
     batch_size = 2
     seq_len = 3
-    hidden_size = 128
+    hidden_size = 1024
     if two_d_input:
         input_shape = [batch_size * seq_len, hidden_size]
     else:

--- a/tests/models/layers/test_dmoe.py
+++ b/tests/models/layers/test_dmoe.py
@@ -79,6 +79,7 @@ def test_dmoe(
     mlp_type: str,
     moe_world_size: int,
     moe_normalize_expert_weights: Union[float, int],
+    hidden_size: int,
     two_d_input: bool,
 ):
     if moe_world_size > moe_num_experts or moe_num_experts % moe_world_size != 0:

--- a/tests/models/layers/test_dmoe.py
+++ b/tests/models/layers/test_dmoe.py
@@ -87,7 +87,7 @@ def test_dmoe(
     rank = dist.get_rank()
     batch_size = 2
     seq_len = 3
-    hidden_size = 256
+    hidden_size = 192
     if two_d_input:
         input_shape = [batch_size * seq_len, hidden_size]
     else:

--- a/tests/models/layers/test_dmoe.py
+++ b/tests/models/layers/test_dmoe.py
@@ -63,7 +63,7 @@ def _get_torch_dtype(fp16: bool, bf16: bool) -> Optional[torch.dtype]:
 )
 @pytest.mark.gpu
 @pytest.mark.world_size(2)
-@pytest.mark.parametrize('moe_num_experts', [1])
+@pytest.mark.parametrize('moe_num_experts', [1, 2, 8])
 @pytest.mark.parametrize('mlp_type', ['glu', 'mlp'])
 @pytest.mark.parametrize('moe_world_size', [1, 2])
 @pytest.mark.parametrize('moe_normalize_expert_weights', [1, 2.0])

--- a/tests/models/layers/test_dmoe.py
+++ b/tests/models/layers/test_dmoe.py
@@ -257,6 +257,8 @@ def test_dmoe_defaults(two_d_input: bool,):
     )
     mb_dmoe_optimizer = optim.SGD(mb_dmoe.parameters(), lr=0.1)
 
+    print(args)
+
     # Generate inputs based on hidden_size in megablocks arguments
     batch_size = 2
     seq_len = 3

--- a/tests/models/layers/test_dmoe.py
+++ b/tests/models/layers/test_dmoe.py
@@ -73,6 +73,7 @@ def _get_torch_dtype(fp16: bool, bf16: bool) -> Optional[torch.dtype]:
 @pytest.mark.parametrize('moe_num_experts', [1])
 @pytest.mark.parametrize('moe_world_size', [1])
 @pytest.mark.parametrize('two_d_input', [True])
+@pytest.mark.parametrize('hidden_size', [32, 64, 96, 128, 160, 192, 224, 256])
 def test_dmoe(
     moe_num_experts: int,
     mlp_type: str,
@@ -87,7 +88,7 @@ def test_dmoe(
     rank = dist.get_rank()
     batch_size = 2
     seq_len = 3
-    hidden_size = 192
+    hidden_size = hidden_size
     if two_d_input:
         input_shape = [batch_size * seq_len, hidden_size]
     else:

--- a/tests/models/layers/test_dmoe.py
+++ b/tests/models/layers/test_dmoe.py
@@ -63,7 +63,7 @@ def _get_torch_dtype(fp16: bool, bf16: bool) -> Optional[torch.dtype]:
 )
 @pytest.mark.gpu
 @pytest.mark.world_size(2)
-@pytest.mark.parametrize('moe_num_experts', [1, 2, 4, 8])
+@pytest.mark.parametrize('moe_num_experts', [1, 2, 8])
 @pytest.mark.parametrize('mlp_type', ['glu', 'mlp'])
 @pytest.mark.parametrize('moe_world_size', [1, 2])
 @pytest.mark.parametrize('moe_normalize_expert_weights', [1, 2.0])

--- a/tests/models/layers/test_dmoe.py
+++ b/tests/models/layers/test_dmoe.py
@@ -221,10 +221,11 @@ def test_dmoe_defaults(two_d_input: bool,):
     dtype = _get_torch_dtype(fp16, bf16)
     x = _get_all_inputs(input_shape, dtype)[rank]
 
-    # Construct DDP torch dMoE
+    # Construct DDP torch dMoE. torch_dmoe does not currently support bias.
     device = torch.device(f'cuda:{dist.get_rank()}')
     common_args = {
         'device': device,
+        'bias': False,
     }
 
     torch_dmoe = dMoE(**common_args).to(device, dtype=dtype)

--- a/tests/models/layers/test_dmoe.py
+++ b/tests/models/layers/test_dmoe.py
@@ -147,6 +147,8 @@ def test_dmoe(
     mb_dmoe = megablocks.layers.dmoe.dMoE(args).to(device)
     mb_dmoe.router = DDP(mb_dmoe.router, device_ids=[rank])
 
+    print(args)
+
     if moe_world_size > 1:
         assert device_mesh is not None
         two_d_placements: List[Placement] = [Replicate(), Shard(0)]

--- a/tests/models/layers/test_dmoe.py
+++ b/tests/models/layers/test_dmoe.py
@@ -4,7 +4,7 @@
 import copy
 from contextlib import nullcontext
 from functools import partial
-from typing import List, Optional
+from typing import List, Optional, Union
 
 import pytest
 import torch
@@ -66,12 +66,13 @@ def _get_torch_dtype(fp16: bool, bf16: bool) -> Optional[torch.dtype]:
 @pytest.mark.parametrize('moe_num_experts', [8])
 @pytest.mark.parametrize('mlp_type', ['glu', 'mlp'])
 @pytest.mark.parametrize('moe_world_size', [1, 2])
-@pytest.mark.parametrize('moe_normalize_expert_weights', [1, 2])
+@pytest.mark.parametrize('moe_normalize_expert_weights', [1, 2.0])
 @pytest.mark.parametrize('two_d_input', [True, False])
 def test_dmoe(
     moe_num_experts: int,
     mlp_type: str,
     moe_world_size: int,
+    moe_normalize_expert_weights: Union[float, int],
     two_d_input: bool,
 ):
     # Generate inputs
@@ -96,7 +97,7 @@ def test_dmoe(
         'moe_top_k': 2,
         'activation_fn': partial(F.gelu, approximate='none'),
         'moe_jitter_eps': 0.0,  # Disable randomiztion
-        'moe_normalize_expert_weights': 1,
+        'moe_normalize_expert_weights': moe_normalize_expert_weights,
         'uniform_expert_assignment': False,
         'bias': False,
         'device': device,

--- a/tests/models/layers/test_dmoe.py
+++ b/tests/models/layers/test_dmoe.py
@@ -63,11 +63,14 @@ def _get_torch_dtype(fp16: bool, bf16: bool) -> Optional[torch.dtype]:
 )
 @pytest.mark.gpu
 @pytest.mark.world_size(2)
-@pytest.mark.parametrize('moe_num_experts', [1, 2, 8])
-@pytest.mark.parametrize('mlp_type', ['glu', 'mlp'])
+@pytest.mark.parametrize('moe_num_experts', [1, 2, 4, 8])
+#@pytest.mark.parametrize('mlp_type', ['glu', 'mlp'])
 @pytest.mark.parametrize('moe_world_size', [1, 2])
-@pytest.mark.parametrize('moe_normalize_expert_weights', [1, 2.0])
-@pytest.mark.parametrize('two_d_input', [True, False])
+#@pytest.mark.parametrize('moe_normalize_expert_weights', [1, 2.0])
+#@pytest.mark.parametrize('two_d_input', [True, False])
+@pytest.mark.parametrize('mlp_type', ['mlp'])
+@pytest.mark.parametrize('moe_normalize_expert_weights', [1])
+@pytest.mark.parametrize('two_d_input', [True])
 def test_dmoe(
     moe_num_experts: int,
     mlp_type: str,

--- a/tests/models/layers/test_dmoe.py
+++ b/tests/models/layers/test_dmoe.py
@@ -87,7 +87,7 @@ def test_dmoe(
     rank = dist.get_rank()
     batch_size = 2
     seq_len = 3
-    hidden_size = 128
+    hidden_size = 256
     if two_d_input:
         input_shape = [batch_size * seq_len, hidden_size]
     else:
@@ -104,7 +104,7 @@ def test_dmoe(
         'ffn_hidden_size': hidden_size,
         'moe_top_k': moe_top_k,
         'activation_fn': partial(F.gelu, approximate='none'),
-        #'moe_jitter_eps': 0.0,  # Disable randomiztion
+        'moe_jitter_eps': 0.0,  # Disable randomiztion
         'moe_normalize_expert_weights': moe_normalize_expert_weights,
         'uniform_expert_assignment': False,
         'bias': False,

--- a/tests/models/layers/test_dmoe.py
+++ b/tests/models/layers/test_dmoe.py
@@ -65,7 +65,7 @@ def _get_torch_dtype(fp16: bool, bf16: bool) -> Optional[torch.dtype]:
 @pytest.mark.world_size(2)
 @pytest.mark.parametrize('moe_num_experts', [1, 2, 4, 8])
 #@pytest.mark.parametrize('mlp_type', ['glu', 'mlp'])
-@pytest.mark.parametrize('moe_world_size', [1, 2])
+@pytest.mark.parametrize('moe_world_size', [1, 2, 4])
 #@pytest.mark.parametrize('moe_normalize_expert_weights', [1, 2.0])
 #@pytest.mark.parametrize('two_d_input', [True, False])
 @pytest.mark.parametrize('mlp_type', ['mlp'])
@@ -80,7 +80,7 @@ def test_dmoe(
 ):
     if moe_world_size > moe_num_experts or moe_num_experts % moe_world_size != 0:
         pytest.skip('Mismatch between moe_world_size and moe_num_experts.')
-    moe_top_k = min(1, moe_num_experts)
+    moe_top_k = min(2, moe_num_experts)
     # Generate inputs
     rank = dist.get_rank()
     batch_size = 2

--- a/tests/models/layers/test_dmoe.py
+++ b/tests/models/layers/test_dmoe.py
@@ -77,6 +77,7 @@ def test_dmoe(
 ):
     if moe_world_size > moe_num_experts or moe_num_experts % moe_world_size != 0:
         pytest.skip('Mismatch between moe_world_size and moe_num_experts.')
+    moe_top_k = min(2, moe_num_experts)
     # Generate inputs
     rank = dist.get_rank()
     batch_size = 2
@@ -96,7 +97,7 @@ def test_dmoe(
     common_args = {
         'hidden_size': hidden_size,
         'ffn_hidden_size': hidden_size,
-        'moe_top_k': 2,
+        'moe_top_k': moe_top_k,
         'activation_fn': partial(F.gelu, approximate='none'),
         'moe_jitter_eps': 0.0,  # Disable randomiztion
         'moe_normalize_expert_weights': moe_normalize_expert_weights,

--- a/tests/models/layers/test_dmoe.py
+++ b/tests/models/layers/test_dmoe.py
@@ -63,7 +63,7 @@ def _get_torch_dtype(fp16: bool, bf16: bool) -> Optional[torch.dtype]:
 )
 @pytest.mark.gpu
 @pytest.mark.world_size(2)
-@pytest.mark.parametrize('moe_num_experts', [8])
+@pytest.mark.parametrize('moe_num_experts', [1])
 @pytest.mark.parametrize('mlp_type', ['glu', 'mlp'])
 @pytest.mark.parametrize('moe_world_size', [1, 2])
 @pytest.mark.parametrize('moe_normalize_expert_weights', [1, 2.0])

--- a/tests/models/layers/test_dmoe.py
+++ b/tests/models/layers/test_dmoe.py
@@ -100,11 +100,11 @@ def test_dmoe(
     # Construct DDP torch dMoE
     device = torch.device(f'cuda:{dist.get_rank()}')
     common_args = {
-        'hidden_size': hidden_size,
-        'ffn_hidden_size': hidden_size,
+        #'hidden_size': hidden_size,
+        #'ffn_hidden_size': hidden_size,
         'moe_top_k': moe_top_k,
         'activation_fn': partial(F.gelu, approximate='none'),
-        #'moe_jitter_eps': 0.0,  # Disable randomiztion
+        'moe_jitter_eps': 0.0,  # Disable randomiztion
         'moe_normalize_expert_weights': moe_normalize_expert_weights,
         'uniform_expert_assignment': False,
         'bias': False,

--- a/tests/models/layers/test_dmoe.py
+++ b/tests/models/layers/test_dmoe.py
@@ -100,11 +100,11 @@ def test_dmoe(
     # Construct DDP torch dMoE
     device = torch.device(f'cuda:{dist.get_rank()}')
     common_args = {
-        'hidden_size': hidden_size,
-        'ffn_hidden_size': hidden_size,
+        #'hidden_size': hidden_size,
+        #'ffn_hidden_size': hidden_size,
         'moe_top_k': moe_top_k,
         'activation_fn': partial(F.gelu, approximate='none'),
-        'moe_jitter_eps': 0.0,  # Disable randomiztion
+        #'moe_jitter_eps': 0.0,  # Disable randomiztion
         'moe_normalize_expert_weights': moe_normalize_expert_weights,
         'uniform_expert_assignment': False,
         'bias': False,

--- a/tests/models/layers/test_dmoe.py
+++ b/tests/models/layers/test_dmoe.py
@@ -87,7 +87,7 @@ def test_dmoe(
     rank = dist.get_rank()
     batch_size = 2
     seq_len = 3
-    hidden_size = 1024
+    hidden_size = 128
     if two_d_input:
         input_shape = [batch_size * seq_len, hidden_size]
     else:
@@ -100,11 +100,11 @@ def test_dmoe(
     # Construct DDP torch dMoE
     device = torch.device(f'cuda:{dist.get_rank()}')
     common_args = {
-        #'hidden_size': hidden_size,
-        #'ffn_hidden_size': hidden_size,
+        'hidden_size': hidden_size,
+        'ffn_hidden_size': hidden_size,
         'moe_top_k': moe_top_k,
         'activation_fn': partial(F.gelu, approximate='none'),
-        'moe_jitter_eps': 0.0,  # Disable randomiztion
+        #'moe_jitter_eps': 0.0,  # Disable randomiztion
         'moe_normalize_expert_weights': moe_normalize_expert_weights,
         'uniform_expert_assignment': False,
         'bias': False,

--- a/tests/models/layers/test_dmoe.py
+++ b/tests/models/layers/test_dmoe.py
@@ -100,8 +100,8 @@ def test_dmoe(
     # Construct DDP torch dMoE
     device = torch.device(f'cuda:{dist.get_rank()}')
     common_args = {
-        #'hidden_size': hidden_size,
-        #'ffn_hidden_size': hidden_size,
+        'hidden_size': hidden_size,
+        'ffn_hidden_size': hidden_size,
         'moe_top_k': moe_top_k,
         'activation_fn': partial(F.gelu, approximate='none'),
         #'moe_jitter_eps': 0.0,  # Disable randomiztion


### PR DESCRIPTION
Users are hitting issues where changing their `ffn_type` from `mb_dmoe` to `torch_dmoe` results in errors with their config. This is because `torch_dmoe` does not have any defaults set. This PR ensures that `torch_dmoe` has the same defaults as `mb_dmoe`, according to the [Arguments dataclass](https://github.com/databricks/megablocks/blob/main/megablocks/layers/arguments.py) in the Megablocks repo. Fixed typing in some places as well. Added a test to make sure that `mb_dmoe` and `torch_dmoe` are the same in fwd and bwd for these defauly values.

There was also a bug for some inputs (top k = 1) where the outputs of the `max` function were 1 dimensional instead of 2. This bug has also been addressed.

There's a separate bug with Megablocks where, if both the `hidden_size` and `ffn_hidden_size` are both 128, there's an unintended bug -- this is why `hidden_size` has been bumped to 256. With values of `hidden_size` and `ffn_hidden_size` not divisible by 128, there's an unhelpful error thrown. Will open a separate PR on megablocks side to address this.