### PR TITLE
Fix backwards compatibility for ICL arg

### DIFF
--- a/llmfoundry/utils/builders.py
+++ b/llmfoundry/utils/builders.py
@@ -595,6 +595,20 @@ def build_icl_evaluators(
             icl_constructor_kwargs['pad_tok_id'] = pad_tok_id
             icl_constructor_kwargs['num_fewshot'] = num_fewshot
 
+            # Support backwards compatibility for the naming of "prelimiter" as "question_prelimiter"
+            if 'question_prelimiter' in icl_constructor_kwargs:
+                if 'prelimiter' in icl_constructor_kwargs:
+                    raise ValueError(
+                        'Both "question_prelimiter" and "prelimiter" are specified in the ICL task config. '
+                        +
+                        'Please only specify one of them, as they map to the same argument.'
+                    )
+                else:
+                    icl_constructor_kwargs['prelimiter'
+                                          ] = icl_constructor_kwargs.pop(
+                                              'question_prelimiter'
+                                          )
+
             assert early_stopping_criteria is None or isinstance(
                 early_stopping_criteria,
                 list,

--- a/llmfoundry/utils/builders.py
+++ b/llmfoundry/utils/builders.py
@@ -601,12 +601,12 @@ def build_icl_evaluators(
                     raise ValueError(
                         'Both "question_prelimiter" and "prelimiter" are specified in the ICL task config. '
                         +
-                        'Please only specify one of them, as they map to the same argument.'
+                        'Please only specify one of them, as they map to the same argument.',
                     )
                 else:
                     icl_constructor_kwargs['prelimiter'
                                           ] = icl_constructor_kwargs.pop(
-                                              'question_prelimiter'
+                                              'question_prelimiter',
                                           )
 
             assert early_stopping_criteria is None or isinstance(

--- a/tests/eval/test_in_context_learning_datasets.py
+++ b/tests/eval/test_in_context_learning_datasets.py
@@ -2627,4 +2627,4 @@ def test_bc_question_prelimiter(
 
     assert len(evaluators) == 1
     evaluator = evaluators[0]
-    assert evaluator.dataloader.dataloader.dataset.prelimiter == 'This is a question: '
+    assert evaluator.dataloader.dataloader.dataset.prelimiter == 'This is a question: '  # type: ignore

--- a/tests/eval/test_in_context_learning_datasets.py
+++ b/tests/eval/test_in_context_learning_datasets.py
@@ -37,6 +37,7 @@ from llmfoundry.eval.metrics import (
     InContextLearningLMAccuracy,
     InContextLearningMultipleChoiceAccuracy,
 )
+from llmfoundry.utils.builders import build_icl_evaluators
 
 
 def test_strip_data():
@@ -2588,3 +2589,42 @@ def test_hf_dataloading_custom_parsing(
     )
     assert decoded_batch[0].endswith('Orbs: quas wex exort\nSpell:')
     assert decoded_batch[1].endswith('Orbs: quas quas quas\nSpell:')
+
+
+@pytest.mark.parametrize(
+    'prelimiter_key_name',
+    ['prelimiter', 'question_prelimiter'],
+)
+def test_bc_question_prelimiter(
+    mpt_tokenizer: transformers.PreTrainedTokenizerBase,
+    prelimiter_key_name: str,
+):
+    local_data = os.path.join(os.path.dirname(__file__), 'local_data')
+
+    dataset_uri = f'{local_data}/piqa_small.jsonl'
+
+    icl_tasks = [
+        {
+            'dataset_uri': dataset_uri,
+            'label': 'piqa',
+            'icl_task_type': 'multiple_choice',
+            'max_seq_len': 64,
+            'pad_tok_id': mpt_tokenizer.eos_token_id,
+            'num_fewshot': [0],
+            'prompt_string': '',
+            'example_delimiter': '\n',
+            'continuation_delimiter': ': ',
+            prelimiter_key_name: 'This is a question: ',
+        },
+    ]
+
+    evaluators, _ = build_icl_evaluators(
+        icl_tasks=icl_tasks,
+        tokenizer=mpt_tokenizer,
+        default_batch_size=2,
+        default_max_seq_len=128,
+    )
+
+    assert len(evaluators) == 1
+    evaluator = evaluators[0]
+    assert evaluator.dataloader.dataloader.dataset.prelimiter == 'This is a question: '


### PR DESCRIPTION
We were previously mapping `question_prelimiter` to `prelimiter` in the classes. The previous registry PR removed that mapping as the constructor args are passed along directly. This PR adds backwards compatibility for that naming