### PR TITLE
Expose flag for should_save_peft_only

### DIFF
--- a/llmfoundry/models/hf/hf_causal_lm.py
+++ b/llmfoundry/models/hf/hf_causal_lm.py
@@ -90,6 +90,7 @@ class ComposerHFCausalLM(HuggingFaceModelWithFSDP):
         use_train_metrics: bool = True,
         additional_train_metrics: Optional[List] = None,
         additional_eval_metrics: Optional[List] = None,
+        should_save_peft_only: bool = True,
     ):
 
         config_overrides = config_overrides or {}
@@ -131,6 +132,7 @@ class ComposerHFCausalLM(HuggingFaceModelWithFSDP):
             eval_metrics=eval_metrics,
             init_device=init_device,
             peft_config=peft_config_object,
+            should_save_peft_only=should_save_peft_only,
         )
 
     @staticmethod

--- a/llmfoundry/models/hf/model_wrapper.py
+++ b/llmfoundry/models/hf/model_wrapper.py
@@ -40,6 +40,7 @@ class HuggingFaceModelWithFSDP(HuggingFaceModel):
         shift_labels: bool = False,
         init_device: Optional[str] = None,
         peft_config: Optional['PeftConfig'] = None,
+        should_save_peft_only: bool = True,
     ):
         super().__init__(
             model,
@@ -49,7 +50,7 @@ class HuggingFaceModelWithFSDP(HuggingFaceModel):
             eval_metrics=eval_metrics,
             shift_labels=shift_labels,
             peft_config=peft_config,
-            should_save_peft_only=True,
+            should_save_peft_only=should_save_peft_only,
         )
 
         self.prepare_inner_model(self.model, init_device)


### PR DESCRIPTION
This will allow users to control whether they want their composer checkpoints from lora to have the full weights or just the adapter weights.

Note: This only applies to composer checkpoints, not HF checkpoints. HF checkpoints saved through `hf_checkpointer.py` will still only contain the adapters only. 

## Tests
should_save_peft_only: False
```
2024-07-15 21:27:50     844110 .metadata
2024-07-15 21:27:55 4028659956 __0_0.distcp
2024-07-15 21:27:55 4019819348 __1_0.distcp
2024-07-15 21:27:55 4019819348 __2_0.distcp
2024-07-15 21:27:55 4019819348 __3_0.distcp
2024-07-15 21:27:55 4019819348 __4_0.distcp
2024-07-15 21:27:55 4019819348 __5_0.distcp
2024-07-15 21:27:55 4019819348 __6_0.distcp
2024-07-15 21:27:55 4019819348 __7_0.distcp
```

should_save_peft_only: True
```
2024-07-15 21:35:06     291838 .metadata
2024-07-15 21:35:06   13185952 __0_0.distcp
2024-07-15 21:35:06    4345344 __1_0.distcp
2024-07-15 21:35:06    4345344 __2_0.distcp
2024-07-15 21:35:06    4345344 __3_0.distcp
2024-07-15 21:35:06    4345344 __4_0.distcp
2024-07-15 21:35:06    4345344 __5_0.distcp
2024-07-15 21:35:06    4345344 __6_0.distcp
2024-07-15 21:35:06    4345344 __7_0.distcp
```