### PR TITLE
add error when chat template fails

### DIFF
--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -69,6 +69,7 @@ from llmfoundry.utils.exceptions import (
     ALLOWED_MESSAGES_KEYS,
     ALLOWED_PROMPT_KEYS,
     ALLOWED_RESPONSE_KEYS,
+    ChatTemplateError,
     ConsecutiveRepeatedChatRolesError,
     IncorrectMessageKeyQuantityError,
     InvalidContentTypeError,
@@ -245,15 +246,22 @@ def _slice_chat_formatted_example(
         messages_through_current_turn: List[Dict[str, str]],
         conversation_through_previous_turn: str,
     ) -> Tuple[str, str]:
-        full_conversation = tokenizer.apply_chat_template(
-            messages_through_current_turn,
-            tokenize=False,
-        )
-        prompt_with_history = tokenizer.apply_chat_template(
-            messages_through_current_turn[:-1],
-            tokenize=False,
-            add_generation_prompt=True,
-        )
+        try:
+            full_conversation = tokenizer.apply_chat_template(
+                messages_through_current_turn,
+                tokenize=False,
+            )
+            prompt_with_history = tokenizer.apply_chat_template(
+                messages_through_current_turn[:-1],
+                tokenize=False,
+                add_generation_prompt=True,
+            )
+        except Exception as e:
+            raise ChatTemplateError(
+                tokenizer.chat_template,
+                sample=messages_through_current_turn,
+                inner_message=str(e),
+            )
         if conversation_through_previous_turn != full_conversation[:len(
             conversation_through_previous_turn,
         )]:

--- a/llmfoundry/utils/exceptions.py
+++ b/llmfoundry/utils/exceptions.py
@@ -116,6 +116,21 @@ class ConsecutiveRepeatedChatRolesError(ValueError, ContextualError):
         super().__init__(message)
 
 
+class ChatTemplateError(ValueError, ContextualError):
+    """Error thrown when a chat template fails to process a sample."""
+
+    def __init__(
+        self,
+        template: str,
+        sample: Dict[str, Any],
+        inner_message: str,
+    ) -> None:
+        self.template = template
+        self.sample = sample
+        message = f'Failed to process sample {sample} with template {template}. {inner_message}'
+        super().__init__(message)
+
+
 class InvalidLastChatMessageRoleError(ValueError, ContextualError):
     """Error thrown when the last message role in a chat example is invalid."""
 

--- a/llmfoundry/utils/exceptions.py
+++ b/llmfoundry/utils/exceptions.py
@@ -122,7 +122,7 @@ class ChatTemplateError(ValueError, ContextualError):
     def __init__(
         self,
         template: str,
-        sample: Dict[str, Any],
+        sample: List[Dict[str, Any]],
         inner_message: str,
     ) -> None:
         self.template = template

--- a/llmfoundry/utils/exceptions.py
+++ b/llmfoundry/utils/exceptions.py
@@ -76,7 +76,7 @@ class MissingHuggingFaceURLSplitError(ValueError, UserError):
         super().__init__(message)
 
 
-class NotEnoughDatasetSamplesError(ValueError, UserError):
+class NotEnoughDatasetSamplesError(UserError):
     """Error thrown when there is not enough data to train a model."""
 
     def __init__(

--- a/llmfoundry/utils/exceptions.py
+++ b/llmfoundry/utils/exceptions.py
@@ -152,7 +152,6 @@ class ChatTemplateError(ValueError, UserError):
         super().__init__(message)
 
 
-
 class InvalidLastChatMessageRoleError(ValueError, UserError):
     """Error thrown when the last message role in a chat example is invalid."""
 


### PR DESCRIPTION
# Add Error when Chat Template Fails
Creates the error type `ChatTemplateError`, which encodes the chat template, the error, and the sample that triggered it.