### PR TITLE
Ignore mosaicml logger for exception if excephook is active

### DIFF
--- a/llmfoundry/callbacks/run_timeout_callback.py
+++ b/llmfoundry/callbacks/run_timeout_callback.py
@@ -11,16 +11,16 @@ from composer import Callback, Logger, State
 from composer.loggers import MosaicMLLogger
 
 from llmfoundry.utils.exceptions import RunTimeoutError
+from llmfoundry.utils.mosaicml_logger_utils import no_override_excepthook
 
 log = logging.getLogger(__name__)
 
 
 def _timeout(timeout: int, mosaicml_logger: Optional[MosaicMLLogger] = None):
-    log.error(f'Timeout after {timeout} seconds of inactivity after fit_end.',)
-    if mosaicml_logger is not None and os.environ.get(
-        'OVERRIDE_EXCEPTHOOK',
-        'false',
-    ).lower() != 'true':
+    log.error(
+        f'Timeout after {timeout} seconds of inactivity after fit_end.',
+    )
+    if mosaicml_logger is not None and no_override_excepthook():
         mosaicml_logger.log_exception(RunTimeoutError(timeout=timeout))
     os.kill(os.getpid(), signal.SIGINT)
 

--- a/llmfoundry/callbacks/run_timeout_callback.py
+++ b/llmfoundry/callbacks/run_timeout_callback.py
@@ -17,7 +17,10 @@ log = logging.getLogger(__name__)
 
 def _timeout(timeout: int, mosaicml_logger: Optional[MosaicMLLogger] = None):
     log.error(f'Timeout after {timeout} seconds of inactivity after fit_end.',)
-    if mosaicml_logger is not None:
+    if mosaicml_logger is not None and os.environ.get(
+        'OVERRIDE_EXCEPTHOOK',
+        'false',
+    ).lower() != 'true':
         mosaicml_logger.log_exception(RunTimeoutError(timeout=timeout))
     os.kill(os.getpid(), signal.SIGINT)
 

--- a/llmfoundry/callbacks/run_timeout_callback.py
+++ b/llmfoundry/callbacks/run_timeout_callback.py
@@ -17,9 +17,7 @@ log = logging.getLogger(__name__)
 
 
 def _timeout(timeout: int, mosaicml_logger: Optional[MosaicMLLogger] = None):
-    log.error(
-        f'Timeout after {timeout} seconds of inactivity after fit_end.',
-    )
+    log.error(f'Timeout after {timeout} seconds of inactivity after fit_end.',)
     if mosaicml_logger is not None and no_override_excepthook():
         mosaicml_logger.log_exception(RunTimeoutError(timeout=timeout))
     os.kill(os.getpid(), signal.SIGINT)

--- a/llmfoundry/utils/__init__.py
+++ b/llmfoundry/utils/__init__.py
@@ -31,9 +31,8 @@ from llmfoundry.utils.data_prep_utils import (
     DownloadingIterable,
     merge_shard_groups,
 )
-from llmfoundry.utils.huggingface_hub_utils import (
-    edit_files_for_hf_compatibility,
-)
+from llmfoundry.utils.huggingface_hub_utils import \
+    edit_files_for_hf_compatibility
 from llmfoundry.utils.logging_utils import SpecificWarningFilter
 from llmfoundry.utils.model_download_utils import (
     download_from_hf_hub,

--- a/llmfoundry/utils/__init__.py
+++ b/llmfoundry/utils/__init__.py
@@ -31,8 +31,9 @@ from llmfoundry.utils.data_prep_utils import (
     DownloadingIterable,
     merge_shard_groups,
 )
-from llmfoundry.utils.huggingface_hub_utils import \
-    edit_files_for_hf_compatibility
+from llmfoundry.utils.huggingface_hub_utils import (
+    edit_files_for_hf_compatibility,
+)
 from llmfoundry.utils.logging_utils import SpecificWarningFilter
 from llmfoundry.utils.model_download_utils import (
     download_from_hf_hub,
@@ -44,6 +45,7 @@ from llmfoundry.utils.mosaicml_logger_utils import (
     log_eval_analytics,
     log_train_analytics,
     maybe_create_mosaicml_logger,
+    no_override_excepthook,
 )
 from llmfoundry.utils.prompt_files import load_prompts, load_prompts_from_file
 from llmfoundry.utils.registry_utils import (
@@ -93,6 +95,7 @@ __all__ = [
     'download_from_hf_hub',
     'download_from_oras',
     'maybe_create_mosaicml_logger',
+    'no_override_excepthook',
     'find_mosaicml_logger',
     'log_eval_analytics',
     'log_train_analytics',

--- a/llmfoundry/utils/mosaicml_logger_utils.py
+++ b/llmfoundry/utils/mosaicml_logger_utils.py
@@ -37,6 +37,13 @@ def maybe_create_mosaicml_logger() -> Optional[MosaicMLLogger]:
         return MosaicMLLogger()
 
 
+def no_override_excepthook() -> bool:
+    return os.environ.get(
+        'OVERRIDE_EXCEPTHOOK',
+        'false',
+    ).lower() != 'true'
+
+
 def find_mosaicml_logger(
     loggers: List[LoggerDestination],
 ) -> Optional[MosaicMLLogger]:

--- a/llmfoundry/utils/mosaicml_logger_utils.py
+++ b/llmfoundry/utils/mosaicml_logger_utils.py
@@ -38,7 +38,10 @@ def maybe_create_mosaicml_logger() -> Optional[MosaicMLLogger]:
 
 
 def no_override_excepthook() -> bool:
-    """Returns True if the excepthook flag is off. This means we are not automatically catching exceptions for MosaicMl runs."""
+    """Returns True if the excepthook flag is off.
+
+    This means we are not automatically catching exceptions for MosaicMl runs.
+    """
     return os.environ.get(
         'OVERRIDE_EXCEPTHOOK',
         'false',

--- a/llmfoundry/utils/mosaicml_logger_utils.py
+++ b/llmfoundry/utils/mosaicml_logger_utils.py
@@ -38,6 +38,7 @@ def maybe_create_mosaicml_logger() -> Optional[MosaicMLLogger]:
 
 
 def no_override_excepthook() -> bool:
+    """Returns True if the excepthook flag is off. This means we are not automatically catching exceptions for MosaicMl runs."""
     return os.environ.get(
         'OVERRIDE_EXCEPTHOOK',
         'false',

--- a/scripts/data_prep/convert_delta_to_json.py
+++ b/scripts/data_prep/convert_delta_to_json.py
@@ -28,9 +28,8 @@ from databricks.sql.client import Cursor as Cursor
 from packaging import version
 from pyspark.sql import SparkSession
 from pyspark.sql.connect.client.core import SparkConnectClient
-from pyspark.sql.connect.client.reattach import (
-    ExecutePlanResponseReattachableIterator,
-)
+from pyspark.sql.connect.client.reattach import \
+    ExecutePlanResponseReattachableIterator
 from pyspark.sql.connect.dataframe import DataFrame
 from pyspark.sql.dataframe import DataFrame as SparkDataFrame
 from pyspark.sql.types import Row

--- a/scripts/data_prep/convert_delta_to_json.py
+++ b/scripts/data_prep/convert_delta_to_json.py
@@ -28,13 +28,17 @@ from databricks.sql.client import Cursor as Cursor
 from packaging import version
 from pyspark.sql import SparkSession
 from pyspark.sql.connect.client.core import SparkConnectClient
-from pyspark.sql.connect.client.reattach import \
-    ExecutePlanResponseReattachableIterator
+from pyspark.sql.connect.client.reattach import (
+    ExecutePlanResponseReattachableIterator,
+)
 from pyspark.sql.connect.dataframe import DataFrame
 from pyspark.sql.dataframe import DataFrame as SparkDataFrame
 from pyspark.sql.types import Row
 
-from llmfoundry.utils import maybe_create_mosaicml_logger
+from llmfoundry.utils import (
+    maybe_create_mosaicml_logger,
+    no_override_excepthook,
+)
 from llmfoundry.utils.exceptions import (
     ClusterDoesNotExistError,
     FailedToConnectToDatabricksError,
@@ -676,9 +680,6 @@ if __name__ == '__main__':
         log.info(f'Elapsed time {time.time() - tik}')
 
     except Exception as e:
-        if mosaicml_logger is not None and os.environ.get(
-            'OVERRIDE_EXCEPTHOOK',
-            'false',
-        ).lower() != 'true':
+        if mosaicml_logger is not None and no_override_excepthook():
             mosaicml_logger.log_exception(e)
         raise e

--- a/scripts/data_prep/convert_delta_to_json.py
+++ b/scripts/data_prep/convert_delta_to_json.py
@@ -27,9 +27,8 @@ from databricks.sql.client import Cursor as Cursor
 from packaging import version
 from pyspark.sql import SparkSession
 from pyspark.sql.connect.client.core import SparkConnectClient
-from pyspark.sql.connect.client.reattach import (
-    ExecutePlanResponseReattachableIterator,
-)
+from pyspark.sql.connect.client.reattach import \
+    ExecutePlanResponseReattachableIterator
 from pyspark.sql.connect.dataframe import DataFrame
 from pyspark.sql.dataframe import DataFrame as SparkDataFrame
 from pyspark.sql.types import Row

--- a/scripts/data_prep/convert_delta_to_json.py
+++ b/scripts/data_prep/convert_delta_to_json.py
@@ -27,8 +27,9 @@ from databricks.sql.client import Cursor as Cursor
 from packaging import version
 from pyspark.sql import SparkSession
 from pyspark.sql.connect.client.core import SparkConnectClient
-from pyspark.sql.connect.client.reattach import \
-    ExecutePlanResponseReattachableIterator
+from pyspark.sql.connect.client.reattach import (
+    ExecutePlanResponseReattachableIterator,
+)
 from pyspark.sql.connect.dataframe import DataFrame
 from pyspark.sql.dataframe import DataFrame as SparkDataFrame
 from pyspark.sql.types import Row
@@ -644,6 +645,9 @@ if __name__ == '__main__':
         log.info(f'Elapsed time {time.time() - tik}')
 
     except Exception as e:
-        if mosaicml_logger is not None:
+        if mosaicml_logger is not None and os.environ.get(
+            'OVERRIDE_EXCEPTHOOK',
+            'false',
+        ).lower() != 'true':
             mosaicml_logger.log_exception(e)
         raise e

--- a/scripts/data_prep/convert_text_to_mds.py
+++ b/scripts/data_prep/convert_text_to_mds.py
@@ -24,7 +24,10 @@ from tqdm import tqdm
 from transformers import AutoTokenizer, PreTrainedTokenizerBase
 
 from llmfoundry.data.data import AbstractConcatTokensDataset
-from llmfoundry.utils import maybe_create_mosaicml_logger
+from llmfoundry.utils import (
+    maybe_create_mosaicml_logger,
+    no_override_excepthook,
+)
 from llmfoundry.utils.data_prep_utils import (
     DownloadingIterable,
     download_file,
@@ -624,9 +627,6 @@ if __name__ == '__main__':
             args_str=_args_str(args),
         )
     except Exception as e:
-        if mosaicml_logger is not None and os.environ.get(
-            'OVERRIDE_EXCEPTHOOK',
-            'false',
-        ).lower() != 'true':
+        if mosaicml_logger is not None and no_override_excepthook():
             mosaicml_logger.log_exception(e)
         raise e

--- a/scripts/data_prep/convert_text_to_mds.py
+++ b/scripts/data_prep/convert_text_to_mds.py
@@ -624,6 +624,9 @@ if __name__ == '__main__':
             args_str=_args_str(args),
         )
     except Exception as e:
-        if mosaicml_logger is not None:
+        if mosaicml_logger is not None and os.environ.get(
+            'OVERRIDE_EXCEPTHOOK',
+            'false',
+        ).lower() != 'true':
             mosaicml_logger.log_exception(e)
         raise e

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -396,7 +396,8 @@ def main(cfg: DictConfig) -> Trainer:
     except BaseContextualError as e:
         if mosaicml_logger is not None:
             e.location = TrainDataLoaderLocation
-            mosaicml_logger.log_exception(e)
+            if os.environ.get('OVERRIDE_EXCEPTHOOK', 'false').lower() != 'true':
+                mosaicml_logger.log_exception(e)
         raise e
 
     if mosaicml_logger is not None:
@@ -429,7 +430,9 @@ def main(cfg: DictConfig) -> Trainer:
         except BaseContextualError as e:
             if mosaicml_logger is not None:
                 e.location = EvalDataLoaderLocation
-                mosaicml_logger.log_exception(e)
+                if os.environ.get('OVERRIDE_EXCEPTHOOK',
+                                  'false').lower() != 'true':
+                    mosaicml_logger.log_exception(e)
             raise e
 
     if mosaicml_logger is not None:

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -394,10 +394,12 @@ def main(cfg: DictConfig) -> Trainer:
             train_cfg.device_train_batch_size,
         )
     except BaseContextualError as e:
-        if mosaicml_logger is not None:
-            e.location = TrainDataLoaderLocation
-            if os.environ.get('OVERRIDE_EXCEPTHOOK', 'false').lower() != 'true':
-                mosaicml_logger.log_exception(e)
+        e.location = TrainDataLoaderLocation
+        if mosaicml_logger is not None and os.environ.get(
+            'OVERRIDE_EXCEPTHOOK',
+            'false',
+        ).lower() != 'true':
+            mosaicml_logger.log_exception(e)
         raise e
 
     if mosaicml_logger is not None:
@@ -428,11 +430,12 @@ def main(cfg: DictConfig) -> Trainer:
             if eval_gauntlet_callback is not None:
                 callbacks.append(eval_gauntlet_callback)
         except BaseContextualError as e:
-            if mosaicml_logger is not None:
-                e.location = EvalDataLoaderLocation
-                if os.environ.get('OVERRIDE_EXCEPTHOOK',
-                                  'false').lower() != 'true':
-                    mosaicml_logger.log_exception(e)
+            e.location = EvalDataLoaderLocation
+            if mosaicml_logger is not None and os.environ.get(
+                'OVERRIDE_EXCEPTHOOK',
+                'false',
+            ).lower() != 'true':
+                mosaicml_logger.log_exception(e)
             raise e
 
     if mosaicml_logger is not None:
@@ -480,8 +483,11 @@ def main(cfg: DictConfig) -> Trainer:
                 non_icl_metrics,
             )
     except BaseContextualError as e:
-        if mosaicml_logger is not None:
-            e.location = EvalDataLoaderLocation
+        e.location = EvalDataLoaderLocation
+        if mosaicml_logger is not None and os.environ.get(
+            'OVERRIDE_EXCEPTHOOK',
+            'false',
+        ).lower() != 'true':
             mosaicml_logger.log_exception(e)
         raise e
 

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -56,6 +56,7 @@ from llmfoundry.utils.exceptions import (
     EvalDataLoaderLocation,
     TrainDataLoaderLocation,
 )
+from llmfoundry.utils.mosaicml_logger_utils import no_override_excepthook
 from llmfoundry.utils.registry_utils import import_file
 
 log = logging.getLogger(__name__)
@@ -385,10 +386,7 @@ def main(cfg: DictConfig) -> Trainer:
         )
     except BaseContextualError as e:
         e.location = TrainDataLoaderLocation
-        if mosaicml_logger is not None and os.environ.get(
-            'OVERRIDE_EXCEPTHOOK',
-            'false',
-        ).lower() != 'true':
+        if mosaicml_logger is not None and no_override_excepthook():
             mosaicml_logger.log_exception(e)
         raise e
 
@@ -421,10 +419,7 @@ def main(cfg: DictConfig) -> Trainer:
                 callbacks.append(eval_gauntlet_callback)
         except BaseContextualError as e:
             e.location = EvalDataLoaderLocation
-            if mosaicml_logger is not None and os.environ.get(
-                'OVERRIDE_EXCEPTHOOK',
-                'false',
-            ).lower() != 'true':
+            if mosaicml_logger is not None and no_override_excepthook():
                 mosaicml_logger.log_exception(e)
             raise e
 
@@ -474,10 +469,7 @@ def main(cfg: DictConfig) -> Trainer:
             )
     except BaseContextualError as e:
         e.location = EvalDataLoaderLocation
-        if mosaicml_logger is not None and os.environ.get(
-            'OVERRIDE_EXCEPTHOOK',
-            'false',
-        ).lower() != 'true':
+        if mosaicml_logger is not None and no_override_excepthook():
             mosaicml_logger.log_exception(e)
         raise e
 


### PR DESCRIPTION
## Ignore mosaicml logger for exception if excephook is active

Before we remove the logger all together (re: https://github.com/mosaicml/llm-foundry/pull/1292) we want to first test catching exceptions with a flag. This prevents us from logging an exception twice. I will run tests that turn the logger off in favor of overriding the excepthook to make sure the intended before still holds for finetuning.

Ran a test on dbx-staging to confirm that the flag works. We will have to update the foundry image used for finetuning to incorporate this change.
![image](https://github.com/mosaicml/llm-foundry/assets/29712344/a2582bef-effc-4139-a703-1d25dfedf729)
