### PR TITLE
Remove spurious warning

### DIFF
--- a/llmfoundry/data/utils.py
+++ b/llmfoundry/data/utils.py
@@ -26,14 +26,6 @@ def _validate_cfg(
     eos_token_id = dataset_cfg.get('eos_token_id', None)
     bos_token_id = dataset_cfg.get('bos_token_id', None)
 
-    if eos_token_id is None and bos_token_id is None and (
-        hasattr(tokenizer, 'eos_token_id') or
-        hasattr(tokenizer, 'bos_token_id')
-    ):
-        log.warning(
-            'The user has not provided an eos_token_id or bos_token_id, but the tokenizer has an eos_token_id or a bos_token_id.',
-        )
-
     tokenizer_eos_token_id = getattr(tokenizer, 'eos_token_id', None)
     if eos_token_id is not None and eos_token_id != tokenizer_eos_token_id:
         eos_mismatch_str = f'Provided {eos_token_id=} does not match the eos_token_id of the tokenizer={tokenizer_eos_token_id}.'


### PR DESCRIPTION
This warning isn't helpful (and is confusing for the finetuning case). Only `text` dataloader accepts eos/bos token id, to be used for per sequence attention masking on pretokenized and concatenated sequences. Essentially all tokenizers have an eos/bos, and if you use mpt with `attn_uses_sequence_id` (to enable per sequence masking) without an eos/bos specified, you will get an error separately from this one. `finetuning` dataloader does not accept this.