### PR TITLE
Extendability refactors

### DIFF
--- a/llmfoundry/data/finetuning/dataloader.py
+++ b/llmfoundry/data/finetuning/dataloader.py
@@ -46,7 +46,7 @@ _DEFAULT_TARGET_PROMPTS = 'none'
 
 def build_finetuning_dataloader(
     tokenizer: PreTrainedTokenizerBase,
-    device_batch_size: int,
+    device_batch_size: Union[int, float],
     dataset: Dict[str, Any],
     num_workers: int,
     drop_last: bool = False,

--- a/llmfoundry/data/text_data.py
+++ b/llmfoundry/data/text_data.py
@@ -300,7 +300,7 @@ def build_streams(streams: Optional[Dict[str, Any]] = None,):
 
 def build_text_dataloader(
     tokenizer: PreTrainedTokenizerBase,
-    device_batch_size: int,
+    device_batch_size: Union[int, float],
     dataset: Dict[str, Any],
     drop_last: bool,
     num_workers: int,

--- a/llmfoundry/models/layers/blocks.py
+++ b/llmfoundry/models/layers/blocks.py
@@ -212,12 +212,31 @@ class MPTBlock(nn.Module):
         indices = None
         if not self.use_pad_tok_in_ffn and attention_mask is not None:
             assert unpad_input is not None
+            attention_mask = self.slice_attention_mask(attention_mask, seq_len)
             m, indices, _, _ = unpad_input(m, attention_mask)
         n = self.ffn(m)
         if not self.use_pad_tok_in_ffn and attention_mask is not None:
             assert pad_input is not None
             n = pad_input(n, indices, batch_size, seq_len)
         return n
+
+    def slice_attention_mask(
+        self,
+        attention_mask: torch.ByteTensor,
+        seq_len: int,
+    ) -> torch.ByteTensor:
+        """Slice attention mask to the correct size.
+
+        Can be overridden by subclasses to apply different slicing logic.
+
+        Args:
+            attention_mask (torch.ByteTensor): The attention mask.
+            seq_len (int): The sequence length.
+
+        Returns:
+            torch.ByteTensor: The sliced attention mask.
+        """
+        return attention_mask
 
 
 class FusedNormAttentionNorm(nn.Module):

--- a/llmfoundry/models/mpt/configuration_mpt.py
+++ b/llmfoundry/models/mpt/configuration_mpt.py
@@ -195,6 +195,10 @@ class MPTConfig(PretrainedConfig):
                     v,
                 )
         return config
+    
+    def validate_attention_config(self) -> None:
+        if (self.attn_config.get('seq_parallel_world_size', 1) or 1) > 1:
+            raise NotImplementedError('Sequence Parallelism is not supported.')
 
     def _validate_config(self) -> None:
         # set config defaults
@@ -336,5 +340,5 @@ class MPTConfig(PretrainedConfig):
                 raise ImportError(
                     'In order to set `use_pad_tok_in_ffn=False`, please install flash-attn==1.0.9 or flash-attn==2.3.6',
                 )
-        if (self.attn_config.get('seq_parallel_world_size', 1) or 1) > 1:
-            raise NotImplementedError('Sequence Parallelism is not supported.')
+
+        self.validate_attention_config()

--- a/llmfoundry/models/mpt/configuration_mpt.py
+++ b/llmfoundry/models/mpt/configuration_mpt.py
@@ -15,21 +15,12 @@ from llmfoundry.models.layers.attention import (
     is_flash_v2_installed,
 )
 
-# NOTE: All utils are imported directly even if unused so that
-# HuggingFace can detect all the needed files to copy into its modules folder.
-# Otherwise, certain modules are missing.
-# isort: off
-from llmfoundry.models.layers.norm import LPLayerNorm  # type: ignore (see note)
-from llmfoundry.models.layers.layer_builders import build_norm, build_fc, build_ffn  # type: ignore (see note)
-from llmfoundry.models.layers.dmoe import dMoE  # type: ignore (see note)
-from llmfoundry.layers_registry import norms  # type: ignore (see note)
-from llmfoundry.utils.registry_utils import construct_from_registry  # type: ignore (see note)
 from llmfoundry.models.utils.config_defaults import (
     attn_config_defaults,
     ffn_config_defaults,
     init_config_defaults,
     fc_type_defaults,
-)  # type: ignore (see note)
+)
 
 
 class MPTConfig(PretrainedConfig):

--- a/llmfoundry/models/mpt/configuration_mpt.py
+++ b/llmfoundry/models/mpt/configuration_mpt.py
@@ -14,12 +14,11 @@ from llmfoundry.models.layers.attention import (
     check_alibi_support,
     is_flash_v2_installed,
 )
-
 from llmfoundry.models.utils.config_defaults import (
     attn_config_defaults,
+    fc_type_defaults,
     ffn_config_defaults,
     init_config_defaults,
-    fc_type_defaults,
 )
 
 

--- a/llmfoundry/models/mpt/configuration_mpt.py
+++ b/llmfoundry/models/mpt/configuration_mpt.py
@@ -187,7 +187,8 @@ class MPTConfig(PretrainedConfig):
         return config
 
     def validate_attention_config(self) -> None:
-        if 'seq_parallel_world_size' in self.attn_config and self.attn_config['seq_parallel_world_size'] is None:
+        if 'seq_parallel_world_size' in self.attn_config and self.attn_config[
+            'seq_parallel_world_size'] is None:
             del self.attn_config['seq_parallel_world_size']
         if self.attn_config.get('seq_parallel_world_size', 1) > 1:
             raise NotImplementedError('Sequence Parallelism is not supported.')

--- a/llmfoundry/models/mpt/configuration_mpt.py
+++ b/llmfoundry/models/mpt/configuration_mpt.py
@@ -187,7 +187,9 @@ class MPTConfig(PretrainedConfig):
         return config
 
     def validate_attention_config(self) -> None:
-        if (self.attn_config.get('seq_parallel_world_size', 1) or 1) > 1:
+        if 'seq_parallel_world_size' in self.attn_config and self.attn_config['seq_parallel_world_size'] is None:
+            del self.attn_config['seq_parallel_world_size']
+        if self.attn_config.get('seq_parallel_world_size', 1) > 1:
             raise NotImplementedError('Sequence Parallelism is not supported.')
 
     def _validate_config(self) -> None:

--- a/llmfoundry/models/mpt/configuration_mpt.py
+++ b/llmfoundry/models/mpt/configuration_mpt.py
@@ -195,7 +195,7 @@ class MPTConfig(PretrainedConfig):
                     v,
                 )
         return config
-    
+
     def validate_attention_config(self) -> None:
         if (self.attn_config.get('seq_parallel_world_size', 1) or 1) > 1:
             raise NotImplementedError('Sequence Parallelism is not supported.')

--- a/llmfoundry/models/mpt/modeling_mpt.py
+++ b/llmfoundry/models/mpt/modeling_mpt.py
@@ -425,6 +425,10 @@ class MPTModel(MPTPreTrainedModel):
         log.debug(self)
         log.debug(f'Using {self.config.init_config["name"]} initialization.')
 
+    @property
+    def block_class(self) -> Type[MPTBlock]:
+        return MPTBlock
+
     def construct_blocks(self, config: MPTConfig) -> nn.ModuleList:
         """Construct the nn.ModuleList with the Transformer blocks.
 
@@ -437,7 +441,7 @@ class MPTModel(MPTPreTrainedModel):
         block_args = self.extract_block_args(config.to_dict())
 
         return nn.ModuleList([
-            MPTBlock(
+            self.block_class(
                 device=config.init_device,
                 **block_args,
             ) for _ in range(config.n_layers)

--- a/llmfoundry/models/mpt/modeling_mpt.py
+++ b/llmfoundry/models/mpt/modeling_mpt.py
@@ -80,6 +80,7 @@ from llmfoundry.models.utils.mpt_param_count import (
 # isort: off
 from llmfoundry.models.layers.fc import fcs  #  type: ignore
 from llmfoundry.models.utils.param_init_fns import generic_param_init_fn_  # type: ignore
+from llmfoundry.models.layers.norm import LPLayerNorm  # type: ignore
 # isort: on
 
 log = logging.getLogger(__name__)

--- a/llmfoundry/registry.py
+++ b/llmfoundry/registry.py
@@ -222,6 +222,18 @@ icl_datasets = create_registry(
     description=_icl_datasets_description,
 )
 
+_config_transforms_description = (
+    'The config_transforms registry is used to register functions that transform the training config before it is passed to the Trainer.' +
+    'Note: By default ALL registered transforms will be applied to the train config and NONE to the eval config. Each transform should return the modified config.'
+)
+config_transforms = create_registry(
+    'llmfoundry',
+    'config_transforms',
+    generic_type=Callable[[Dict[str, Any]], Dict[str, Any]],
+    entry_points=True,
+    description=_config_transforms_description,
+)
+
 __all__ = [
     'loggers',
     'callbacks',
@@ -245,4 +257,5 @@ __all__ = [
     'attention_implementations',
     'fcs',
     'icl_datasets',
+    'config_transforms',
 ]

--- a/llmfoundry/registry.py
+++ b/llmfoundry/registry.py
@@ -223,7 +223,8 @@ icl_datasets = create_registry(
 )
 
 _config_transforms_description = (
-    'The config_transforms registry is used to register functions that transform the training config before it is passed to the Trainer.' +
+    'The config_transforms registry is used to register functions that transform the training config before it is passed to the Trainer.'
+    +
     'Note: By default ALL registered transforms will be applied to the train config and NONE to the eval config. Each transform should return the modified config.'
 )
 config_transforms = create_registry(

--- a/llmfoundry/registry.py
+++ b/llmfoundry/registry.py
@@ -223,10 +223,17 @@ icl_datasets = create_registry(
 )
 
 _config_transforms_description = (
-    'The config_transforms registry is used to register functions that transform the training config before it is passed to the Trainer.'
-    +
-    'Note: By default ALL registered transforms will be applied to the train config and NONE to the eval config. Each transform should return the modified config.'
-)
+    """The config_transforms registry is used to register functions that transform the training config
+
+    The config will be transformed before it is used anywhere else. Note: By default ALL registered transforms will be applied to the train config
+    and NONE to the eval config. Each transform should return the modified config.
+
+    Args:
+        cfg (Dict[str, Any]): The training config.
+
+    Returns:
+        cfg (Dict[str, Any]): The modified training config.
+    """)
 config_transforms = create_registry(
     'llmfoundry',
     'config_transforms',

--- a/llmfoundry/registry.py
+++ b/llmfoundry/registry.py
@@ -233,7 +233,8 @@ _config_transforms_description = (
 
     Returns:
         cfg (Dict[str, Any]): The modified training config.
-    """)
+    """
+)
 config_transforms = create_registry(
     'llmfoundry',
     'config_transforms',

--- a/llmfoundry/utils/__init__.py
+++ b/llmfoundry/utils/__init__.py
@@ -58,6 +58,9 @@ from llmfoundry.utils.warnings import (
     experimental_class,
     experimental_function,
 )
+from llmfoundry.registry import config_transforms
+
+config_transforms.register('update_batch_size_info', func=update_batch_size_info)
 
 __all__ = [
     'build_algorithm',

--- a/llmfoundry/utils/__init__.py
+++ b/llmfoundry/utils/__init__.py
@@ -1,6 +1,7 @@
 # Copyright 2022 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
+from llmfoundry.registry import config_transforms
 from llmfoundry.utils.builders import (
     build_algorithm,
     build_callback,
@@ -58,9 +59,11 @@ from llmfoundry.utils.warnings import (
     experimental_class,
     experimental_function,
 )
-from llmfoundry.registry import config_transforms
 
-config_transforms.register('update_batch_size_info', func=update_batch_size_info)
+config_transforms.register(
+    'update_batch_size_info',
+    func=update_batch_size_info,
+)
 
 __all__ = [
     'build_algorithm',

--- a/llmfoundry/utils/builders.py
+++ b/llmfoundry/utils/builders.py
@@ -63,7 +63,7 @@ def build_evaluators(
     eval_gauntlet_config: Optional[Union[str, Dict[str, Any]]],
     *,
     tokenizer: PreTrainedTokenizerBase,
-    device_eval_batch_size: int,
+    device_eval_batch_size: Union[int, float],
     icl_seq_len: int,
     icl_subset_num_batches: Optional[int],
 ) -> Tuple[List[Evaluator], List[str], Optional[EvalGauntlet]]:
@@ -79,6 +79,10 @@ def build_evaluators(
     logger_keys = []
     eval_gauntlet_callback = None
     if icl_tasks_config is not None:
+        if not isinstance(device_eval_batch_size, int):
+            raise ValueError(
+                'device_eval_batch_size should be an int for icl tasks.',
+            )
         icl_evaluators, logger_keys, eval_gauntlet_callback = build_icl_data_and_gauntlet(
             icl_tasks_config,
             eval_gauntlet_config,
@@ -95,7 +99,7 @@ def build_evaluators(
 def build_eval_loaders(
     eval_loader_config: Union[Dict[str, Any], List[Dict[str, Any]]],
     tokenizer: PreTrainedTokenizerBase,
-    device_eval_batch_size: int,
+    device_eval_batch_size: Union[int, float],
 ) -> List[Evaluator]:
     evaluators: List[Evaluator] = []
     if isinstance(eval_loader_config, list):
@@ -122,7 +126,8 @@ def build_eval_loaders(
             # Load the eval data to fail fast. metrics will get added
             # later in add_metrics_to_eval_loaders, after the model is loaded
             metric_names=[],
-            device_eval_microbatch_size=device_eval_batch_size,
+            # TODO: Fix type in Composer
+            device_eval_microbatch_size=device_eval_batch_size,  # type: ignore
         )
         evaluators.append(eval_loader)
     return evaluators

--- a/llmfoundry/utils/config_utils.py
+++ b/llmfoundry/utils/config_utils.py
@@ -420,7 +420,6 @@ def calculate_batch_size_info(
     int, Literal['auto']]]:
 
     world_size = dist.get_world_size()
-    assert isinstance(world_size, int)
     if world_size % data_replication_degree != 0:
         raise ValueError(
             f'World size {world_size} is not divisible by data replication degree {data_replication_degree}.',

--- a/llmfoundry/utils/config_utils.py
+++ b/llmfoundry/utils/config_utils.py
@@ -49,7 +49,7 @@ class EvalConfig:
     # Eval Config required parameters:
     models: List[Dict[str, Any]] = MISSING
     max_seq_len: int = MISSING
-    device_eval_batch_size: int = MISSING
+    device_eval_batch_size: Union[int, float] = MISSING
 
     # Eval Config optional parameters:
     code_paths: Optional[List[str]] = None
@@ -102,7 +102,7 @@ class TrainConfig:
     scheduler: Dict[str, Any] = MISSING
     train_loader: Dict[str, Any] = MISSING
     device_train_batch_size: Union[int, float] = MISSING
-    device_eval_batch_size: int = MISSING
+    device_eval_batch_size: Union[int, float] = MISSING
     max_duration: Union[int, str] = MISSING
     eval_interval: Union[int, str] = MISSING
     max_seq_len: int = MISSING
@@ -161,7 +161,7 @@ class TrainConfig:
     save_ignore_keys: Optional[List[str]] = None
 
     # Dataloader
-    device_train_microbatch_size: Union[str, int] = 'auto'
+    device_train_microbatch_size: Union[str, int, float] = 'auto'
     global_train_batch_size: Optional[int] = None
 
     # Eval dataloader

--- a/llmfoundry/utils/config_utils.py
+++ b/llmfoundry/utils/config_utils.py
@@ -244,6 +244,17 @@ def apply_transforms_to_config(
     transforms: Optional[Union[List[Callable[[Dict[str, Any]], Dict[str, Any]]],
                                List[str], str]],
 ) -> Dict[str, Any]:
+    """Applies a list of transforms to a config.
+
+    Args:
+        cfg (Dict[str, Any]): The config to transform.
+        transforms (Optional[Union[List[Callable[[Dict[str, Any]], Dict[str, Any]]], List[str], str]]): A list of
+            transform functions or strings representing transform functions to apply to the config. If a single string
+            with the value ``all`` is provided, all registered transforms will be applied.
+
+    Returns:
+        Dict[str, Any]: The transformed config.
+    """
     if transforms is None or (
         isinstance(transforms, list) and len(transforms) == 0
     ):

--- a/llmfoundry/utils/huggingface_hub_utils.py
+++ b/llmfoundry/utils/huggingface_hub_utils.py
@@ -243,10 +243,7 @@ def edit_files_for_hf_compatibility(
     # If the config file exists, the entrypoint files would be specified in the auto map
     entrypoint_files = set()
     if config_file_exists:
-        for key, value in config.get('auto_map', {}).items():
-            # Only keep the modeling entrypoints, e.g. AutoModelForCausalLM
-            if 'model' not in key.lower():
-                continue
+        for value in config.get('auto_map', {}).values():
             split_path = value.split('.')
             if len(split_path) > 1:
                 entrypoint_files.add(split_path[0] + '.py')
@@ -278,6 +275,12 @@ def edit_files_for_hf_compatibility(
     all_relative_imports = {
         os.path.splitext(os.path.basename(f))[0]
         for f in files_processed_and_queued
+    }
+    # Filter out __init__ files
+    all_relative_imports = {
+        relative_import
+        for relative_import in all_relative_imports
+        if relative_import != '__init__'
     }
     for entrypoint in entrypoint_files:
         file_path = os.path.join(folder, entrypoint)

--- a/llmfoundry/utils/huggingface_hub_utils.py
+++ b/llmfoundry/utils/huggingface_hub_utils.py
@@ -278,8 +278,7 @@ def edit_files_for_hf_compatibility(
     }
     # Filter out __init__ files
     all_relative_imports = {
-        relative_import
-        for relative_import in all_relative_imports
+        relative_import for relative_import in all_relative_imports
         if relative_import != '__init__'
     }
     for entrypoint in entrypoint_files:

--- a/llmfoundry/utils/huggingface_hub_utils.py
+++ b/llmfoundry/utils/huggingface_hub_utils.py
@@ -288,8 +288,9 @@ def edit_files_for_hf_compatibility(
         existing_relative_imports = get_all_relative_imports(
             os.path.join(folder, entrypoint),
         )
-        # Add in self so we don't create a circular import
-        existing_relative_imports.add(os.path.splitext(entrypoint)[0])
+        # Add in all entrypoints so we don't create a circular import
+        for sub_entrypoint in entrypoint_files:
+            existing_relative_imports.add(os.path.splitext(sub_entrypoint)[0])
         missing_relative_imports = all_relative_imports - existing_relative_imports
         add_relative_imports(
             os.path.join(folder, entrypoint),

--- a/scripts/eval/eval.py
+++ b/scripts/eval/eval.py
@@ -53,7 +53,7 @@ def evaluate_model(
     seed: int,
     icl_tasks: Union[str, List[Dict[str, Any]]],
     max_seq_len: int,
-    device_eval_batch_size: int,
+    device_eval_batch_size: Union[int, float],
     eval_gauntlet_config: Optional[Union[str, Dict[str, Any]]],
     eval_loader_config: Optional[Union[Dict[str, Any], List[Dict[str, Any]]]],
     fsdp_config: Optional[Dict[str, Any]],

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -152,15 +152,6 @@ def validate_config(train_config: TrainConfig):
                 f'MoEs with expert parallelism (moe_world_size {moe_world_size} > 1) require `use_orig_params=True`.',
             )
 
-    attn_config = train_config.model.get('attn_config', None)
-    if attn_config is not None:
-        seq_parallel_world_size = attn_config.get(
-            'seq_parallel_world_size',
-            None,
-        )
-        if seq_parallel_world_size is not None:
-            raise ValueError('Training does not support sequence parallelism.')
-
 
 def _log_num_params(model: ComposerModel, logged_cfg: Dict[str, Any]):
     # Log number of parameters

--- a/tests/models/layers/test_blocks.py
+++ b/tests/models/layers/test_blocks.py
@@ -1,0 +1,62 @@
+from typing import Optional
+
+import pytest
+import torch
+from unittest.mock import MagicMock
+
+from llmfoundry.models.layers import blocks
+from llmfoundry.models.layers.blocks import MPTBlock
+
+def test_default_attention_mask_slicing():
+    attention_mask = torch.tensor([1, 1, 0, 1]).byte()
+    assert isinstance(attention_mask, torch.ByteTensor)
+
+    block = MPTBlock(
+        d_model=4,
+        n_heads=1,
+        expansion_ratio=1,
+    )
+
+    output_mask = block.slice_attention_mask(
+        attention_mask=attention_mask,
+        seq_len=4,
+    )
+    
+    assert torch.equal(output_mask, attention_mask)
+
+def test_attention_mask_slicing_called(monkeypatch: pytest.MonkeyPatch):
+    m = torch.randn(2, 4, 4)
+    attention_mask = torch.tensor([1, 1, 1, 1]).byte()
+    dummy_return_mask = torch.tensor([1, 1, 1, 0]).byte()
+    assert isinstance(attention_mask, torch.ByteTensor)
+    assert isinstance(dummy_return_mask, torch.ByteTensor)
+    indices = torch.arange(4)
+
+    unpad_mock = MagicMock(return_value=(m, indices, None, None))
+    pad_mock = MagicMock(return_value=m)
+    monkeypatch.setattr(blocks, 'unpad_input', unpad_mock)
+    monkeypatch.setattr(blocks, 'pad_input', pad_mock)
+    class MPTBlockTest(MPTBlock):
+        def slice_attention_mask(
+            self,
+            attention_mask: Optional[torch.ByteTensor],
+            seq_len: int,
+        ) -> Optional[torch.ByteTensor]:
+            del seq_len
+            del attention_mask
+            return dummy_return_mask  # type: ignore
+        
+    block = MPTBlockTest(
+        d_model=4,
+        n_heads=1,
+        expansion_ratio=1,
+        use_pad_tok_in_ffn=False,
+    )
+
+    block.apply_ffn(
+        attention_mask=attention_mask,
+        m=m,
+    )
+
+    assert unpad_mock.call_count == 1
+    unpad_mock.assert_called_with(m, dummy_return_mask)

--- a/tests/models/layers/test_blocks.py
+++ b/tests/models/layers/test_blocks.py
@@ -1,11 +1,15 @@
+# Copyright 2024 MosaicML LLM Foundry authors
+# SPDX-License-Identifier: Apache-2.0
+
 from typing import Optional
+from unittest.mock import MagicMock
 
 import pytest
 import torch
-from unittest.mock import MagicMock
 
 from llmfoundry.models.layers import blocks
 from llmfoundry.models.layers.blocks import MPTBlock
+
 
 def test_default_attention_mask_slicing():
     attention_mask = torch.tensor([1, 1, 0, 1]).byte()
@@ -21,8 +25,9 @@ def test_default_attention_mask_slicing():
         attention_mask=attention_mask,
         seq_len=4,
     )
-    
+
     assert torch.equal(output_mask, attention_mask)
+
 
 def test_attention_mask_slicing_called(monkeypatch: pytest.MonkeyPatch):
     m = torch.randn(2, 4, 4)
@@ -36,7 +41,9 @@ def test_attention_mask_slicing_called(monkeypatch: pytest.MonkeyPatch):
     pad_mock = MagicMock(return_value=m)
     monkeypatch.setattr(blocks, 'unpad_input', unpad_mock)
     monkeypatch.setattr(blocks, 'pad_input', pad_mock)
+
     class MPTBlockTest(MPTBlock):
+
         def slice_attention_mask(
             self,
             attention_mask: Optional[torch.ByteTensor],
@@ -45,7 +52,7 @@ def test_attention_mask_slicing_called(monkeypatch: pytest.MonkeyPatch):
             del seq_len
             del attention_mask
             return dummy_return_mask  # type: ignore
-        
+
     block = MPTBlockTest(
         d_model=4,
         n_heads=1,

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -43,6 +43,7 @@ def test_expected_registries_exist():
         'attention_implementations',
         'fcs',
         'icl_datasets',
+        'config_transforms',
     }
 
     assert existing_registries == expected_registry_names

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,9 +7,12 @@ import catalogue
 import pytest
 from omegaconf import DictConfig
 
-from llmfoundry.utils import registry_utils
-from llmfoundry.utils.config_utils import make_dataclass_and_log_config, TrainConfig, TRAIN_CONFIG_KEYS
 from llmfoundry.registry import config_transforms
+from llmfoundry.utils.config_utils import (
+    TRAIN_CONFIG_KEYS,
+    TrainConfig,
+    make_dataclass_and_log_config,
+)
 
 
 def generate_exclusive_test_params(param_names: List[str]):
@@ -32,29 +35,28 @@ def generate_exclusive_test_params(param_names: List[str]):
         param_id = f'{name}=True'
         yield pytest.param(*param_values, id=param_id)
 
+
 def test_config_transforms():
     def dummy_transform(config: Dict[str, Any]) -> Dict[str, Any]:
         config['variables']['fake_key'] = 'fake_value'
         return config
-    
+
     config_transforms.register('dummy_transform', func=dummy_transform)
 
-    config = DictConfig(
-        {
-            'global_train_batch_size': 1,
-            'device_train_microbatch_size': 1,
-            'model': {},
-            'scheduler': {},
-            'max_seq_len': 128,
-            'train_loader': {},
-            'max_duration': 1,
-            'tokenizer': {},
-            'eval_interval': 1,
-            'seed': 1,
-            'optimizer': {},
-            'variables': {},
-        }
-    )
+    config = DictConfig({
+        'global_train_batch_size': 1,
+        'device_train_microbatch_size': 1,
+        'model': {},
+        'scheduler': {},
+        'max_seq_len': 128,
+        'train_loader': {},
+        'max_duration': 1,
+        'tokenizer': {},
+        'eval_interval': 1,
+        'seed': 1,
+        'optimizer': {},
+        'variables': {},
+    },)
     _, parsed_config = make_dataclass_and_log_config(
         config,
         TrainConfig,
@@ -62,6 +64,8 @@ def test_config_transforms():
         transforms='all',
     )
 
+    assert isinstance(parsed_config.variables, Dict)
     assert parsed_config.variables['fake_key'] == 'fake_value'
-    
-    del catalogue.REGISTRY[('llmfoundry', 'config_transforms', 'dummy_transform')]
+
+    del catalogue.REGISTRY[
+        ('llmfoundry', 'config_transforms', 'dummy_transform')]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,15 @@
 # Copyright 2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import List
+from typing import Any, Dict, List
 
+import catalogue
 import pytest
+from omegaconf import DictConfig
+
+from llmfoundry.utils import registry_utils
+from llmfoundry.utils.config_utils import make_dataclass_and_log_config, TrainConfig, TRAIN_CONFIG_KEYS
+from llmfoundry.registry import config_transforms
 
 
 def generate_exclusive_test_params(param_names: List[str]):
@@ -25,3 +31,37 @@ def generate_exclusive_test_params(param_names: List[str]):
         param_values = list(params.values())
         param_id = f'{name}=True'
         yield pytest.param(*param_values, id=param_id)
+
+def test_config_transforms():
+    def dummy_transform(config: Dict[str, Any]) -> Dict[str, Any]:
+        config['variables']['fake_key'] = 'fake_value'
+        return config
+    
+    config_transforms.register('dummy_transform', func=dummy_transform)
+
+    config = DictConfig(
+        {
+            'global_train_batch_size': 1,
+            'device_train_microbatch_size': 1,
+            'model': {},
+            'scheduler': {},
+            'max_seq_len': 128,
+            'train_loader': {},
+            'max_duration': 1,
+            'tokenizer': {},
+            'eval_interval': 1,
+            'seed': 1,
+            'optimizer': {},
+            'variables': {},
+        }
+    )
+    _, parsed_config = make_dataclass_and_log_config(
+        config,
+        TrainConfig,
+        TRAIN_CONFIG_KEYS,
+        transforms='all',
+    )
+
+    assert parsed_config.variables['fake_key'] == 'fake_value'
+    
+    del catalogue.REGISTRY[('llmfoundry', 'config_transforms', 'dummy_transform')]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -37,12 +37,6 @@ def generate_exclusive_test_params(param_names: List[str]):
 
 
 def test_config_transforms():
-    def dummy_transform(config: Dict[str, Any]) -> Dict[str, Any]:
-        config['variables']['fake_key'] = 'fake_value'
-        return config
-
-    config_transforms.register('dummy_transform', func=dummy_transform)
-
     config = DictConfig({
         'global_train_batch_size': 1,
         'device_train_microbatch_size': 1,
@@ -57,6 +51,13 @@ def test_config_transforms():
         'optimizer': {},
         'variables': {},
     },)
+
+    def dummy_transform(config: Dict[str, Any]) -> Dict[str, Any]:
+        config['variables']['fake_key'] = 'fake_value'
+        return config
+
+    config_transforms.register('dummy_transform', func=dummy_transform)
+
     _, parsed_config = make_dataclass_and_log_config(
         config,
         TrainConfig,


### PR DESCRIPTION
This PR includes a few changes for increased extendability of the code:
- Fixes some typing
- Adds `slice_attention_mask` to `MPTBlock`
- Removes the need for extra imports in `configuration_mpt.py` just for HF checkpointing
- Factors out the attention config validation
- Makes the block class overridable on `MPTModel`
- Adds a registry for transforms that can be applied to the `TrainConfig`

Loss before and after:
<img width="817" alt="Screenshot 2024-06-19 at 10 54 00 PM" src="https://github.com/mosaicml/llm-foundry/assets/43149077/7c354321-9f63-4d56-a750-d2dbaf78aafd">

