### PR TITLE
Move MLFlow dataset outside of log_config 

### DIFF
--- a/llmfoundry/utils/config_utils.py
+++ b/llmfoundry/utils/config_utils.py
@@ -527,7 +527,7 @@ def _parse_source_dataset(cfg: TrainConfig) -> List[Tuple[str, str, str]]:
     data_paths = []
 
     # Handle train loader if it exists
-    train_dataset: Dict = cfg.train_loader.get('dataset', {})
+    train_dataset: TrainConfig = cfg.train_loader.get('dataset', {})
     train_split = train_dataset.get('split', None)
     train_source_path = cfg.source_dataset_train
     _process_data_source(

--- a/llmfoundry/utils/config_utils.py
+++ b/llmfoundry/utils/config_utils.py
@@ -551,6 +551,7 @@ def _parse_source_dataset(cfg: TrainConfig) -> List[Tuple[str, str, str]]:
         ]  # Normalize to list if it's a single dictionary
 
     for eval_data_loader in eval_data_loaders:
+        print(f'---- DEBUG {eval_data_loader}, {type(eval_data_loader)}')
         assert isinstance(eval_data_loader, dict)  # pyright type check
         eval_dataset: Dict = eval_data_loader.get('dataset', {})
         eval_split = eval_dataset.get('split', None)

--- a/llmfoundry/utils/config_utils.py
+++ b/llmfoundry/utils/config_utils.py
@@ -177,6 +177,10 @@ class TrainConfig:
     # Profiling
     profiler: Optional[Dict[str, Any]] = None
 
+    # MLFlow datasets
+    source_dataset_train: Optional[Dict[str, Any]] = None
+    source_dataset_eval: Optional[Dict[str, Any]] = None
+
     # Variables to ignore
     variables: Optional[Dict[str, Any]] = None
 

--- a/llmfoundry/utils/config_utils.py
+++ b/llmfoundry/utils/config_utils.py
@@ -534,7 +534,6 @@ def _parse_source_dataset(cfg: TrainConfig) -> List[Tuple[str, str, str]]:
     train_dataset: TrainConfig = cfg.train_loader.get('dataset', {})
     train_split = train_dataset.get('split', None)
     train_source_path = cfg.source_dataset_train
-    print(f'---- VERBOSE {cfg}')
     _process_data_source(
         train_source_path,
         train_dataset,
@@ -632,6 +631,9 @@ def log_dataset_uri(cfg: Dict[str, Any]) -> None:
     Args:
         cfg (DictConfig): A config dictionary of a run
     """
+    loggers = cfg.get('loggers', None) or {}
+    if 'mlflow' not in loggers or not mlflow.active_run():
+        return
     # Figure out which data source to use
     data_paths = _parse_source_dataset(cfg)
 

--- a/llmfoundry/utils/config_utils.py
+++ b/llmfoundry/utils/config_utils.py
@@ -534,7 +534,7 @@ def _parse_source_dataset(cfg: TrainConfig) -> List[Tuple[str, str, str]]:
     train_dataset: TrainConfig = cfg.train_loader.get('dataset', {})
     train_split = train_dataset.get('split', None)
     train_source_path = cfg.source_dataset_train
-    print(f'---- VERBOSE {train_source_path}')
+    print(f'---- VERBOSE {cfg}')
     _process_data_source(
         train_source_path,
         train_dataset,
@@ -545,24 +545,25 @@ def _parse_source_dataset(cfg: TrainConfig) -> List[Tuple[str, str, str]]:
 
     # Handle eval_loader which might be a list or a single dictionary
     eval_data_loaders = cfg.eval_loader
-    if not isinstance(eval_data_loaders, list):
-        eval_data_loaders = [
-            eval_data_loaders,
-        ]  # Normalize to list if it's a single dictionary
+    if eval_data_loaders:
+        if not isinstance(eval_data_loaders, list):
+            eval_data_loaders = [
+                eval_data_loaders,
+            ]  # Normalize to list if it's a single dictionary
 
-    for eval_data_loader in eval_data_loaders:
-        print(f'---- DEBUG {eval_data_loader}, {type(eval_data_loader)}')
-        assert isinstance(eval_data_loader, dict)  # pyright type check
-        eval_dataset: Dict = eval_data_loader.get('dataset', {})
-        eval_split = eval_dataset.get('split', None)
-        eval_source_path = cfg.source_dataset_eval
-        _process_data_source(
-            eval_source_path,
-            eval_dataset,
-            eval_split,
-            'eval',
-            data_paths,
-        )
+        for eval_data_loader in eval_data_loaders:
+            print(f'---- DEBUG {eval_data_loader}, {type(eval_data_loader)}')
+            assert isinstance(eval_data_loader, dict)  # pyright type check
+            eval_dataset: Dict = eval_data_loader.get('dataset', {})
+            eval_split = eval_dataset.get('split', None)
+            eval_source_path = cfg.source_dataset_eval
+            _process_data_source(
+                eval_source_path,
+                eval_dataset,
+                eval_split,
+                'eval',
+                data_paths,
+            )
 
     return data_paths
 

--- a/llmfoundry/utils/config_utils.py
+++ b/llmfoundry/utils/config_utils.py
@@ -625,6 +625,9 @@ def log_dataset_uri(cfg: Dict[str, Any]) -> None:
     Args:
         cfg (DictConfig): A config dictionary of a run
     """
+    loggers = cfg.get('loggers', None) or {}
+    if 'mlflow' not in loggers or not mlflow.active_run():
+        return
     # Figure out which data source to use
     data_paths = _parse_source_dataset(cfg)
 

--- a/llmfoundry/utils/config_utils.py
+++ b/llmfoundry/utils/config_utils.py
@@ -39,7 +39,7 @@ __all__ = [
     'update_batch_size_info',
     'process_init_device',
     'log_config',
-    'log_dataset_uri'
+    'log_dataset_uri',
 ]
 
 

--- a/llmfoundry/utils/config_utils.py
+++ b/llmfoundry/utils/config_utils.py
@@ -511,7 +511,7 @@ def log_config(cfg: Dict[str, Any]) -> None:
         mlflow.log_params(params=cfg)
 
 
-def _parse_source_dataset(cfg: Dict[str, Any]) -> List[Tuple[str, str, str]]:
+def _parse_source_dataset(cfg: TrainConfig) -> List[Tuple[str, str, str]]:
     """Parse a run config for dataset information.
 
     Given a config dictionary, parse through it to determine what the datasource
@@ -527,9 +527,9 @@ def _parse_source_dataset(cfg: Dict[str, Any]) -> List[Tuple[str, str, str]]:
     data_paths = []
 
     # Handle train loader if it exists
-    train_dataset: Dict = cfg.get('train_loader', {}).get('dataset', {})
+    train_dataset: Dict = cfg.train_loader.get('dataset', {})
     train_split = train_dataset.get('split', None)
-    train_source_path = cfg.get('source_dataset_train', None)
+    train_source_path = cfg.source_dataset_train
     _process_data_source(
         train_source_path,
         train_dataset,
@@ -539,7 +539,7 @@ def _parse_source_dataset(cfg: Dict[str, Any]) -> List[Tuple[str, str, str]]:
     )
 
     # Handle eval_loader which might be a list or a single dictionary
-    eval_data_loaders = cfg.get('eval_loader', {})
+    eval_data_loaders = cfg.eval_loader
     if not isinstance(eval_data_loaders, list):
         eval_data_loaders = [
             eval_data_loaders,
@@ -549,7 +549,7 @@ def _parse_source_dataset(cfg: Dict[str, Any]) -> List[Tuple[str, str, str]]:
         assert isinstance(eval_data_loader, dict)  # pyright type check
         eval_dataset: Dict = eval_data_loader.get('dataset', {})
         eval_split = eval_dataset.get('split', None)
-        eval_source_path = cfg.get('source_dataset_eval', None)
+        eval_source_path = cfg.source_dataset_eval
         _process_data_source(
             eval_source_path,
             eval_dataset,

--- a/llmfoundry/utils/config_utils.py
+++ b/llmfoundry/utils/config_utils.py
@@ -534,6 +534,7 @@ def _parse_source_dataset(cfg: TrainConfig) -> List[Tuple[str, str, str]]:
     train_dataset: TrainConfig = cfg.train_loader.get('dataset', {})
     train_split = train_dataset.get('split', None)
     train_source_path = cfg.source_dataset_train
+    print(f'---- VERBOSE {train_source_path}')
     _process_data_source(
         train_source_path,
         train_dataset,

--- a/llmfoundry/utils/config_utils.py
+++ b/llmfoundry/utils/config_utils.py
@@ -39,6 +39,7 @@ __all__ = [
     'update_batch_size_info',
     'process_init_device',
     'log_config',
+    'log_dataset_uri'
 ]
 
 
@@ -508,7 +509,6 @@ def log_config(cfg: Dict[str, Any]) -> None:
 
     if 'mlflow' in loggers and mlflow.active_run():
         mlflow.log_params(params=cfg)
-        _log_dataset_uri(cfg)
 
 
 def _parse_source_dataset(cfg: Dict[str, Any]) -> List[Tuple[str, str, str]]:
@@ -619,7 +619,7 @@ def _process_data_source(
         log.warning('DataSource Not Found.')
 
 
-def _log_dataset_uri(cfg: Dict[str, Any]) -> None:
+def log_dataset_uri(cfg: Dict[str, Any]) -> None:
     """Logs dataset tracking information to MLflow.
 
     Args:

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -55,7 +55,7 @@ from llmfoundry.utils.config_utils import (
     TRAIN_CONFIG_KEYS,
     TrainConfig,
     log_config,
-    log_log_dataset_uri,
+    log_dataset_uri,
     make_dataclass_and_log_config,
     pop_config,
     process_init_device,

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -55,6 +55,7 @@ from llmfoundry.utils.config_utils import (
     TRAIN_CONFIG_KEYS,
     TrainConfig,
     log_config,
+    log_log_dataset_uri,
     make_dataclass_and_log_config,
     pop_config,
     process_init_device,
@@ -530,6 +531,7 @@ def main(cfg: DictConfig) -> Trainer:
     if train_cfg.log_config:
         log.info('Logging config')
         log_config(logged_cfg)
+    log_dataset_uri(train_cfg)
     torch.cuda.empty_cache()
     gc.collect()
 

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -531,7 +531,7 @@ def main(cfg: DictConfig) -> Trainer:
     if train_cfg.log_config:
         log.info('Logging config')
         log_config(logged_cfg)
-    log_dataset_uri(train_cfg)
+    log_dataset_uri(logged_cfg)
     torch.cuda.empty_cache()
     gc.collect()
 

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -531,9 +531,7 @@ def main(cfg: DictConfig) -> Trainer:
     if train_cfg.log_config:
         log.info('Logging config')
         log_config(logged_cfg)
-    loggers = logged_cfg.get('loggers', None) or {}
-    if 'mlflow' in loggers and mlflow.active_run():
-        log_dataset_uri(logged_cfg)
+    log_dataset_uri(logged_cfg)
     torch.cuda.empty_cache()
     gc.collect()
 

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -531,7 +531,7 @@ def main(cfg: DictConfig) -> Trainer:
     if train_cfg.log_config:
         log.info('Logging config')
         log_config(logged_cfg)
-    log_dataset_uri(logged_cfg)
+    log_dataset_uri(train_cfg)
     torch.cuda.empty_cache()
     gc.collect()
 

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -531,7 +531,9 @@ def main(cfg: DictConfig) -> Trainer:
     if train_cfg.log_config:
         log.info('Logging config')
         log_config(logged_cfg)
-    log_dataset_uri(train_cfg)
+    loggers = logged_cfg.get('loggers', None) or {}
+    if 'mlflow' in loggers and mlflow.active_run():
+        log_dataset_uri(logged_cfg)
     torch.cuda.empty_cache()
     gc.collect()
 

--- a/tests/utils/test_mlflow_logging.py
+++ b/tests/utils/test_mlflow_logging.py
@@ -7,8 +7,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from llmfoundry.utils.config_utils import (
-    log_dataset_uri,
     _parse_source_dataset,
+    log_dataset_uri,
 )
 
 mlflow = pytest.importorskip('mlflow')
@@ -84,7 +84,7 @@ def test_log_dataset_uri():
         }},
         source_dataset_train='huggingface/train_dataset',
         source_dataset_eval='huggingface/eval_dataset',
-        loggers={'mlflow': {}}
+        loggers={'mlflow': {}},
     )
 
     with patch('mlflow.log_input') as mock_log_input, \

--- a/tests/utils/test_mlflow_logging.py
+++ b/tests/utils/test_mlflow_logging.py
@@ -84,9 +84,11 @@ def test_log_dataset_uri():
         }},
         source_dataset_train='huggingface/train_dataset',
         source_dataset_eval='huggingface/eval_dataset',
+        loggers={'mlflow': {}}
     )
 
-    with patch('mlflow.log_input') as mock_log_input:
+    with patch('mlflow.log_input') as mock_log_input, \
+         patch('mlflow.active_run', return_value=True):
         log_dataset_uri(cfg)
         assert mock_log_input.call_count == 2
         meta_dataset_calls = [

--- a/tests/utils/test_mlflow_logging.py
+++ b/tests/utils/test_mlflow_logging.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from llmfoundry.utils.config_utils import (
-    _log_dataset_uri,
+    log_dataset_uri,
     _parse_source_dataset,
 )
 
@@ -87,7 +87,7 @@ def test_log_dataset_uri():
     )
 
     with patch('mlflow.log_input') as mock_log_input:
-        _log_dataset_uri(cfg)
+        log_dataset_uri(cfg)
         assert mock_log_input.call_count == 2
         meta_dataset_calls = [
             args[0] for args, _ in mock_log_input.call_args_list


### PR DESCRIPTION
Finetuning product now defaults log_config to false, meaning that datasets will no longer show up for fine tuning runs. This attempts to fix that by making dataset logging independent of config logging