### PR TITLE
Add flag for saving only composer checkpoint

### DIFF
--- a/llmfoundry/train/train.py
+++ b/llmfoundry/train/train.py
@@ -537,6 +537,12 @@ def train(cfg: DictConfig) -> Trainer:
         hf_checkpointer_callback._save_checkpoint(trainer.state, trainer.logger)
         return trainer
 
+    if train_cfg.only_composer_checkpoint:
+        log.info('Not training. Only saving composer checkpoint.')
+        trainer.save_checkpoint_to_save_folder()
+        log.info('Done saving checkpoint.')
+        return trainer
+
     if train_cfg.log_config:
         log.info('Logging config')
         log_config(logged_cfg)

--- a/llmfoundry/utils/config_utils.py
+++ b/llmfoundry/utils/config_utils.py
@@ -162,6 +162,7 @@ class TrainConfig:
     load_ignore_keys: Optional[List[str]] = None
     save_ignore_keys: Optional[List[str]] = None
     only_hf_checkpoint: bool = False
+    only_composer_checkpoint: bool = False
 
     # Dataloader
     device_train_microbatch_size: Union[str, int, float] = 'auto'


### PR DESCRIPTION
test: `ift-meta-llama-3-8b-bjyg3w-KRJ2jI`

Similar to https://github.com/mosaicml/llm-foundry/pull/1335 but for composer checkpoints. 

