### PR TITLE
Avoid circular import in hf checkpointer

### DIFF
--- a/llmfoundry/utils/huggingface_hub_utils.py
+++ b/llmfoundry/utils/huggingface_hub_utils.py
@@ -279,7 +279,7 @@ def edit_files_for_hf_compatibility(
     # Filter out __init__ files
     all_relative_imports = {
         relative_import for relative_import in all_relative_imports
-        if relative_import != '__init__'
+        if relative_import not in {'__init__', 'modeling_mpt'}
     }
     for entrypoint in entrypoint_files:
         file_path = os.path.join(folder, entrypoint)


### PR DESCRIPTION
If you extend LLM Foundry modeling/config code, the hf checkpointer may create a circular import in its attempt to automatically add all the missing imports to the files for hf. This PR simply excludes the dangerous circular import by preventing either of the entrypoint files (the modeling file or the config file), from including an import to the modeling file. The modeling file is expected to include a legitimate import of the config file, but the config file should not import the modeling file as this would be circular.