### PR TITLE
Currently multi-gpu generate does not work with hf.generate for hf checkpoints. This PR fixes that.

### DIFF
--- a/llmfoundry/models/layers/attention.py
+++ b/llmfoundry/models/layers/attention.py
@@ -266,11 +266,11 @@ def flash_attn_fn(
 
     batch_size, seqlen = query.shape[:2]
 
-    indices_q = flash_attn_padding_info['indices_q']
-    indices_k = flash_attn_padding_info['indices_k']
-    indices_v = flash_attn_padding_info['indices_v']
-    cu_seqlens_q = flash_attn_padding_info['cu_seqlens_q']
-    cu_seqlens_k = flash_attn_padding_info['cu_seqlens_k']
+    indices_q = flash_attn_padding_info['indices_q'].to(query.device)
+    indices_k = flash_attn_padding_info['indices_k'].to(key.device)
+    indices_v = flash_attn_padding_info['indices_v'].to(value.device)
+    cu_seqlens_q = flash_attn_padding_info['cu_seqlens_q'].to(query.device)
+    cu_seqlens_k = flash_attn_padding_info['cu_seqlens_k'].to(key.device)
     max_seqlen_q = flash_attn_padding_info['max_seqlen_q']
     max_seqlen_k = flash_attn_padding_info['max_seqlen_k']
 
@@ -667,6 +667,8 @@ class GroupedQueryAttention(nn.Module):
             else:
                 (cos, sin) = rotary_emb(x=value, seq_len=seq_len)
             if is_transformers_version_gte('4.38'):
+                cos = cos.to(query.device)
+                sin = sin.to(query.device)
                 query, key = apply_rotary_pos_emb(
                     q=query,
                     k=key,

--- a/llmfoundry/models/layers/attention.py
+++ b/llmfoundry/models/layers/attention.py
@@ -266,6 +266,8 @@ def flash_attn_fn(
 
     batch_size, seqlen = query.shape[:2]
 
+    # In the following lines we move the tensors to the same devices as query, key, and value respectively. These operations should be no-ops during training.
+    # This is done to fix pipeline parallel generation using hf.generate. Please see this comment for details: https://github.com/mosaicml/llm-foundry/pull/1332#issue-2386827204
     indices_q = flash_attn_padding_info['indices_q'].to(query.device)
     indices_k = flash_attn_padding_info['indices_k'].to(key.device)
     indices_v = flash_attn_padding_info['indices_v'].to(value.device)
@@ -667,6 +669,8 @@ class GroupedQueryAttention(nn.Module):
             else:
                 (cos, sin) = rotary_emb(x=value, seq_len=seq_len)
             if is_transformers_version_gte('4.38'):
+                # In the following lines we move the cos and sin tensors to the same devices as query. These operations should be no-ops during training.
+                # This is done to fix pipeline parallel generation using hf.generate. Please see this comment for details: https://github.com/mosaicml/llm-foundry/pull/1332#issue-2386827204
                 cos = cos.to(query.device)
                 sin = sin.to(query.device)
                 query, key = apply_rotary_pos_emb(

--- a/llmfoundry/models/layers/blocks.py
+++ b/llmfoundry/models/layers/blocks.py
@@ -198,7 +198,7 @@ class MPTBlock(nn.Module):
                 m = self.norm_2(x)
 
         n = self.apply_ffn(attention_mask, m)
-        x = x + self.resid_ffn_dropout(n).to(x.device)
+        x = x.to(device=n.device) + self.resid_ffn_dropout(n)
         return x, attn_weights, past_key_value
 
     def apply_ffn(

--- a/llmfoundry/models/layers/blocks.py
+++ b/llmfoundry/models/layers/blocks.py
@@ -198,7 +198,7 @@ class MPTBlock(nn.Module):
                 m = self.norm_2(x)
 
         n = self.apply_ffn(attention_mask, m)
-        x = x + self.resid_ffn_dropout(n)
+        x = x + self.resid_ffn_dropout(n).to(x.device)
         return x, attn_weights, past_key_value
 
     def apply_ffn(

--- a/llmfoundry/models/layers/blocks.py
+++ b/llmfoundry/models/layers/blocks.py
@@ -198,6 +198,8 @@ class MPTBlock(nn.Module):
                 m = self.norm_2(x)
 
         n = self.apply_ffn(attention_mask, m)
+        # In the following line we move the `x` tensor to the same devices as the output of ffn layer. This operation should be a no-op during training.
+        # This is done to fix pipeline parallel generation using hf.generate. Please see this comment for details: https://github.com/mosaicml/llm-foundry/pull/1332#issue-2386827204
         x = x.to(device=n.device) + self.resid_ffn_dropout(n)
         return x, attn_weights, past_key_value
 

--- a/llmfoundry/models/layers/dmoe.py
+++ b/llmfoundry/models/layers/dmoe.py
@@ -280,6 +280,8 @@ class DroplessMLP(torch.nn.Module):
 
             expert_tokens = x[None, token_list].reshape(-1, hidden_size)
             mlp_output = self.mlp(expert_tokens, expert_idx)
+            # In the following lines we move tensors to the same devices as the output of mlp. These operations should be no-ops during training.
+            # This is done to fix pipeline parallel generation using hf.generate. Please see this comment for details: https://github.com/mosaicml/llm-foundry/pull/1332#issue-2386827204
             expert_weights = expert_weights.to(mlp_output.device)
             expert_out = mlp_output * expert_weights[token_list, topk_list,
                                                      None]

--- a/llmfoundry/models/layers/dmoe.py
+++ b/llmfoundry/models/layers/dmoe.py
@@ -279,12 +279,10 @@ class DroplessMLP(torch.nn.Module):
             topk_list = topk_idx.tolist()
 
             expert_tokens = x[None, token_list].reshape(-1, hidden_size)
-            expert_weights_slice = expert_weights[token_list, topk_list, None]
-            mlp_output = self.mlp(
-                expert_tokens,
-                expert_idx,
-            ).to(device=expert_weights_slice.device,)
-            expert_out = mlp_output * expert_weights_slice
+            mlp_output = self.mlp(expert_tokens,
+                                  expert_idx).to(expert_weights.device)
+            expert_out = mlp_output * expert_weights[token_list, topk_list,
+                                                     None]
 
             out.index_add_(0, token_idx, expert_out)
 

--- a/llmfoundry/models/layers/dmoe.py
+++ b/llmfoundry/models/layers/dmoe.py
@@ -279,11 +279,12 @@ class DroplessMLP(torch.nn.Module):
             topk_list = topk_idx.tolist()
 
             expert_tokens = x[None, token_list].reshape(-1, hidden_size)
-            mlp_output = self.mlp(expert_tokens,
-                                  expert_idx).to(expert_weights.device)
+            mlp_output = self.mlp(expert_tokens, expert_idx)
+            expert_weights = expert_weights.to(mlp_output.device)
             expert_out = mlp_output * expert_weights[token_list, topk_list,
                                                      None]
-
+            out = out.to(mlp_output.device)
+            token_idx = token_idx.to(mlp_output.device)
             out.index_add_(0, token_idx, expert_out)
 
         out = out.view(in_shape)

--- a/llmfoundry/models/layers/dmoe.py
+++ b/llmfoundry/models/layers/dmoe.py
@@ -279,9 +279,12 @@ class DroplessMLP(torch.nn.Module):
             topk_list = topk_idx.tolist()
 
             expert_tokens = x[None, token_list].reshape(-1, hidden_size)
-            mlp_output = self.mlp(expert_tokens, expert_idx)
-            expert_out = mlp_output * expert_weights[token_list, topk_list,
-                                                     None]
+            expert_weights_slice = expert_weights[token_list, topk_list, None]
+            mlp_output = self.mlp(
+                expert_tokens,
+                expert_idx,
+            ).to(device=expert_weights_slice.device,)
+            expert_out = mlp_output * expert_weights_slice
 
             out.index_add_(0, token_idx, expert_out)
 

--- a/llmfoundry/models/mpt/modeling_mpt.py
+++ b/llmfoundry/models/mpt/modeling_mpt.py
@@ -109,7 +109,7 @@ def gen_rotary_embedding(
         )
     elif rope_impl == 'hf':
         if rope_hf_config['type'] == 'no_scaling':
-            return HFRotaryEmbeddingMP(
+            return HFRotaryEmbedding(
                 rope_head_dim,
                 max_position_embeddings=max_seq_len,
                 base=rope_theta,
@@ -304,18 +304,6 @@ def apply_sequence_id(
     attn_bias = attn_bias.masked_fill(cannot_attend, min_val)
 
     return attn_bias
-
-
-class HFRotaryEmbeddingMP(HFRotaryEmbedding):
-
-    @torch.no_grad()
-    def forward(
-        self,
-        x: torch.Tensor,
-        position_ids: torch.Tensor,
-    ) -> tuple[torch.tensor, torch.tensor]:
-        self.inv_freq = self.inv_freq.to(position_ids.device)
-        return super().forward(x, position_ids)
 
 
 class MPTPreTrainedModel(PreTrainedModel):


### PR DESCRIPTION
Multi gpu generation using hf.generate with device map = 'auto' does pipeline parallelism and moves different modules to different gpus. This results in input tensors to certain operations being on different gpus than other inputs to that operation, which results in an error. This PR moves the tensors to match the other tensors. This should not slow down training because during training all of these tensor movements should be no-ops. 