### PR TITLE
Avoid HF race condition

### DIFF
--- a/llmfoundry/models/hf/hf_causal_lm.py
+++ b/llmfoundry/models/hf/hf_causal_lm.py
@@ -306,6 +306,12 @@ class ComposerHFCausalLM(HuggingFaceModelWithFSDP):
                         use_auth_token=use_auth_token,
                         config=config,
                     )
+        elif dist.get_local_rank() == 0:
+            with init_empty_weights(include_buffers=False):
+                AutoModelForCausalLM.from_config(
+                    config,
+                    trust_remote_code=trust_remote_code,
+                )
 
         dist.barrier()
 


### PR DESCRIPTION
With the latest transformers version, it seems that there is a new race condition in the hf model code, so we apply the same fix as before, of running local rank 0 first to initialize the cache.

Before the transformers bump 6/6 runs succeeded. After the transformers bump 2/5 runs succeeded (6th failed for an unrelated reason). After this PR, 6/6 succeeded.

Transformers issue here: https://github.com/huggingface/transformers/issues/27421