### PR TITLE
Add a config arg to just save an hf checkpoint

### DIFF
--- a/llmfoundry/utils/config_utils.py
+++ b/llmfoundry/utils/config_utils.py
@@ -161,7 +161,7 @@ class TrainConfig:
     load_strict_model_weights: bool = True
     load_ignore_keys: Optional[List[str]] = None
     save_ignore_keys: Optional[List[str]] = None
-    just_hf_checkpoint: bool = False
+    only_hf_checkpoint: bool = False
 
     # Dataloader
     device_train_microbatch_size: Union[str, int, float] = 'auto'

--- a/llmfoundry/utils/config_utils.py
+++ b/llmfoundry/utils/config_utils.py
@@ -161,6 +161,7 @@ class TrainConfig:
     load_strict_model_weights: bool = True
     load_ignore_keys: Optional[List[str]] = None
     save_ignore_keys: Optional[List[str]] = None
+    just_hf_checkpoint: bool = False
 
     # Dataloader
     device_train_microbatch_size: Union[str, int, float] = 'auto'

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -534,7 +534,7 @@ def main(cfg: DictConfig) -> Trainer:
         ]
         if len(hf_checkpointer_callbacks) == 0:
             raise ValueError(
-                'No HuggingFaceCheckpointer callback found, but just_hf_checkpoint was set to True.',
+                'No HuggingFaceCheckpointer callback found, but just_hf_checkpoint was set to True. Please add a HuggingFaceCheckpointer.',
             )
 
         hf_checkpointer_callback = hf_checkpointer_callbacks[0]

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -536,6 +536,10 @@ def main(cfg: DictConfig) -> Trainer:
             raise ValueError(
                 'No HuggingFaceCheckpointer callback found, but only_hf_checkpoint was set to True. Please add a HuggingFaceCheckpointer.',
             )
+        if len(hf_checkpointer_callbacks) > 1:
+            warnings.warn(
+                'Multiple HuggingFaceCheckpointer callbacks found. Only the first one will be used.',
+            )
 
         hf_checkpointer_callback = hf_checkpointer_callbacks[0]
         hf_checkpointer_callback._save_checkpoint(trainer.state, trainer.logger)

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -539,6 +539,7 @@ def main(cfg: DictConfig) -> Trainer:
 
         hf_checkpointer_callback = hf_checkpointer_callbacks[0]
         hf_checkpointer_callback._save_checkpoint(trainer.state, trainer.logger)
+        return trainer
 
     if train_cfg.log_config:
         log.info('Logging config')

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -528,13 +528,13 @@ def main(cfg: DictConfig) -> Trainer:
     )
 
     # Optionally just save an HF checkpoint
-    if train_cfg.just_hf_checkpoint:
+    if train_cfg.only_hf_checkpoint:
         hf_checkpointer_callbacks = [
             c for c in callbacks if isinstance(c, HuggingFaceCheckpointer)
         ]
         if len(hf_checkpointer_callbacks) == 0:
             raise ValueError(
-                'No HuggingFaceCheckpointer callback found, but just_hf_checkpoint was set to True. Please add a HuggingFaceCheckpointer.',
+                'No HuggingFaceCheckpointer callback found, but only_hf_checkpoint was set to True. Please add a HuggingFaceCheckpointer.',
             )
 
         hf_checkpointer_callback = hf_checkpointer_callbacks[0]

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -22,7 +22,7 @@ from composer.utils import dist, get_device, reproducibility
 from omegaconf import DictConfig
 from omegaconf import OmegaConf as om
 
-from llmfoundry.callbacks import AsyncEval
+from llmfoundry.callbacks import AsyncEval, HuggingFaceCheckpointer
 from llmfoundry.data.dataloader import build_dataloader
 from llmfoundry.eval.metrics.nlp import InContextLearningMetric
 from llmfoundry.layers_registry import ffns_with_megablocks
@@ -526,6 +526,15 @@ def main(cfg: DictConfig) -> Trainer:
         profiler=profiler,
         compile_config=compile_config,
     )
+
+    # Optionally just save an HF checkpoint
+    if train_cfg.just_hf_checkpoint:
+        hf_checkpointer_callbacks = [c for c in callbacks if isinstance(c, HuggingFaceCheckpointer)]
+        if len(hf_checkpointer_callback) == 0:
+            raise ValueError('No HuggingFaceCheckpointer callback found, but just_hf_checkpoint was set to True.')
+
+        hf_checkpointer_callback = hf_checkpointer_callbacks[0]
+        hf_checkpointer_callback._save_checkpoint(trainer.state, trainer.logger)
 
     if train_cfg.log_config:
         log.info('Logging config')

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -537,8 +537,8 @@ def main(cfg: DictConfig) -> Trainer:
                 'No HuggingFaceCheckpointer callback found, but only_hf_checkpoint was set to True. Please add a HuggingFaceCheckpointer.',
             )
         if len(hf_checkpointer_callbacks) > 1:
-            warnings.warn(
-                'Multiple HuggingFaceCheckpointer callbacks found. Only the first one will be used.',
+            raise ValueError(
+                'Multiple HuggingFaceCheckpointer callbacks found, but only_hf_checkpoint was set to True. Please remove all but one HuggingFaceCheckpointer.',
             )
 
         hf_checkpointer_callback = hf_checkpointer_callbacks[0]

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -529,9 +529,13 @@ def main(cfg: DictConfig) -> Trainer:
 
     # Optionally just save an HF checkpoint
     if train_cfg.just_hf_checkpoint:
-        hf_checkpointer_callbacks = [c for c in callbacks if isinstance(c, HuggingFaceCheckpointer)]
+        hf_checkpointer_callbacks = [
+            c for c in callbacks if isinstance(c, HuggingFaceCheckpointer)
+        ]
         if len(hf_checkpointer_callback) == 0:
-            raise ValueError('No HuggingFaceCheckpointer callback found, but just_hf_checkpoint was set to True.')
+            raise ValueError(
+                'No HuggingFaceCheckpointer callback found, but just_hf_checkpoint was set to True.'
+            )
 
         hf_checkpointer_callback = hf_checkpointer_callbacks[0]
         hf_checkpointer_callback._save_checkpoint(trainer.state, trainer.logger)

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -534,7 +534,7 @@ def main(cfg: DictConfig) -> Trainer:
         ]
         if len(hf_checkpointer_callbacks) == 0:
             raise ValueError(
-                'No HuggingFaceCheckpointer callback found, but just_hf_checkpoint was set to True.'
+                'No HuggingFaceCheckpointer callback found, but just_hf_checkpoint was set to True.',
             )
 
         hf_checkpointer_callback = hf_checkpointer_callbacks[0]

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -532,7 +532,7 @@ def main(cfg: DictConfig) -> Trainer:
         hf_checkpointer_callbacks = [
             c for c in callbacks if isinstance(c, HuggingFaceCheckpointer)
         ]
-        if len(hf_checkpointer_callback) == 0:
+        if len(hf_checkpointer_callbacks) == 0:
             raise ValueError(
                 'No HuggingFaceCheckpointer callback found, but just_hf_checkpoint was set to True.'
             )


### PR DESCRIPTION
We have an offline conversion script from composer to hf checkpoint format, but it only works for monolithic checkpoints, and has some other components hardcoded. We are also working on improved utilities for working with checkpoints in composer, but as a stopgap, we are introducing an arg here that will run train.py, but just call the hf checkpointer save and then exit.

Test run: `just-hf-4-nWWD05` (and confirmed the checkpoint shows up in object store)