### PR TITLE
Wrap `FileNotFound` exceptions in the finetuning dataloader and `convert_text_to_mds`

### DIFF
--- a/llmfoundry/data/finetuning/dataloader.py
+++ b/llmfoundry/data/finetuning/dataloader.py
@@ -25,6 +25,7 @@ from llmfoundry.data.packing import BinPackCollator, auto_packing_ratio
 from llmfoundry.data.text_data import build_streams
 from llmfoundry.utils.config_utils import to_dict_container
 from llmfoundry.utils.exceptions import (
+    DatasetMissingFileError,
     MissingHuggingFaceURLSplitError,
     NotEnoughDatasetSamplesError,
 )
@@ -541,14 +542,7 @@ def _download_remote_hf_dataset(remote_path: str, split: str) -> str:
                 get_file(path=name, destination=destination, overwrite=True)
             except FileNotFoundError as e:
                 if extension == SUPPORTED_EXTENSIONS[-1]:
-                    files_searched = [
-                        f'{name}/{split}{ext}' for ext in SUPPORTED_EXTENSIONS
-                    ]
-                    raise FileNotFoundError(
-                        f'Could not find a file with any of ' + \
-                        f'the supported extensions: {SUPPORTED_EXTENSIONS}\n' + \
-                        f'at {files_searched}',
-                    ) from e
+                    raise DatasetMissingFileError(file_name=f"name/{split}") from e
                 else:
                     log.debug(
                         f'Could not find {name}, looking for another extension',

--- a/llmfoundry/data/finetuning/dataloader.py
+++ b/llmfoundry/data/finetuning/dataloader.py
@@ -550,7 +550,7 @@ def _download_remote_hf_dataset(remote_path: str, split: str) -> str:
                 if extension == SUPPORTED_EXTENSIONS[-1]:
                     raise DatasetMissingFileError(
                         file_name=f'name/{split}',
-                        supported_extensions=SUPPORTED_EXTENSIONS
+                        supported_extensions=SUPPORTED_EXTENSIONS,
                     ) from e
                 else:
                     log.debug(

--- a/llmfoundry/data/finetuning/dataloader.py
+++ b/llmfoundry/data/finetuning/dataloader.py
@@ -550,6 +550,7 @@ def _download_remote_hf_dataset(remote_path: str, split: str) -> str:
                 if extension == SUPPORTED_EXTENSIONS[-1]:
                     raise DatasetMissingFileError(
                         file_name=f'name/{split}',
+                        supported_extensions=SUPPORTED_EXTENSIONS
                     ) from e
                 else:
                     log.debug(

--- a/llmfoundry/utils/exceptions.py
+++ b/llmfoundry/utils/exceptions.py
@@ -364,7 +364,7 @@ class DatasetMissingFileError(UserError):
     def __init__(
         self,
         file_name: str,
-        supported_extensions: List[str],
+        supported_extensions: Any, # Run into type error when using List[str]
     ) -> None:
         message = "Could not find the file '{file_name}' with any of the supported extensions: "
         message += ', '.join(supported_extensions) + '.'

--- a/llmfoundry/utils/exceptions.py
+++ b/llmfoundry/utils/exceptions.py
@@ -364,7 +364,7 @@ class DatasetMissingFileError(UserError):
     def __init__(
         self,
         file_name: str,
-        supported_extensions: Optional[List[str]] = None,
+        supported_extensions: Union[List[str], None] = None,
     ) -> None:
         message = "Could not find the file '{file_name}' with any of the supported extensions: "
         if supported_extensions is not None:

--- a/llmfoundry/utils/exceptions.py
+++ b/llmfoundry/utils/exceptions.py
@@ -29,6 +29,8 @@ __all__ = [
     'OutputFolderNotEmptyError',
     'MisconfiguredHfDatasetError',
     'RunTimeoutError',
+    'DatasetMissingFileError',
+    'DatasetInvalidFolderError',
 ]
 
 ALLOWED_RESPONSE_KEYS = {'response', 'completion'}

--- a/llmfoundry/utils/exceptions.py
+++ b/llmfoundry/utils/exceptions.py
@@ -364,7 +364,7 @@ class DatasetMissingFileError(UserError):
     def __init__(
         self,
         file_name: str,
-        supported_extensions: Any, # Run into type error when using List[str]
+        supported_extensions: Any,  # Run into type error when using List[str]
     ) -> None:
         message = "Could not find the file '{file_name}' with any of the supported extensions: "
         message += ', '.join(supported_extensions) + '.'

--- a/llmfoundry/utils/exceptions.py
+++ b/llmfoundry/utils/exceptions.py
@@ -361,9 +361,10 @@ class RunTimeoutError(InternalError):
 class DatasetMissingFileError(UserError):
     """Error thrown when a dataset cannot find a file."""
 
-    def __init__(self, file_name: str, supported_extensions: List[str]) -> None:
+    def __init__(self, file_name: str, supported_extensions: Optional[List[str]]) -> None:
         message = "Could not find the file '{file_name}' with any of the supported extensions: "
-        message += ', '.join(supported_extensions) + '.'
+        if supported_extensions is not None:       
+            message += ', '.join(supported_extensions) + '.'
         message += ' Please check your train / eval data and try again.'
         super().__init__(message, file_name=file_name)
 

--- a/llmfoundry/utils/exceptions.py
+++ b/llmfoundry/utils/exceptions.py
@@ -361,9 +361,13 @@ class RunTimeoutError(InternalError):
 class DatasetMissingFileError(UserError):
     """Error thrown when a dataset cannot find a file."""
 
-    def __init__(self, file_name: str, supported_extensions: Optional[List[str]]) -> None:
+    def __init__(
+        self,
+        file_name: str,
+        supported_extensions: Optional[List[str]] = None,
+    ) -> None:
         message = "Could not find the file '{file_name}' with any of the supported extensions: "
-        if supported_extensions is not None:       
+        if supported_extensions is not None:
             message += ', '.join(supported_extensions) + '.'
         message += ' Please check your train / eval data and try again.'
         super().__init__(message, file_name=file_name)

--- a/llmfoundry/utils/exceptions.py
+++ b/llmfoundry/utils/exceptions.py
@@ -4,6 +4,8 @@
 """Custom exceptions for the LLMFoundry."""
 from typing import Any, Dict, List, Literal, Optional, Union
 
+from llmfoundry.data.finetuning.tasks import SUPPORTED_EXTENSIONS
+
 __all__ = [
     'ALLOWED_RESPONSE_KEYS',
     'ALLOWED_PROMPT_KEYS',
@@ -354,3 +356,20 @@ class RunTimeoutError(InternalError):
     def __init__(self, timeout: int) -> None:
         message = f'Run timed out after {timeout} seconds.'
         super().__init__(message, timeout=timeout)
+
+
+class DatasetMissingFileError(UserError):
+    """Error thrown when a dataset cannot find a file."""
+    def __init__(self, file_name: List[str]) -> None:
+        message = "Could not find the file '{file_name}' with any of the supported extensions: "
+        message += ", ".join(SUPPORTED_EXTENSIONS) + '.'
+        message += " Please check your train / eval data and try again."
+        super().__init__(message, file_name=file_name)
+
+
+class DatasetInvalidFolderError(UserError):
+    """Error thrown when a dataset folder is invalid."""
+    def __init__(self, folder_path: str) -> None:
+        message = f"Could not find objects at the path '{folder_path}'. "
+        message += "Please check your `input_folder` and try again."
+        super().__init__(message, folder_path=folder_path)

--- a/llmfoundry/utils/exceptions.py
+++ b/llmfoundry/utils/exceptions.py
@@ -360,16 +360,18 @@ class RunTimeoutError(InternalError):
 
 class DatasetMissingFileError(UserError):
     """Error thrown when a dataset cannot find a file."""
+
     def __init__(self, file_name: List[str]) -> None:
         message = "Could not find the file '{file_name}' with any of the supported extensions: "
-        message += ", ".join(SUPPORTED_EXTENSIONS) + '.'
-        message += " Please check your train / eval data and try again."
+        message += ', '.join(SUPPORTED_EXTENSIONS) + '.'
+        message += ' Please check your train / eval data and try again.'
         super().__init__(message, file_name=file_name)
 
 
 class DatasetInvalidFolderError(UserError):
     """Error thrown when a dataset folder is invalid."""
+
     def __init__(self, folder_path: str) -> None:
         message = f"Could not find objects at the path '{folder_path}'. "
-        message += "Please check your `input_folder` and try again."
+        message += 'Please check your `input_folder` and try again.'
         super().__init__(message, folder_path=folder_path)

--- a/llmfoundry/utils/exceptions.py
+++ b/llmfoundry/utils/exceptions.py
@@ -364,11 +364,10 @@ class DatasetMissingFileError(UserError):
     def __init__(
         self,
         file_name: str,
-        supported_extensions: Union[List[str], None] = None,
+        supported_extensions: List[str],
     ) -> None:
         message = "Could not find the file '{file_name}' with any of the supported extensions: "
-        if supported_extensions is not None:
-            message += ', '.join(supported_extensions) + '.'
+        message += ', '.join(supported_extensions) + '.'
         message += ' Please check your train / eval data and try again.'
         super().__init__(message, file_name=file_name)
 

--- a/llmfoundry/utils/exceptions.py
+++ b/llmfoundry/utils/exceptions.py
@@ -361,7 +361,7 @@ class RunTimeoutError(InternalError):
 class DatasetMissingFileError(UserError):
     """Error thrown when a dataset cannot find a file."""
 
-    def __init__(self, file_name: List[str]) -> None:
+    def __init__(self, file_name: str) -> None:
         message = "Could not find the file '{file_name}' with any of the supported extensions: "
         message += ', '.join(SUPPORTED_EXTENSIONS) + '.'
         message += ' Please check your train / eval data and try again.'

--- a/llmfoundry/utils/exceptions.py
+++ b/llmfoundry/utils/exceptions.py
@@ -4,8 +4,6 @@
 """Custom exceptions for the LLMFoundry."""
 from typing import Any, Dict, List, Literal, Optional, Union
 
-from llmfoundry.data.finetuning.tasks import SUPPORTED_EXTENSIONS
-
 __all__ = [
     'ALLOWED_RESPONSE_KEYS',
     'ALLOWED_PROMPT_KEYS',
@@ -361,9 +359,9 @@ class RunTimeoutError(InternalError):
 class DatasetMissingFileError(UserError):
     """Error thrown when a dataset cannot find a file."""
 
-    def __init__(self, file_name: str) -> None:
+    def __init__(self, file_name: str, supported_extensions: List[str]) -> None:
         message = "Could not find the file '{file_name}' with any of the supported extensions: "
-        message += ', '.join(SUPPORTED_EXTENSIONS) + '.'
+        message += ', '.join(supported_extensions) + '.'
         message += ' Please check your train / eval data and try again.'
         super().__init__(message, file_name=file_name)
 

--- a/scripts/data_prep/convert_text_to_mds.py
+++ b/scripts/data_prep/convert_text_to_mds.py
@@ -30,6 +30,7 @@ from llmfoundry.utils.data_prep_utils import (
     merge_shard_groups,
 )
 from llmfoundry.utils.exceptions import (
+    DatasetInvalidFolderError,
     InputFolderMissingDataError,
     OutputFolderNotEmptyError,
 )
@@ -232,10 +233,13 @@ def get_object_names(input_folder: str) -> List[str]:
     object_store = maybe_create_object_store_from_uri(input_folder)
     if object_store is not None:
         _, _, folder_prefix = parse_uri(input_folder)
-        names = [
-            name for name in object_store.list_objects(folder_prefix)
-            if name.endswith('.txt')
-        ]
+        try:
+            names = [
+                name for name in object_store.list_objects(folder_prefix)
+                if name.endswith('.txt')
+            ]
+        except FileNotFoundError as e:
+            raise DatasetInvalidFolderError(input_folder) from e
     else:
         # input_folder is a local folder
         names = [


### PR DESCRIPTION
Creates two exceptions:
-  `DatasetMissingFileError` --> Tells the user that a dataset file could not be found during a failure in the finetuning dataloader where `split` / `path` were not defined properly
- `DatasetInvalidFolderError` --> Tells the user that an `input_folder` is invalid and while trying to list objects in `convert_text_to_mds.py`

mapi exceptions implemented in https://github.com/databricks-mosaic/mcloud/pull/4088