### PR TITLE
Fix packing + streaming + resumption

### DIFF
--- a/llmfoundry/data/finetuning/dataloader.py
+++ b/llmfoundry/data/finetuning/dataloader.py
@@ -233,6 +233,7 @@ def build_finetuning_dataloader(
             max_seq_len=dataset_cfg['max_seq_len'],
             allow_unsafe_types=dataset_cfg.get('allow_unsafe_types', False),
             replication=replication_factor,
+            packing_ratio=dataloader_batch_size / dataset_batch_size,
         )
 
     else:

--- a/llmfoundry/data/finetuning/dataloader.py
+++ b/llmfoundry/data/finetuning/dataloader.py
@@ -391,6 +391,7 @@ def _validate_config(
         'allow_pad_trimming',
         'seq_parallel_replication',
         'auto_packing_replication',
+        'max_leftover_bins_to_keep',
     }
     if not set(kwargs.keys()).issubset(allowed_additional_kwargs):
         raise ValueError(

--- a/llmfoundry/data/finetuning/dataloader.py
+++ b/llmfoundry/data/finetuning/dataloader.py
@@ -222,7 +222,7 @@ def build_finetuning_dataloader(
             cache_limit=dataset_cfg.get('cache_limit', None),
             partition_algo=dataset_cfg.get('partition_algo', 'relaxed'),
             num_canonical_nodes=dataset_cfg.get('num_canonical_nodes', None),
-            batch_size=dataset_batch_size,
+            batch_size=dataloader_batch_size,
             shuffle=dataset_cfg.get('shuffle', False),
             shuffle_algo=dataset_cfg.get('shuffle_algo', 'py1e'),
             shuffle_seed=dataset_cfg.get('shuffle_seed', 9176),

--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -683,7 +683,8 @@ class StreamingFinetuningDataset(StreamingDataset):
             num_samples = self.packing_ratio * num_samples
 
         return super().state_dict(
-            num_samples=num_samples, from_beginning=from_beginning
+            num_samples=num_samples,
+            from_beginning=from_beginning,
         )
 
 

--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -592,6 +592,7 @@ class StreamingFinetuningDataset(StreamingDataset):
         max_seq_len: int = 2048,
         allow_unsafe_types: bool = False,
         replication: Optional[int] = None,
+        packing_ratio: Optional[float] = None,
         **kwargs: Any,
     ):
 
@@ -644,6 +645,7 @@ class StreamingFinetuningDataset(StreamingDataset):
 
         self.tokenizer = tokenizer
         self.max_seq_len = max_seq_len
+        self.packing_ratio = packing_ratio
 
     # How to process a sample
     def __getitem__(self, idx: int) -> Dict[str, Any]:
@@ -674,6 +676,15 @@ class StreamingFinetuningDataset(StreamingDataset):
             # Convert to latest format by wrapping sample as a "turn"
             return {'turns': [sample]}
         return tokenize_formatted_example(sample, tokenizer=self.tokenizer)
+
+    def state_dict(self, num_samples: int,
+                   from_beginning: bool) -> Dict[str, Any]:
+        if self.packing_ratio is not None:
+            num_samples = self.packing_ratio * num_samples
+
+        return super().state_dict(
+            num_samples=num_samples, from_beginning=from_beginning
+        )
 
 
 class DatasetConstructor:

--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -649,6 +649,7 @@ class StreamingFinetuningDataset(StreamingDataset):
 
     # How to process a sample
     def __getitem__(self, idx: int) -> Dict[str, Any]:
+        print(f'idx: {idx}')
         sample = super().__getitem__(idx)
         if 'turns' in sample:
             # Already tokenized in latest format

--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -649,7 +649,6 @@ class StreamingFinetuningDataset(StreamingDataset):
 
     # How to process a sample
     def __getitem__(self, idx: int) -> Dict[str, Any]:
-        print('Idx:', idx)
         sample = super().__getitem__(idx)
         if 'turns' in sample:
             # Already tokenized in latest format

--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -649,7 +649,6 @@ class StreamingFinetuningDataset(StreamingDataset):
 
     # How to process a sample
     def __getitem__(self, idx: int) -> Dict[str, Any]:
-        print(f'idx: {idx}')
         sample = super().__getitem__(idx)
         if 'turns' in sample:
             # Already tokenized in latest format

--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -649,6 +649,7 @@ class StreamingFinetuningDataset(StreamingDataset):
 
     # How to process a sample
     def __getitem__(self, idx: int) -> Dict[str, Any]:
+        print('Idx:', idx)
         sample = super().__getitem__(idx)
         if 'turns' in sample:
             # Already tokenized in latest format

--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -680,11 +680,7 @@ class StreamingFinetuningDataset(StreamingDataset):
     def state_dict(self, num_samples: int,
                    from_beginning: bool) -> Dict[str, Any]:
         if self.packing_ratio is not None:
-            num_samples = self.packing_ratio * num_samples
-
-        print('+'*30)
-        print(num_samples)
-        print('+'*30)
+            num_samples = int(self.packing_ratio * num_samples)
 
         return super().state_dict(
             num_samples=num_samples,

--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -682,6 +682,10 @@ class StreamingFinetuningDataset(StreamingDataset):
         if self.packing_ratio is not None:
             num_samples = self.packing_ratio * num_samples
 
+        print('+'*30)
+        print(num_samples)
+        print('+'*30)
+
         return super().state_dict(
             num_samples=num_samples,
             from_beginning=from_beginning,

--- a/llmfoundry/data/packing.py
+++ b/llmfoundry/data/packing.py
@@ -189,6 +189,9 @@ def _first_fit_bin_packing(
     # Will contain tuples (bin_size_size, packed_example)
     bins: List[Tuple[int, Dict[str, torch.Tensor]]] = existing_bins
 
+    # DO NOT MERGE
+    bins = []
+
     starting_total_bin_sizes = sum([bin_size for bin_size, _ in bins])
 
     sizes_and_examples = list(zip(sizes, examples))

--- a/llmfoundry/data/packing.py
+++ b/llmfoundry/data/packing.py
@@ -189,9 +189,6 @@ def _first_fit_bin_packing(
     # Will contain tuples (bin_size_size, packed_example)
     bins: List[Tuple[int, Dict[str, torch.Tensor]]] = existing_bins
 
-    # DO NOT MERGE
-    bins = []
-
     starting_total_bin_sizes = sum([bin_size for bin_size, _ in bins])
 
     sizes_and_examples = list(zip(sizes, examples))

--- a/tests/data/test_packing.py
+++ b/tests/data/test_packing.py
@@ -210,6 +210,7 @@ def test_auto_packing_with_streaming_dataloader(tmp_path: Path):
     assert isinstance(loader, DataLoader)
     assert isinstance(loader.dataset, StreamingFinetuningDataset)
     assert loader.dataset.packing_ratio is not None
+    assert isinstance(loader.batch_size, int)
     assert loader.dataset.packing_ratio == int(loader.batch_size / 6)
 
     state_dict = loader.dataset.state_dict(num_samples=2, from_beginning=False)

--- a/tests/data/test_packing.py
+++ b/tests/data/test_packing.py
@@ -206,6 +206,12 @@ def test_auto_packing_with_streaming_dataloader(tmp_path: Path):
         if batch_ix >= 3:
             break
 
+    assert loader.dataset.packing_ratio is not None
+    assert loader.dataset.packing_ratio == int(loader.batch_size / 6)
+
+    state_dict = loader.dataset.state_dict(num_samples=2, from_beginning=False)
+    assert state_dict['sample_in_epoch'] == 2 * loader.dataset.packing_ratio
+
 
 @pytest.mark.parametrize('packing_ratio', ['auto', 2.0])
 @patch(

--- a/tests/data/test_packing.py
+++ b/tests/data/test_packing.py
@@ -16,6 +16,7 @@ from torch.utils.data import DataLoader
 from llmfoundry.data.finetuning.dataloader import build_finetuning_dataloader
 from llmfoundry.data.packing import BinPackCollator, auto_packing_ratio
 from llmfoundry.utils.builders import build_tokenizer
+from llmfoundry.data.finetuning.tasks import StreamingFinetuningDataset
 
 
 def _data_to_batch(data: List[List[int]], max_seq_len: int,
@@ -205,7 +206,9 @@ def test_auto_packing_with_streaming_dataloader(tmp_path: Path):
         batch_ix += 1
         if batch_ix >= 3:
             break
-
+    
+    assert isinstance(loader, DataLoader)
+    assert isinstance(loader.dataset, StreamingFinetuningDataset)
     assert loader.dataset.packing_ratio is not None
     assert loader.dataset.packing_ratio == int(loader.batch_size / 6)
 

--- a/tests/data/test_packing.py
+++ b/tests/data/test_packing.py
@@ -14,9 +14,9 @@ from streaming import MDSWriter
 from torch.utils.data import DataLoader
 
 from llmfoundry.data.finetuning.dataloader import build_finetuning_dataloader
+from llmfoundry.data.finetuning.tasks import StreamingFinetuningDataset
 from llmfoundry.data.packing import BinPackCollator, auto_packing_ratio
 from llmfoundry.utils.builders import build_tokenizer
-from llmfoundry.data.finetuning.tasks import StreamingFinetuningDataset
 
 
 def _data_to_batch(data: List[List[int]], max_seq_len: int,
@@ -206,7 +206,7 @@ def test_auto_packing_with_streaming_dataloader(tmp_path: Path):
         batch_ix += 1
         if batch_ix >= 3:
             break
-    
+
     assert isinstance(loader, DataLoader)
     assert isinstance(loader.dataset, StreamingFinetuningDataset)
     assert loader.dataset.packing_ratio is not None


### PR DESCRIPTION
There was a long standing bug when resuming a streaming, finetuning dataset with packing enabled. The issue would only occur if you resumed _not_ on an epoch boundary. The issue would be fairly significant, in that resumption would resume at an earlier sample than it should have, so data would be unexpectedly repeated. The root cause of the issue is that, when packing, the num samples recorded for streaming resumption needed to be multiplied by the packing ratio.

Manual test, with PR, resumption is deterministic:
<img width="1130" alt="Screenshot 2024-06-14 at 2 42 55 AM" src="https://github.com/mosaicml/llm-foundry/assets/43149077/9bcd724a-3ea1-41e1-9c5b-dc81b177fbe7">

Before this PR (note, loss is lower upon resumption because its repeating samples, and then it reverts to the same general loss curve once its through the repeats):
<img width="1133" alt="Screenshot 2024-06-14 at 11 24 59 AM" src="https://github.com/mosaicml/llm-foundry/assets/43149077/06f2d440-c023-4849-8761-d44710e96bf7">

The above plots were with `num_workers=0`, when setting `num_workers=8`, we discovered a second deterministic resumption bug, where the wrong batch size was passed to streaming. This has now also been fixed, and here is a manual test with `num_workers=8`.

<img width="1592" alt="Screenshot 2024-06-14 at 2 33 17 PM" src="https://github.com/mosaicml/llm-foundry/assets/43149077/de614cd7-c539-451d-8e2e-4dcfcf1d3a7c">

Note: There will still be some non determinism if `max_leftover_bins_to_keep` is not set to zero, because we don't save the reservoir. This will just be slight non determinism, as opposed to the current bug which would repeat samples.