### PR TITLE
Fix hf dataset hang on small dataset

### DIFF
--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -34,7 +34,6 @@ those keys are strings (i.e. text).
 import importlib
 import logging
 import os
-import shutil
 import warnings
 from collections.abc import Mapping
 from functools import partial

--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -897,10 +897,6 @@ class DatasetConstructor:
                         SUPPORTED_EXTENSIONS,
                     )
 
-            hf_metadata_dir = os.path.join(dataset_name, '.huggingface')
-            if os.path.exists(hf_metadata_dir):
-                shutil.rmtree(hf_metadata_dir)
-
             dataset = hf_datasets.load_dataset(
                 dataset_name,
                 split=split,
@@ -918,6 +914,8 @@ class DatasetConstructor:
             detected_cpu_count = os.cpu_count() or 1
             detected_cpus_with_margin = detected_cpu_count - 8
             num_cpus_to_use = max(1, detected_cpus_with_margin)
+            if len(dataset) < num_cpus_to_use:
+                num_cpus_to_use = 1
 
             columns_to_remove = list(dataset[0].keys())
             tokenized_dataset = dataset.map(

--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -34,6 +34,7 @@ those keys are strings (i.e. text).
 import importlib
 import logging
 import os
+import shutil
 import warnings
 from collections.abc import Mapping
 from functools import partial
@@ -895,10 +896,8 @@ class DatasetConstructor:
                         dataset_name,
                         SUPPORTED_EXTENSIONS,
                     )
-                
-            print('+'*30)
-            print(os.listdir(dataset_name))
-            print('+'*30)
+
+            shutil.rmtree(os.path.join(dataset_name, '.huggingface'))
 
             dataset = hf_datasets.load_dataset(
                 dataset_name,

--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -895,6 +895,10 @@ class DatasetConstructor:
                         dataset_name,
                         SUPPORTED_EXTENSIONS,
                     )
+                
+            print('+'*30)
+            print(os.listdir(dataset_name))
+            print('+'*30)
 
             dataset = hf_datasets.load_dataset(
                 dataset_name,

--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -897,7 +897,9 @@ class DatasetConstructor:
                         SUPPORTED_EXTENSIONS,
                     )
 
-            shutil.rmtree(os.path.join(dataset_name, '.huggingface'))
+            hf_metadata_dir = os.path.join(dataset_name, '.huggingface')
+            if os.path.exists(hf_metadata_dir):
+                shutil.rmtree(hf_metadata_dir)
 
             dataset = hf_datasets.load_dataset(
                 dataset_name,


### PR DESCRIPTION
It seems that when processing a small dataset with multiprocessing, hf datasets sometimes hangs. This PR fixes this by just not doing multiprocessing when the dataset is small. Not sure if this covers all cases, but at least fixes the hang we are seeing now.

Before, with a dataset with 3 samples, it would hang after tokenization ~20% of the time. After this PR, 20 runs completed successfully. Also after this PR, a dataset with 512 samples still appropriately uses multiprocessing, and completed successfully 20 times.