### PR TITLE
[MCLOUD-4910] Escape UC names during data prep

### DIFF
--- a/scripts/data_prep/convert_delta_to_json.py
+++ b/scripts/data_prep/convert_delta_to_json.py
@@ -375,7 +375,7 @@ def get_total_rows(
     sparkSession: Optional[SparkSession],
 ):
     ans = run_query(
-        f'SELECT COUNT(*) FROM {format_tablename(tablename)}',
+        f'SELECT COUNT(*) FROM {tablename}',
         method,
         cursor,
         sparkSession,
@@ -393,7 +393,7 @@ def get_columns_info(
     sparkSession: Optional[SparkSession],
 ):
     ans = run_query(
-        f'SHOW COLUMNS IN {format_tablename(tablename)}',
+        f'SHOW COLUMNS IN {tablename}',
         method,
         cursor,
         sparkSession,
@@ -452,7 +452,7 @@ def fetch(
 
     if method == 'dbconnect' and sparkSession is not None:
         log.info(f'{processes=}')
-        df = sparkSession.table(format_tablename(tablename))
+        df = sparkSession.table(tablename)
 
         # Running the query and collecting the data as arrow or json.
         signed, _, _ = df.collect_cf('arrow')  # pyright: ignore
@@ -630,7 +630,7 @@ if __name__ == '__main__':
     parser.add_argument(
         '--delta_table_name',
         required=True,
-        type=str,
+        type=format_tablename,
         help='UC table <catalog>.<schema>.<table name>',
     )
     parser.add_argument(

--- a/scripts/data_prep/convert_delta_to_json.py
+++ b/scripts/data_prep/convert_delta_to_json.py
@@ -294,6 +294,9 @@ def format_tablename(tablename: str) -> str:
     """
     match = re.match(TABLENAME_PATTERN, tablename)
 
+    if match is None:
+        return tablename
+
     formatted_identifiers = []
     for i in range(1, 4):
         identifier = f"`{match.group(i)}`"

--- a/scripts/data_prep/convert_delta_to_json.py
+++ b/scripts/data_prep/convert_delta_to_json.py
@@ -43,7 +43,7 @@ from llmfoundry.utils.exceptions import (
 MINIMUM_DB_CONNECT_DBR_VERSION = '14.1'
 MINIMUM_SQ_CONNECT_DBR_VERSION = '12.2'
 
-TABLENAME_PATTERN = re.compile(r"(\S+)\.(\S+)\.(\S+)")
+TABLENAME_PATTERN = re.compile(r'(\S+)\.(\S+)\.(\S+)')
 
 log = logging.getLogger(__name__)
 
@@ -287,7 +287,7 @@ def download_starargs(args: Tuple) -> None:
 
 
 def format_tablename(table_name: str) -> str:
-    """Escape catalog, schema and table names with backticks
+    """Escape catalog, schema and table names with backticks.
 
     This needs to be done when running SQL queries/setting spark sessions to prevent invalid identifier errors.
 
@@ -301,10 +301,10 @@ def format_tablename(table_name: str) -> str:
 
     formatted_identifiers = []
     for i in range(1, 4):
-        identifier = f"`{match.group(i)}`"
+        identifier = f'`{match.group(i)}`'
         formatted_identifiers.append(identifier)
 
-    return ".".join(formatted_identifiers)
+    return '.'.join(formatted_identifiers)
 
 
 def fetch_data(

--- a/scripts/data_prep/convert_delta_to_json.py
+++ b/scripts/data_prep/convert_delta_to_json.py
@@ -286,9 +286,10 @@ def download_starargs(args: Tuple) -> None:
     return download(*args)
 
 def format_tablename(tablename: str) -> str:
-    """
-    Escape catalog, schema and table names with backticks when running
-    SQL queries/setting spark sessions to prevent invalid identifier errors.
+    """Escape catalog, schema and table names with backticks
+
+    This needs to be done when running SQL queries/setting spark sessions to prevent invalid identifier errors.
+
     Args:
         tablename (str): catalog.scheme.tablename on UC
     """

--- a/scripts/data_prep/convert_delta_to_json.py
+++ b/scripts/data_prep/convert_delta_to_json.py
@@ -451,7 +451,7 @@ def fetch(
 
     if method == 'dbconnect' and sparkSession is not None:
         log.info(f'{processes=}')
-        df = sparkSession.table(tablename)
+        df = sparkSession.table(format_tablename(tablename))
 
         # Running the query and collecting the data as arrow or json.
         signed, _, _ = df.collect_cf('arrow')  # pyright: ignore

--- a/scripts/data_prep/convert_delta_to_json.py
+++ b/scripts/data_prep/convert_delta_to_json.py
@@ -285,6 +285,7 @@ def download(
 def download_starargs(args: Tuple) -> None:
     return download(*args)
 
+
 def format_tablename(table_name: str) -> str:
     """Escape catalog, schema and table names with backticks
 
@@ -304,6 +305,7 @@ def format_tablename(table_name: str) -> str:
         formatted_identifiers.append(identifier)
 
     return ".".join(formatted_identifiers)
+
 
 def fetch_data(
     method: str,

--- a/scripts/data_prep/convert_delta_to_json.py
+++ b/scripts/data_prep/convert_delta_to_json.py
@@ -296,9 +296,10 @@ def format_tablename(tablename: str) -> str:
 
     formatted_identifiers = []
     for i in range(1, 4):
-        identifier = match.group(i)
-        if re.match(r"\w+$", identifier) is None:
-            identifier = f"`{identifier}`"
+        # identifier = match.group(i)
+        # if re.match(r"\w+$", identifier) is None:
+            # identifier = f"`{identifier}`"
+        identifier = f"`{match.group(i)}`"
         formatted_identifiers.append(identifier)
 
     return ".".join(formatted_identifiers)

--- a/scripts/data_prep/convert_delta_to_json.py
+++ b/scripts/data_prep/convert_delta_to_json.py
@@ -291,7 +291,7 @@ def format_tablename(table_name: str) -> str:
     This needs to be done when running SQL queries/setting spark sessions to prevent invalid identifier errors.
 
     Args:
-        tablename (str): catalog.scheme.tablename on UC
+        table_name (str): catalog.scheme.tablename on UC
     """
     match = re.match(TABLENAME_PATTERN, table_name)
 

--- a/scripts/data_prep/convert_delta_to_json.py
+++ b/scripts/data_prep/convert_delta_to_json.py
@@ -285,7 +285,7 @@ def download(
 def download_starargs(args: Tuple) -> None:
     return download(*args)
 
-def format_tablename(tablename: str) -> str:
+def format_tablename(table_name: str) -> str:
     """Escape catalog, schema and table names with backticks
 
     This needs to be done when running SQL queries/setting spark sessions to prevent invalid identifier errors.
@@ -293,10 +293,10 @@ def format_tablename(tablename: str) -> str:
     Args:
         tablename (str): catalog.scheme.tablename on UC
     """
-    match = re.match(TABLENAME_PATTERN, tablename)
+    match = re.match(TABLENAME_PATTERN, table_name)
 
     if match is None:
-        return tablename
+        return table_name
 
     formatted_identifiers = []
     for i in range(1, 4):
@@ -603,6 +603,8 @@ def fetch_DT(args: Namespace) -> None:
         use_serverless=args.use_serverless,
     )
 
+    args.delta_table_name = format_tablename(args.delta_table_name)
+
     fetch(
         method,
         args.delta_table_name,
@@ -631,7 +633,7 @@ if __name__ == '__main__':
     parser.add_argument(
         '--delta_table_name',
         required=True,
-        type=format_tablename,
+        type=str,
         help='UC table <catalog>.<schema>.<table name>',
     )
     parser.add_argument(

--- a/scripts/data_prep/convert_delta_to_json.py
+++ b/scripts/data_prep/convert_delta_to_json.py
@@ -287,8 +287,8 @@ def download_starargs(args: Tuple) -> None:
 
 def format_tablename(tablename: str) -> str:
     """
-    If the catalog, schema or tablename is hyphenated/contains special characters, escape them with backticks
-    when running SQL queries to prevent invalid identifier errors.
+    Escape catalog, schema and table names with backticks when running
+    SQL queries/setting spark sessions to prevent invalid identifier errors.
     Args:
         tablename (str): catalog.scheme.tablename on UC
     """
@@ -296,9 +296,6 @@ def format_tablename(tablename: str) -> str:
 
     formatted_identifiers = []
     for i in range(1, 4):
-        # identifier = match.group(i)
-        # if re.match(r"\w+$", identifier) is None:
-            # identifier = f"`{identifier}`"
         identifier = f"`{match.group(i)}`"
         formatted_identifiers.append(identifier)
 

--- a/tests/a_scripts/data_prep/test_convert_delta_to_json.py
+++ b/tests/a_scripts/data_prep/test_convert_delta_to_json.py
@@ -14,6 +14,7 @@ from scripts.data_prep.convert_delta_to_json import (
     fetch_DT,
     iterative_combine_jsons,
     run_query,
+    format_tablename,
 )
 
 
@@ -359,3 +360,8 @@ class TestConvertDeltaToJsonl(unittest.TestCase):
         fetch_DT(args)
         assert not mock_sql_connect.called
         assert not mock_databricks_session.builder.remote.called
+
+    def test_format_tablename(self):
+        self.assertEqual(format_tablename('test_catalog.hyphenated-schema.test_table'), 'test_catalog.`hyphenated-schema`.test_table')
+        self.assertEqual(format_tablename('catalog.schema.table'), 'catalog.schema.table')
+        self.assertEqual(format_tablename('hyphenated-catalog.schema.test_table'), '`hyphenated-catalog`.schema.test_table')

--- a/tests/a_scripts/data_prep/test_convert_delta_to_json.py
+++ b/tests/a_scripts/data_prep/test_convert_delta_to_json.py
@@ -12,9 +12,9 @@ from unittest.mock import MagicMock, mock_open, patch
 from scripts.data_prep.convert_delta_to_json import (
     download,
     fetch_DT,
+    format_tablename,
     iterative_combine_jsons,
     run_query,
-    format_tablename,
 )
 
 
@@ -362,6 +362,15 @@ class TestConvertDeltaToJsonl(unittest.TestCase):
         assert not mock_databricks_session.builder.remote.called
 
     def test_format_tablename(self):
-        self.assertEqual(format_tablename('test_catalog.hyphenated-schema.test_table'), '`test_catalog`.`hyphenated-schema`.`test_table`')
-        self.assertEqual(format_tablename('catalog.schema.table'), '`catalog`.`schema`.`table`')
-        self.assertEqual(format_tablename('hyphenated-catalog.schema.test_table'), '`hyphenated-catalog`.`schema`.`test_table`')
+        self.assertEqual(
+            format_tablename('test_catalog.hyphenated-schema.test_table'),
+            '`test_catalog`.`hyphenated-schema`.`test_table`',
+        )
+        self.assertEqual(
+            format_tablename('catalog.schema.table'),
+            '`catalog`.`schema`.`table`',
+        )
+        self.assertEqual(
+            format_tablename('hyphenated-catalog.schema.test_table'),
+            '`hyphenated-catalog`.`schema`.`test_table`',
+        )

--- a/tests/a_scripts/data_prep/test_convert_delta_to_json.py
+++ b/tests/a_scripts/data_prep/test_convert_delta_to_json.py
@@ -362,6 +362,6 @@ class TestConvertDeltaToJsonl(unittest.TestCase):
         assert not mock_databricks_session.builder.remote.called
 
     def test_format_tablename(self):
-        self.assertEqual(format_tablename('test_catalog.hyphenated-schema.test_table'), 'test_catalog.`hyphenated-schema`.test_table')
-        self.assertEqual(format_tablename('catalog.schema.table'), 'catalog.schema.table')
-        self.assertEqual(format_tablename('hyphenated-catalog.schema.test_table'), '`hyphenated-catalog`.schema.test_table')
+        self.assertEqual(format_tablename('test_catalog.hyphenated-schema.test_table'), '`test_catalog`.`hyphenated-schema`.`test_table`')
+        self.assertEqual(format_tablename('catalog.schema.table'), '`catalog`.`schema`.`table`')
+        self.assertEqual(format_tablename('hyphenated-catalog.schema.test_table'), '`hyphenated-catalog`.`schema`.`test_table`')


### PR DESCRIPTION
[JIRA](https://databricks.atlassian.net/browse/MCLOUD-4910). This PR aims to get past an issue that occurs when specifying a delta table for training data that has a valid name with hyphens/special characters.

We now escape the table names with backticks.

Testing: `test_format_tablename`

Manual testing: When submitting fine-tuning runs with custom YAMLs pointing to this branch, the logs indicate that delta tables are read without `[INVALID_IDENTIFIER]` errors - even when hyphenated.

NOTE: We always apply escaping (`` `catalog`.`schema`.`tablename` ``). We do not expect the user to escape their own input. We do not handle cases where UC object names contain backticks.