### PR TITLE
Fix TE HF checkpoint saving

### DIFF
--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 import numpy as np
 import torch
 import torch.nn as nn
-from composer.core import Callback, Event, State, Time, TimeUnit
+from composer.core import Callback, Event, Precision, State, Time, TimeUnit
 from composer.core.state import fsdp_state_dict_type_context
 from composer.loggers import Logger, MLFlowLogger
 from composer.models import HuggingFaceModel
@@ -496,7 +496,8 @@ class HuggingFaceCheckpointer(Callback):
             # Needed for proper hf ckpt saving.
             context_manager = te.onnx_export(
                 True,
-            ) if is_te_imported else contextlib.nullcontext()
+            ) if is_te_imported and state.precision == Precision.AMP_FP8 else contextlib.nullcontext(
+            )
             with context_manager:
                 new_model_instance.save_pretrained(temp_save_dir)
                 if original_tokenizer is not None:

--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -495,13 +495,14 @@ class HuggingFaceCheckpointer(Callback):
             # This context manager casts the TE extra state in io.BytesIO format to tensor format
             # Needed for proper hf ckpt saving.
             context_manager = te.onnx_export(
-                True
+                True,
             ) if is_te_imported else contextlib.nullcontext()
             with context_manager:
                 new_model_instance.save_pretrained(temp_save_dir)
                 if original_tokenizer is not None:
                     assert isinstance(
-                        original_tokenizer, PreTrainedTokenizerBase
+                        original_tokenizer,
+                        PreTrainedTokenizerBase,
                     )
                     original_tokenizer.save_pretrained(temp_save_dir)
 

--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -500,12 +500,12 @@ class HuggingFaceCheckpointer(Callback):
             )
             with context_manager:
                 new_model_instance.save_pretrained(temp_save_dir)
-                if original_tokenizer is not None:
-                    assert isinstance(
-                        original_tokenizer,
-                        PreTrainedTokenizerBase,
-                    )
-                    original_tokenizer.save_pretrained(temp_save_dir)
+            if original_tokenizer is not None:
+                assert isinstance(
+                    original_tokenizer,
+                    PreTrainedTokenizerBase,
+                )
+                original_tokenizer.save_pretrained(temp_save_dir)
 
             # Only need to edit files for MPT because it has custom code
             if original_model.config.model_type == 'mpt':

--- a/tests/a_scripts/inference/test_convert_composer_to_hf.py
+++ b/tests/a_scripts/inference/test_convert_composer_to_hf.py
@@ -816,13 +816,13 @@ def test_huggingface_conversion_callback(
             import transformer_engine.pytorch as te
         except ImportError:
             pytest.skip(
-                'Precision amp_fp8 requires transformer-engine to be installed'
+                'Precision amp_fp8 requires transformer-engine to be installed',
             )
 
         # Check we are using mpt models only for FP8.
         if (model == 'neo' or model == 'llama2'):
             pytest.skip(
-                'Precision amp_fp8 works only for mpt models, not hf models'
+                'Precision amp_fp8 works only for mpt models, not hf models',
             )
 
         # Check that we are using H100 or later for FP8.
@@ -927,7 +927,7 @@ def test_huggingface_conversion_callback(
     from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 
     context_manager = te.onnx_export(
-        True
+        True,
     ) if trainer_precision == 'amp_fp8' else contextlib.nullcontext()
     with context_manager:
         with FSDP.summon_full_params(

--- a/tests/a_scripts/inference/test_convert_composer_to_hf.py
+++ b/tests/a_scripts/inference/test_convert_composer_to_hf.py
@@ -926,9 +926,9 @@ def test_huggingface_conversion_callback(
     # summon full params to check equivalence
     from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 
-    context_manager = te.onnx_export(
+    context_manager = te.onnx_export(  # type: ignore
         True,
-    ) if trainer_precision == 'amp_fp8' else contextlib.nullcontext()  # type: ignore
+    ) if trainer_precision == 'amp_fp8' else contextlib.nullcontext()
     with context_manager:
         with FSDP.summon_full_params(
             trainer.state.model,

--- a/tests/a_scripts/inference/test_convert_composer_to_hf.py
+++ b/tests/a_scripts/inference/test_convert_composer_to_hf.py
@@ -928,7 +928,7 @@ def test_huggingface_conversion_callback(
 
     context_manager = te.onnx_export(
         True,
-    ) if trainer_precision == 'amp_fp8' else contextlib.nullcontext()
+    ) if trainer_precision == 'amp_fp8' else contextlib.nullcontext()  # type: ignore
     with context_manager:
         with FSDP.summon_full_params(
             trainer.state.model,

--- a/tests/a_scripts/inference/test_convert_composer_to_hf.py
+++ b/tests/a_scripts/inference/test_convert_composer_to_hf.py
@@ -468,6 +468,7 @@ def _get_model_and_tokenizer(
     model: str,
     max_seq_len: int,
     tie_word_embeddings: bool,
+    precision: str,
 ):
     if model == 'mpt':
         model_cfg = {
@@ -482,6 +483,7 @@ def _get_model_and_tokenizer(
             'attn_config': {
                 'attn_impl': 'torch',
             },
+            'fc_type': 'te' if precision == 'amp_fp8' else 'torch',
             'loss_fn': 'torch_crossentropy',
             'tie_word_embeddings': tie_word_embeddings,
         }
@@ -783,8 +785,9 @@ def _assert_checkpoint_equivalence(
 )
 @pytest.mark.parametrize('fsdp_state_dict_type', ['full', 'sharded', None])
 @pytest.mark.parametrize(
-    'hf_save_interval,save_interval,max_duration,expected_hf_checkpoints,expected_normal_checkpoints',
-    [('1ba', '1ba', '1ba', 1, 1)],
+    'hf_save_interval,save_interval,max_duration,expected_hf_checkpoints,expected_normal_checkpoints,trainer_precision',
+    [('1ba', '1ba', '1ba', 1, 1, 'amp_bf16'),
+     ('1ba', '1ba', '1ba', 1, 1, 'amp_fp8')],
 )
 @patch('os.cpu_count', MagicMock(return_value=1))
 @patch(
@@ -801,10 +804,13 @@ def test_huggingface_conversion_callback(
     max_duration: str,
     expected_hf_checkpoints: int,
     expected_normal_checkpoints: int,
+    trainer_precision: str,
     peft_config: Optional[dict],
 ):
     if model == 'mptmoe' and fsdp_state_dict_type is None:
         pytest.skip('mptmoe requires FSDP')
+    if (model == 'neo' or model == 'llama2') and trainer_precision == 'amp_fp8':
+        pytest.skip('Precision amp_fp8 requires mpt models, not hf models')
     delete_transformers_cache()
 
     dist.initialize_dist(get_device('gpu'))
@@ -825,9 +831,10 @@ def test_huggingface_conversion_callback(
 
     # Get small version of each model
     model_cfg, tokenizer_name = _get_model_and_tokenizer(
-        model,
-        max_seq_len,
-        tie_word_embeddings,
+        model=model,
+        max_seq_len=max_seq_len,
+        tie_word_embeddings=tie_word_embeddings,
+        precision=trainer_precision,
     )
     assert model_cfg is not None
     assert tokenizer_name is not None
@@ -883,7 +890,7 @@ def test_huggingface_conversion_callback(
     trainer = Trainer(
         model=original_model,
         device='gpu',
-        precision='amp_bf16',
+        precision=trainer_precision,
         fsdp_config=fsdp_config if fsdp_state_dict_type is not None else None,
         train_dataloader=train_dataloader,
         save_folder=os.path.join(tmp_path, 'checkpoints'),
@@ -899,25 +906,28 @@ def test_huggingface_conversion_callback(
     _assert_mlflow_logger_calls(mlflow_logger_mock, peft_config)
 
     # summon full params to check equivalence
+    import transformer_engine.pytorch as te
     from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
-    with FSDP.summon_full_params(
-        trainer.state.model,
-        writeback=False,
-        recurse=True,
-    ):
-        _assert_checkpoint_equivalence(
-            tmp_path=tmp_path,
-            expected_normal_checkpoints=expected_normal_checkpoints,
-            expected_hf_checkpoints=expected_hf_checkpoints,
-            trainer=trainer,
-            batches_per_epoch=batches_per_epoch,
-            original_model=original_model,
-            precision=precision,
-            model=model,
-            tokenizer=tokenizer,
-            fsdp_state_dict_type=fsdp_state_dict_type,
-            peft_config=peft_config,
-        )
+
+    with te.onnx_export(True):  # Ensure proper ckpting of TE modules.
+        with FSDP.summon_full_params(
+            trainer.state.model,
+            writeback=False,
+            recurse=True,
+        ):
+            _assert_checkpoint_equivalence(
+                tmp_path=tmp_path,
+                expected_normal_checkpoints=expected_normal_checkpoints,
+                expected_hf_checkpoints=expected_hf_checkpoints,
+                trainer=trainer,
+                batches_per_epoch=batches_per_epoch,
+                original_model=original_model,
+                precision=precision,
+                model=model,
+                tokenizer=tokenizer,
+                fsdp_state_dict_type=fsdp_state_dict_type,
+                peft_config=peft_config,
+            )
 
     dist.barrier()
     delete_transformers_cache()

--- a/tests/a_scripts/inference/test_convert_composer_to_hf.py
+++ b/tests/a_scripts/inference/test_convert_composer_to_hf.py
@@ -815,15 +815,19 @@ def test_huggingface_conversion_callback(
         try:
             import transformer_engine.pytorch as te
         except ImportError:
-            pytest.skip('Precision amp_fp8 requires transformer-engine to be installed')
-        
+            pytest.skip(
+                'Precision amp_fp8 requires transformer-engine to be installed'
+            )
+
         # Check we are using mpt models only for FP8.
         if (model == 'neo' or model == 'llama2'):
-            pytest.skip('Precision amp_fp8 works only for mpt models, not hf models')
+            pytest.skip(
+                'Precision amp_fp8 works only for mpt models, not hf models'
+            )
 
         # Check that we are using H100 or later for FP8.
         if not (torch.cuda.get_device_capability() >= (8, 9)):
-            pytest.skip("Amp FP8 requires a GPU with compute capability >= 8.9")
+            pytest.skip('Amp FP8 requires a GPU with compute capability >= 8.9')
 
     delete_transformers_cache()
 
@@ -922,7 +926,9 @@ def test_huggingface_conversion_callback(
     # summon full params to check equivalence
     from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 
-    context_manager = te.onnx_export(True) if trainer_precision == 'amp_fp8' else contextlib.nullcontext()
+    context_manager = te.onnx_export(
+        True
+    ) if trainer_precision == 'amp_fp8' else contextlib.nullcontext()
     with context_manager:
         with FSDP.summon_full_params(
             trainer.state.model,


### PR DESCRIPTION
# Description 
Fixes HF Checkpoint callback for TransformerEngine FP8 saving. This PR ensures we serialize the io.BytesIO extra_state tensors as regular tensors in`save_pretrained` so the code does not error. 


# Tests
- Added unit test, skipped on A100 GPU ✔️ 
- Added unit test, manually ran on H100 GPU ✅ 
```
tests/a_scripts/inference/test_convert_composer_to_hf.py::test_huggingface_conversion_callback[1ba-1ba-1ba-1-1-amp_fp8-full-mpt-True-None]
  /usr/lib/python3/dist-packages/transformer_engine/pytorch/module/base.py:394: UserWarning: The given buffer is not writable, and PyTorch does not support non-writable tensors. This means you can write to the underlying (supposedly non-writable) buffer using the tensor. You may want to copy the buffer to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at ../torch/csrc/utils/tensor_new.cpp:1524.)
    state_serialized = torch.frombuffer(pickle.dumps(state), dtype=torch.uint8)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================================================================== 25 passed, 11 skipped, 1621 deselected, 266 warnings in 92.95s (0:01:32) ======================================================================================
Waiting up to 30 seconds for all training processes to terminate. Press Ctrl-C to exit immediately.
```
- Before: `failed-hf-checkpointer-fp8-llama3-8b-metamath-4ep-KOTaOP` 🔴 
- After: `success-hf-checkpointer-fp8-llama3-8b-metamath-4ep-yxNFTK` ✅ 

# Issues
Closes https://databricks.atlassian.net/browse/RGENAI-255 