### PR TITLE
Add fp32 to the set of valid inputs to attention layer

### DIFF
--- a/llmfoundry/models/layers/attention.py
+++ b/llmfoundry/models/layers/attention.py
@@ -212,7 +212,7 @@ def check_valid_inputs(
     valid_dtypes: Optional[list[torch.dtype]] = None,
 ):
     if valid_dtypes is None:
-        valid_dtypes = [torch.float16, torch.bfloat16]
+        valid_dtypes = [torch.float32, torch.float16, torch.bfloat16]
     for tensor in tensors:
         if tensor.dtype not in valid_dtypes:
             raise TypeError(f'{tensor.dtype=} must be in {valid_dtypes=}.')


### PR DESCRIPTION
# Description
Add fp32 to the set of valid inputs for attention layer. 

**Note**: 
- flash attn is incompatible with torch.float32 🔴 
- torch attn is compatible with torch.float32 ✅ 

# Tests: 

- Before:  `full-eval-fp32-train-fp8-llama3-8b-metamath-4ep-ObqlFj`  🔴 
   - `mixed_precision: full` 
- After: `torch-attn-full-eval-fp32-train-fp8-metamath-4ep-pmGJKN` ✅ 
   - `mixed_precision: full` 