### PR TITLE
Adding a child class of hf's rotary embedding to make hf generate work on multiple gpus.

### DIFF
--- a/llmfoundry/models/mpt/modeling_mpt.py
+++ b/llmfoundry/models/mpt/modeling_mpt.py
@@ -313,7 +313,7 @@ class HFRotaryEmbeddingMP(HFRotaryEmbedding):
         self,
         x: torch.Tensor,
         position_ids: torch.Tensor,
-    ) -> tuple[torch.tensor, torch.tensor]:
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         # In this subclass, we move `inv_freq` to same device as position_ids. This operation should be a no-op during training.
         # This is done to fix pipeline parallel generation using hf.generate. Please see this comment for details: https://github.com/mosaicml/llm-foundry/pull/1334#issue-2387337525
         self.inv_freq = self.inv_freq.to(position_ids.device)

--- a/llmfoundry/models/mpt/modeling_mpt.py
+++ b/llmfoundry/models/mpt/modeling_mpt.py
@@ -109,7 +109,7 @@ def gen_rotary_embedding(
         )
     elif rope_impl == 'hf':
         if rope_hf_config['type'] == 'no_scaling':
-            return HFRotaryEmbeddingMP(
+            return HFRotaryEmbeddingFoundry(
                 rope_head_dim,
                 max_position_embeddings=max_seq_len,
                 base=rope_theta,
@@ -317,7 +317,7 @@ class HFRotaryEmbeddingFoundry(HFRotaryEmbedding):
         # In this subclass, we move `inv_freq` to same device as position_ids. This operation should be a no-op during training.
         # This is done to fix pipeline parallel generation using hf.generate. Please see this comment for details: https://github.com/mosaicml/llm-foundry/pull/1334#issue-2387337525
         self.inv_freq = self.inv_freq.to(position_ids.device)
-        return super().forward(x, position_ids)
+        return super().forward(x=x, position_ids=position_ids)
 
 
 class MPTPreTrainedModel(PreTrainedModel):

--- a/llmfoundry/models/mpt/modeling_mpt.py
+++ b/llmfoundry/models/mpt/modeling_mpt.py
@@ -314,6 +314,8 @@ class HFRotaryEmbeddingMP(HFRotaryEmbedding):
         x: torch.Tensor,
         position_ids: torch.Tensor,
     ) -> tuple[torch.tensor, torch.tensor]:
+        # In this subclass, we move `inv_freq` to same device as position_ids. This operation should be a no-op during training.
+        # This is done to fix pipeline parallel generation using hf.generate. Please see this comment for details: https://github.com/mosaicml/llm-foundry/pull/1334#issue-2387337525
         self.inv_freq = self.inv_freq.to(position_ids.device)
         return super().forward(x, position_ids)
 

--- a/llmfoundry/models/mpt/modeling_mpt.py
+++ b/llmfoundry/models/mpt/modeling_mpt.py
@@ -306,7 +306,7 @@ def apply_sequence_id(
     return attn_bias
 
 
-class HFRotaryEmbeddingMP(HFRotaryEmbedding):
+class HFRotaryEmbeddingFoundry(HFRotaryEmbedding):
 
     @torch.no_grad()
     def forward(

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -46,6 +46,7 @@ from llmfoundry.models.layers.attention import (
 )
 from llmfoundry.models.layers.blocks import MPTBlock
 from llmfoundry.models.mpt import MPTConfig, MPTForCausalLM, MPTModel
+from llmfoundry.models.mpt.modeling_mpt import HFRotaryEmbeddingMP
 from llmfoundry.utils import build_tokenizer
 from llmfoundry.utils.builders import build_composer_model
 from llmfoundry.utils.config_utils import to_dict_container
@@ -2908,3 +2909,10 @@ def test_resolve_reuse_kv_layer_idx(reuse_kv_layer_idx: int):
             'The relative index of kv layer to reuse, override_attn_config\[\"reuse_kv_layer_idx\"\]=0, should be negative\.',  # type: ignore
         ):
             _validate_helper(b_idx=2)
+
+
+def test_hf_rotary_child_class_builds():
+    rope_head_dim = 32
+    max_seq_len = 128
+    rope_theta = 10000
+    HFRotaryEmbeddingMP(rope_head_dim, max_seq_len, rope_theta, device='cpu')

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -48,7 +48,7 @@ from llmfoundry.models.layers.attention import (
 )
 from llmfoundry.models.layers.blocks import MPTBlock
 from llmfoundry.models.mpt import MPTConfig, MPTForCausalLM, MPTModel
-from llmfoundry.models.mpt.modeling_mpt import HFRotaryEmbeddingMP
+from llmfoundry.models.mpt.modeling_mpt import HFRotaryEmbeddingFoundry
 from llmfoundry.utils import build_tokenizer
 from llmfoundry.utils.builders import build_composer_model
 from llmfoundry.utils.config_utils import to_dict_container
@@ -2924,7 +2924,7 @@ def test_hf_rotary_child_class_builds():
         list(range(max_seq_len)),
     ] * bsz)
 
-    rot_emb_mp = HFRotaryEmbeddingMP(
+    rot_emb_mp = HFRotaryEmbeddingFoundry(
         rope_head_dim,
         max_seq_len,
         rope_theta,


### PR DESCRIPTION
Multi gpu generation using hf.generate with device map = 'auto' does pipeline parallelism and moves different modules to different gpus. We see that for some reason, rope embedding's `inv_freq` buffer does not get moved to the right device. In this PR we explicitly move it to the correct device. This should not slow down training because during training this tensor movement should be a no-op.


Related to this: https://github.com/mosaicml/llm-foundry/pull/1332