### PR TITLE
Using self.shift_labels instead of self.model.transformer.shift_label in the loss function.

### DIFF
--- a/llmfoundry/models/mpt/modeling_mpt.py
+++ b/llmfoundry/models/mpt/modeling_mpt.py
@@ -1157,7 +1157,7 @@ class ComposerMPTCausalLM(HuggingFaceModel):
 
     def loss(self, outputs: CausalLMOutputWithPast,
              batch: Mapping) -> Union[dict, torch.Tensor]:
-        if self.model.transformer.shift_labels:
+        if self.shift_labels:
             targets = self.get_targets(batch)
         else:
             targets = batch['labels']


### PR DESCRIPTION
Using self.shift_labels instead of self.model.transformer.shift_label in the loss function.