### PR TITLE
Bump mlflow to 2.13.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ classifiers = [
 
 install_requires = [
     'mosaicml[libcloud,wandb,oci,gcs]>=0.23.2,<0.24',
-    'mlflow>=2.12.1,<2.13',
+    'mlflow>=2.13.2,<2.14',
     'accelerate>=0.25,<0.26',  # for HF inference `device_map`
     'transformers>=4.40,<4.41',
     'mosaicml-streaming>=0.7.6,<0.8',


### PR DESCRIPTION
https://databricks.slack.com/archives/C05T1A4UMT8/p1718320174357049

Working (broken, but fix should be in different patch than in this one) run: 
test-uc-mlflow-jsdna4
https://e2-dogfood.staging.cloud.databricks.com/ml/experiments/3354908383479081/runs/076c6b9e13fb40f79fc4c6143be10c7b?o=6051921418418893
Needed to bump mlflow so that UCVolume directories can be detected by SourceDatasets