### PR TITLE
Extra for serverless

### DIFF
--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -180,7 +180,7 @@ def _initialize_dist_with_barrier(dist_timeout: Union[int, float]):
     Args:
         dist_timeout (Union[int, float]): Timeout for initializing the process group
     """
-    log.debug('Initializing dist with device...')
+    log.debug('Hack here to see it works: Initializing dist with device...')
     dist.initialize_dist(get_device(None), timeout=dist_timeout)
     log.debug('Testing barrier with device...')
     dist.barrier()

--- a/setup.py
+++ b/setup.py
@@ -123,6 +123,11 @@ extra_deps['megablocks'] = [
     'grouped-gemm==0.1.4',
 ]
 
+extra_deps['serverless'] = {
+    dep for key, deps in extra_deps.items() for dep in deps
+    if 'gpu' not in key and 'megablocks' not in key and 'databricks-connect' not in dep
+}
+
 extra_deps['all-cpu'] = {
     dep for key, deps in extra_deps.items() for dep in deps
     if 'gpu' not in key and 'megablocks' not in key


### PR DESCRIPTION
Create a new extra deps which is the same as all-cpu except databricks-connect. This makes llmfoundry more flexible in use with applications running with databricks-connect, as the version mismatch usually leads to unexpected import errors. 