### PR TITLE
Remove databricks-connect from all-cpu dep

### DIFF
--- a/scripts/data_prep/convert_delta_to_json.py
+++ b/scripts/data_prep/convert_delta_to_json.py
@@ -2,6 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+import sys
+log = logging.getLogger(__name__)
+
+try:
+    from databricks.connect import DatabricksSession
+except ImportError:
+    log.warning("Error: databricks-connect is not installed.")
+    log.warning("Please install it using 'pip install databricks-connect'.")
+    sys.exit(1)
+
 import os
 import re
 import time
@@ -21,7 +31,6 @@ import pyspark.sql.connect.proto.cloud_pb2 as cloud_pb2
 import requests
 from composer.utils import retry
 from databricks import sql
-from databricks.connect import DatabricksSession
 from databricks.sdk import WorkspaceClient
 from databricks.sql.client import Connection as Connection
 from databricks.sql.client import Cursor as Cursor
@@ -46,8 +55,6 @@ from llmfoundry.utils.exceptions import (
 
 MINIMUM_DB_CONNECT_DBR_VERSION = '14.1'
 MINIMUM_SQ_CONNECT_DBR_VERSION = '12.2'
-
-log = logging.getLogger(__name__)
 
 Result = namedtuple(
     'Result',

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -180,7 +180,7 @@ def _initialize_dist_with_barrier(dist_timeout: Union[int, float]):
     Args:
         dist_timeout (Union[int, float]): Timeout for initializing the process group
     """
-    log.debug('Initializing dist with device...')
+    log.debug('Hack here to see it works: Initializing dist with device...')
     dist.initialize_dist(get_device(None), timeout=dist_timeout)
     log.debug('Testing barrier with device...')
     dist.barrier()

--- a/setup.py
+++ b/setup.py
@@ -123,13 +123,19 @@ extra_deps['megablocks'] = [
     'grouped-gemm==0.1.4',
 ]
 
-extra_deps['all-cpu'] = {
+extra_deps['serverless'] = {
     dep for key, deps in extra_deps.items() for dep in deps
     if 'gpu' not in key and 'megablocks' not in key and 'databricks-connect' not in dep
 }
+
+extra_deps['all-cpu'] = {
+    dep for key, deps in extra_deps.items() for dep in deps
+    if 'gpu' not in key and 'megablocks' not in key 
+}
+
 extra_deps['all'] = {
     dep for key, deps in extra_deps.items() for dep in deps
-    if key not in {'gpu-flash2', 'all-cpu'}
+    if key not in {'gpu-flash2', 'all-cpu', 'serverless'}
 }
 extra_deps['all-flash2'] = {
     dep for key, deps in extra_deps.items() for dep in deps

--- a/setup.py
+++ b/setup.py
@@ -125,7 +125,7 @@ extra_deps['megablocks'] = [
 
 extra_deps['all-cpu'] = {
     dep for key, deps in extra_deps.items() for dep in deps
-    if 'gpu' not in key and 'megablocks' not in key and 'databricks-connect' not in key
+    if 'gpu' not in key and 'megablocks' not in key and 'databricks-connect' not in dep
 }
 extra_deps['all'] = {
     dep for key, deps in extra_deps.items() for dep in deps

--- a/setup.py
+++ b/setup.py
@@ -125,7 +125,7 @@ extra_deps['megablocks'] = [
 
 extra_deps['all-cpu'] = {
     dep for key, deps in extra_deps.items() for dep in deps
-    if 'gpu' not in key and 'megablocks' not in key
+    if 'gpu' not in key and 'megablocks' not in key and 'databricks-connect' not in key
 }
 extra_deps['all'] = {
     dep for key, deps in extra_deps.items() for dep in deps

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ extra_deps['dev'] = [
     'pytest-cov>=4,<5',
     'pyright==1.1.256',
     'toml>=0.10.2,<0.11',
-    'packaging>=21,<23',
+    'packaging>=23,<24',
     'hf_transfer==0.1.3',
 ]
 


### PR DESCRIPTION
Remove databricks-connect from deps to make it flexible use with applications running with databricks-connect, as the version mismatch can usually lead to strange import errors. Create a new extra deps which is the same as all-cpu except databricks-connect. 