### PR TITLE
Fix the error message thrown from dataloader

### DIFF
--- a/llmfoundry/data/finetuning/dataloader.py
+++ b/llmfoundry/data/finetuning/dataloader.py
@@ -542,7 +542,8 @@ def _download_remote_hf_dataset(remote_path: str, split: str) -> str:
             except FileNotFoundError as e:
                 if extension == SUPPORTED_EXTENSIONS[-1]:
                     files_searched = [
-                        f'{name[:-len(extension)]}{ext}' for ext in SUPPORTED_EXTENSIONS
+                        f'{name[:-len(extension)]}{ext}'
+                        for ext in SUPPORTED_EXTENSIONS
                     ]
                     raise FileNotFoundError(
                         f'Could not find a file with any of ' + \
@@ -740,12 +741,12 @@ if __name__ == '__main__':
                         print(
                             '\033[91m{}\033[00m\n'.format('TARGET:   '),
                             tokenizer.decode(
-                                batch['input_ids'][
-                                    j,
-                                    torch.logical_and(
-                                        is_subseq,
-                                        batch['labels'][j] != _HF_IGNORE_INDEX,
-                                    )],
+                                batch['input_ids'][j,
+                                                   torch.logical_and(
+                                                       is_subseq,
+                                                       batch['labels'][j] !=
+                                                       _HF_IGNORE_INDEX,
+                                                   )],
                                 skip_special_tokens=False,
                                 clean_up_tokenization_spaces=True,
                             ),
@@ -775,8 +776,8 @@ if __name__ == '__main__':
                     print(
                         '\033[91m{}\033[00m\n'.format('TARGET:   '),
                         tokenizer.decode(
-                            batch['input_ids'][
-                                j, batch['labels'][j] != _HF_IGNORE_INDEX],
+                            batch['input_ids'][j, batch['labels'][j] !=
+                                               _HF_IGNORE_INDEX],
                             skip_special_tokens=False,
                             clean_up_tokenization_spaces=True,
                         ),

--- a/llmfoundry/data/finetuning/dataloader.py
+++ b/llmfoundry/data/finetuning/dataloader.py
@@ -542,7 +542,7 @@ def _download_remote_hf_dataset(remote_path: str, split: str) -> str:
             except FileNotFoundError as e:
                 if extension == SUPPORTED_EXTENSIONS[-1]:
                     files_searched = [
-                        f'{name}/{split}{ext}' for ext in SUPPORTED_EXTENSIONS
+                        f'{name[:-len(extension)]}{ext}' for ext in SUPPORTED_EXTENSIONS
                     ]
                     raise FileNotFoundError(
                         f'Could not find a file with any of ' + \


### PR DESCRIPTION
Previously the dataloader will throw the error message that contain duplicated fileName + extension in the `Could not find a file with any of the supported extensions:`. This PR patched a simple fix to remove the unnecessary concat in the error message string.