### PR TITLE
Update databricks connect version

### DIFF
--- a/llmfoundry/utils/config_utils.py
+++ b/llmfoundry/utils/config_utils.py
@@ -106,7 +106,9 @@ class TrainConfig:
     max_duration: Union[int, str] = MISSING
     eval_interval: Union[int, str] = MISSING
     max_seq_len: int = MISSING
-    seed: int = MISSING
+
+    # Seed
+    seed: int = 17
 
     # Precision
     precision: str = 'amp_bf16'

--- a/scripts/data_prep/convert_delta_to_json.py
+++ b/scripts/data_prep/convert_delta_to_json.py
@@ -7,7 +7,6 @@ import re
 import time
 import urllib.parse
 from argparse import ArgumentParser, Namespace
-from collections import namedtuple
 from concurrent.futures import ProcessPoolExecutor
 from typing import Iterable, List, Optional, Tuple, Union
 from uuid import uuid4
@@ -44,6 +43,7 @@ MINIMUM_DB_CONNECT_DBR_VERSION = '14.3'
 MINIMUM_SQ_CONNECT_DBR_VERSION = '12.2'
 
 log = logging.getLogger(__name__)
+
 
 def iterative_combine_jsons(json_directory: str, output_file: str) -> None:
     """Combine jsonl files in json_directory into one big jsonl file.
@@ -310,7 +310,9 @@ def fetch(
 
         # Running the query and collecting the data as arrow or json.
         query = df._plan.to_proto(df._session.client)  # pyright: ignore
-        schema, cloudfetch_results = df._session.client.experimental_to_cloudfetch(query, "arrow", compression=False)  # pyright: ignore
+        schema, cloudfetch_results = df._session.client.experimental_to_cloudfetch(
+            query, 'arrow', compression=False
+        )  # pyright: ignore
         signed = [result.url for result in cloudfetch_results]
         log.info(f'len(signed) = {len(signed)}')
 

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -180,7 +180,7 @@ def _initialize_dist_with_barrier(dist_timeout: Union[int, float]):
     Args:
         dist_timeout (Union[int, float]): Timeout for initializing the process group
     """
-    log.debug('Initializing dist with device...')
+    log.debug('Hack here to see it works: Initializing dist with device...')
     dist.initialize_dist(get_device(None), timeout=dist_timeout)
     log.debug('Testing barrier with device...')
     dist.barrier()

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ extra_deps['dev'] = [
 extra_deps['databricks'] = [
     'mosaicml[databricks]>=0.23.4,<0.24',
     'databricks-sql-connector>=3,<4',
-    'databricks-connect==14.1.0',
+    'databricks-connect>=14.3.0',
     'lz4>=4,<5',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ extra_deps['dev'] = [
     'pytest-cov>=4,<5',
     'pyright==1.1.256',
     'toml>=0.10.2,<0.11',
-    'packaging>=21,<23',
+    'packaging>=23.2,<24',
     'hf_transfer==0.1.3',
 ]
 

--- a/tests/a_scripts/data_prep/test_convert_delta_to_json.py
+++ b/tests/a_scripts/data_prep/test_convert_delta_to_json.py
@@ -200,7 +200,7 @@ class TestConvertDeltaToJsonl(unittest.TestCase):
         args.DATABRICKS_TOKEN = 'token'
         args.use_serverless = False
 
-        mock_cluster_response = Namespace(spark_version='14.1.0-scala2.12')
+        mock_cluster_response = Namespace(spark_version='14.3.0-scala2.12')
         mock_workspace_client.return_value.clusters.get.return_value = mock_cluster_response
 
         mock_remote = MagicMock()


### PR DESCRIPTION
This PR update convert_delta_to_json script to make it usable with databricks-connect >=14.3. 

Current convert_delta_to_jsonl requires databricks-connect pin to 14.1.0. The reason was that when the script was developed we needed to monkeypatch SparkClient. The monkeypatched code can only work with dbconnect==14.1. Later versions of databricks-connect added the monkeypatch function. 

 