### PR TITLE
Error if metadata matches existing keys

### DIFF
--- a/llmfoundry/utils/config_utils.py
+++ b/llmfoundry/utils/config_utils.py
@@ -171,6 +171,7 @@ class TrainConfig:
 
     # Metadata
     metadata: Optional[Dict[str, Any]] = None
+    flatten_metadata: bool = True
     run_name: Optional[str] = None
 
     # Resumption

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -320,15 +320,18 @@ def main(cfg: DictConfig) -> Trainer:
             loggers.append(mosaicml_logger)
 
     if train_cfg.metadata is not None:
-        # Flatten the metadata for logging
-        logged_cfg.pop('metadata', None)
-        common_keys = set(logged_cfg.keys()) & set(train_cfg.metadata.keys())
-        if common_keys:
-            raise ValueError(
-                f'Keys {common_keys} are already present in the config. Please rename them in metadata.',
-            )
+        # Optionally flatten the metadata for logging
+        if train_cfg.flatten_metadata:
+            logged_cfg.pop('metadata', None)
+            common_keys = set(logged_cfg.keys()
+                             ) & set(train_cfg.metadata.keys())
+            if common_keys:
+                raise ValueError(
+                    f'Keys {common_keys} are already present in the config. Please rename them in metadata.',
+                )
 
-        logged_cfg.update(train_cfg.metadata, merge=True)
+            logged_cfg.update(train_cfg.metadata, merge=True)
+
         if mosaicml_logger is not None:
             mosaicml_logger.log_metrics(train_cfg.metadata)
             mosaicml_logger._flush_metadata(force_flush=True)

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -323,11 +323,14 @@ def main(cfg: DictConfig) -> Trainer:
         # Optionally flatten the metadata for logging
         if train_cfg.flatten_metadata:
             logged_cfg.pop('metadata', None)
-            common_keys = set(logged_cfg.keys()
-                             ) & set(train_cfg.metadata.keys())
+            common_keys = set(
+                logged_cfg.keys(),
+            ) & set(train_cfg.metadata.keys())
             if common_keys:
                 raise ValueError(
-                    f'Keys {common_keys} are already present in the config. Please rename them in metadata.',
+                    f'Keys {common_keys} are already present in the config. Please rename them in metadata '
+                    +
+                    'or set flatten_metadata=False to avoid flattening the metadata in the logged config.',
                 )
 
             logged_cfg.update(train_cfg.metadata, merge=True)

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -326,7 +326,7 @@ def main(cfg: DictConfig) -> Trainer:
             common_keys = set(
                 logged_cfg.keys(),
             ) & set(train_cfg.metadata.keys())
-            if common_keys:
+            if len(common_keys) > 0:
                 raise ValueError(
                     f'Keys {common_keys} are already present in the config. Please rename them in metadata '
                     +

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -322,6 +322,12 @@ def main(cfg: DictConfig) -> Trainer:
     if train_cfg.metadata is not None:
         # Flatten the metadata for logging
         logged_cfg.pop('metadata', None)
+        common_keys = set(logged_cfg.keys()) & set(train_cfg.metadata.keys())
+        if common_keys:
+            raise ValueError(
+                f'Keys {common_keys} are already present in the config. Please rename them in metadata.',
+            )
+
         logged_cfg.update(train_cfg.metadata, merge=True)
         if mosaicml_logger is not None:
             mosaicml_logger.log_metrics(train_cfg.metadata)


### PR DESCRIPTION
We flatten the metadata so that it is easier to parse out of mlflow/run metadata. Because of this, a user's metadata key could overwrite the real key in the config that gets logged. This PR fixes that by simple erroring and asking the user to rename their metadata key. It also adds `flatten_metadata` to allow not flattening the metadata.

Original run that overwrites the key: `metadata-with-error-4-G9ps3T`
Run with duplicate key that now errors: `metadata-unflat-1-ltIBGL`
Run without flattening metadata: `metadata-unflat-2-VoxpxS`