### PR TITLE
Allow for transforms on the model before MLFlow registration

### DIFF
--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -425,6 +425,8 @@ class HuggingFaceCheckpointer(Callback):
             state_dict_model = state.model.model
             original_tokenizer = state.model.tokenizer
 
+        self.using_peft = composer_model.using_peft
+
         if version.parse(torch.__version__) > version.parse('2.2.9'):
             from torch.distributed._tensor import DTensor
             from torch.distributed.checkpoint.state_dict import (
@@ -502,7 +504,7 @@ class HuggingFaceCheckpointer(Callback):
             # First create the model instance on meta device to avoid the
             # initialization cost.
             with init_empty_weights():
-                if composer_model.using_peft:
+                if self.using_peft:
                     active_adapter = original_model.active_adapter
                     base_model = original_model.get_base_model()
                     new_base_model_instance = type(base_model)(new_config)
@@ -599,7 +601,7 @@ class HuggingFaceCheckpointer(Callback):
                     model_saving_kwargs: Dict[str, Any] = {
                         'path': local_save_path,
                     }
-                    if composer_model.using_peft:
+                    if self.using_peft:
                         model_saving_kwargs['flavor'] = 'peft'
                         model_saving_kwargs['save_pretrained_dir'
                                            ] = temp_save_dir

--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -179,6 +179,7 @@ class HuggingFaceCheckpointer(Callback):
             'bfloat16': torch.bfloat16,
         }[precision]
         self.flatten_imports = flatten_imports
+        self.using_peft = False
 
         # mlflow config setup
         self.mlflow_registered_model_name = mlflow_registered_model_name

--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -382,7 +382,7 @@ class HuggingFaceCheckpointer(Callback):
     ) -> PreTrainedModel:
         """Transform the model before registering with MLFlow.
 
-        This allows a subclass to modify the model before registering with MLFlow. The base class implementation will
+        This allows a subclass to modify the model before registering with MLflow. The base class implementation will
         make no modifications.
 
         Args:

--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -481,6 +481,9 @@ class HuggingFaceCheckpointer(Callback):
                              FSDP)) else contextlib.nullcontext()
             with state_dict_context:
                 state_dict = state_dict_model.state_dict()
+        
+        print("State dict model type:", type(state_dict_model))
+        print("is it a hugging face model?", isinstance(state_dict_model, HuggingFaceModel))
 
         # Convert the state dict to the requested precision
         for k, v in state_dict.items():

--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -17,9 +17,7 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 import numpy as np
 import torch
 import torch.nn as nn
-from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from composer.core import Callback, Event, Precision, State, Time, TimeUnit
-from composer.core.state import fsdp_state_dict_type_context
 from composer.loggers import Logger, MLFlowLogger
 from composer.models import HuggingFaceModel
 from composer.utils import (
@@ -30,7 +28,12 @@ from composer.utils import (
 )
 from composer.utils.misc import create_interval_scheduler
 from mlflow.transformers import _fetch_model_card, _write_license_information
-from packaging import version
+from torch.distributed._tensor import DTensor
+from torch.distributed.checkpoint.state_dict import (
+    StateDictOptions,
+    get_model_state_dict,
+)
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from transformers import (
     PretrainedConfig,
     PreTrainedModel,
@@ -276,7 +279,7 @@ class HuggingFaceCheckpointer(Callback):
                 mlflow.environment_variables.MLFLOW_HUGGINGFACE_MODEL_MAX_SHARD_SIZE.set(
                     '1GB',
                 )
-            
+
             # Check if the model is using PEFT
             if state.is_model_ddp:
                 composer_model = state.model.module
@@ -430,62 +433,46 @@ class HuggingFaceCheckpointer(Callback):
             state_dict_model = state.model.model
             original_tokenizer = state.model.tokenizer
 
-        if version.parse(torch.__version__) > version.parse('2.2.9'):
-            from torch.distributed._tensor import DTensor
-            from torch.distributed.checkpoint.state_dict import (
-                StateDictOptions,
-                get_model_state_dict,
-            )
-            cpu_offload = True
+        cpu_offload = True
 
-            # Add a dtensor->cpu tensor hook to avoid CUDA OOM
-            def dtensor_to_tensor_hook(
-                module: nn.Module,
-                state_dict: Dict[str, Any],
-                prefix: str,
-                *args: Any,
-            ) -> Dict[str, Any]:
-                dtensor_fqns = []
-                for fqn in state_dict.keys():
-                    tensor = state_dict[fqn]
-                    if isinstance(tensor, DTensor):
-                        dtensor_fqns.append(fqn)
-                        tensor = tensor.full_tensor()  # type: ignore
-                        if dist.get_global_rank() == 0:
-                            if cpu_offload:
-                                tensor = tensor.cpu()
-                            state_dict[fqn] = tensor
-                if dist.get_global_rank() != 0:
-                    for fqn in dtensor_fqns:
-                        del state_dict[fqn]
-                return state_dict
+        # Add a dtensor->cpu tensor hook to avoid CUDA OOM
+        def dtensor_to_tensor_hook(
+            module: nn.Module,
+            state_dict: Dict[str, Any],
+            prefix: str,
+            *args: Any,
+        ) -> Dict[str, Any]:
+            dtensor_fqns = []
+            for fqn in state_dict.keys():
+                tensor = state_dict[fqn]
+                if isinstance(tensor, DTensor):
+                    dtensor_fqns.append(fqn)
+                    tensor = tensor.full_tensor()  # type: ignore
+                    if dist.get_global_rank() == 0:
+                        if cpu_offload:
+                            tensor = tensor.cpu()
+                        state_dict[fqn] = tensor
+            if dist.get_global_rank() != 0:
+                for fqn in dtensor_fqns:
+                    del state_dict[fqn]
+            return state_dict
 
-            hooks = []
-            for _, module in state_dict_model.named_modules():
-                if isinstance(module, FSDP):
-                    hooks.append(
-                        module.
-                        _register_state_dict_hook(dtensor_to_tensor_hook),
-                    )
+        hooks = []
+        for _, module in state_dict_model.named_modules():
+            if isinstance(module, FSDP):
+                hooks.append(
+                    module._register_state_dict_hook(dtensor_to_tensor_hook),
+                )
 
-            state_dict = get_model_state_dict(
-                state_dict_model,
-                options=StateDictOptions(
-                    full_state_dict=True,
-                    cpu_offload=cpu_offload,
-                ),
-            )
-            for hook in hooks:
-                hook.remove()
-        else:
-            state_dict_context = fsdp_state_dict_type_context(
-                original_model,
-                state_dict_type='full',
-            ) if ((not state.is_model_ddp) and
-                  isinstance(state_dict_model,
-                             FSDP)) else contextlib.nullcontext()
-            with state_dict_context:
-                state_dict = state_dict_model.state_dict()
+        state_dict = get_model_state_dict(
+            state_dict_model,
+            options=StateDictOptions(
+                full_state_dict=True,
+                cpu_offload=cpu_offload,
+            ),
+        )
+        for hook in hooks:
+            hook.remove()
 
         # Convert the state dict to the requested precision
         for k, v in state_dict.items():

--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -365,6 +365,7 @@ class HuggingFaceCheckpointer(Callback):
     def transform_model_pre_registration(
         self,
         model: PreTrainedModel,
+        composer_model,
     ) -> PreTrainedModel:
         """Transform the model before registering with MLFlow.
 
@@ -373,6 +374,7 @@ class HuggingFaceCheckpointer(Callback):
 
         Args:
             model (PreTrainedModel): The model to be transformed.
+            composer_model: The composer model.
 
         Returns:
             PreTrainedModel: The transformed model.

--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -481,9 +481,6 @@ class HuggingFaceCheckpointer(Callback):
                              FSDP)) else contextlib.nullcontext()
             with state_dict_context:
                 state_dict = state_dict_model.state_dict()
-        
-        print("State dict model type:", type(state_dict_model))
-        print("is it a hugging face model?", isinstance(state_dict_model, HuggingFaceModel))
 
         # Convert the state dict to the requested precision
         for k, v in state_dict.items():
@@ -524,8 +521,6 @@ class HuggingFaceCheckpointer(Callback):
             # Then load the state dict in with "assign" so that the state dict
             # is loaded properly even though the model is initially on meta device.
             new_model_instance.load_state_dict(state_dict, assign=True)
-            print(state_dict.keys())
-            exit(0)
             del state_dict
 
             # Transform the model and tokenizer before saving
@@ -579,9 +574,7 @@ class HuggingFaceCheckpointer(Callback):
         if dist.get_global_rank() == 0:
             if self.mlflow_registered_model_name and self._is_last_batch(state):
 
-                new_model_instance = self.transform_model_pre_registration(
-                    new_model_instance,
-                )
+                new_model_instance = self.transform_model_pre_registration(new_model_instance)
 
                 components = {'model': new_model_instance}
                 if original_tokenizer is not None:

--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -576,7 +576,8 @@ class HuggingFaceCheckpointer(Callback):
             if self.mlflow_registered_model_name and self._is_last_batch(state):
 
                 new_model_instance = self.transform_model_pre_registration(
-                    new_model_instance
+                    new_model_instance,
+                    composer_model,
                 )
 
                 components = {'model': new_model_instance}

--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -521,6 +521,8 @@ class HuggingFaceCheckpointer(Callback):
             # Then load the state dict in with "assign" so that the state dict
             # is loaded properly even though the model is initially on meta device.
             new_model_instance.load_state_dict(state_dict, assign=True)
+            print(state_dict.keys())
+            exit(0)
             del state_dict
 
             # Transform the model and tokenizer before saving

--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -380,7 +380,7 @@ class HuggingFaceCheckpointer(Callback):
         self,
         model: PreTrainedModel,
     ) -> PreTrainedModel:
-        """Transform the model before registering with MLFlow.
+        """Transform the model before registering with MLflow.
 
         This allows a subclass to modify the model before registering with MLflow. The base class implementation will
         make no modifications.

--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -574,7 +574,9 @@ class HuggingFaceCheckpointer(Callback):
         if dist.get_global_rank() == 0:
             if self.mlflow_registered_model_name and self._is_last_batch(state):
 
-                new_model_instance = self.transform_model_pre_registration(new_model_instance)
+                new_model_instance = self.transform_model_pre_registration(
+                    new_model_instance
+                )
 
                 components = {'model': new_model_instance}
                 if original_tokenizer is not None:

--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -365,7 +365,6 @@ class HuggingFaceCheckpointer(Callback):
     def transform_model_pre_registration(
         self,
         model: PreTrainedModel,
-        composer_model,
     ) -> PreTrainedModel:
         """Transform the model before registering with MLFlow.
 
@@ -374,7 +373,6 @@ class HuggingFaceCheckpointer(Callback):
 
         Args:
             model (PreTrainedModel): The model to be transformed.
-            composer_model: The composer model.
 
         Returns:
             PreTrainedModel: The transformed model.
@@ -484,7 +482,7 @@ class HuggingFaceCheckpointer(Callback):
             with state_dict_context:
                 state_dict = state_dict_model.state_dict()
 
-        # Convert the state dict to the requested precis
+        # Convert the state dict to the requested precision
         for k, v in state_dict.items():
             if isinstance(v, torch.Tensor):
                 state_dict[k] = v.to(dtype=self.dtype)
@@ -515,11 +513,10 @@ class HuggingFaceCheckpointer(Callback):
                     )
                     new_model_instance.to(dtype=self.dtype)
                 else:
-                    with init_empty_weights():
-                        new_model_instance = type(original_model)(new_config)
-                        new_model_instance.generation_config.update(
-                            **original_model.generation_config.to_dict(),
-                        )
+                    new_model_instance = type(original_model)(new_config)
+                    new_model_instance.generation_config.update(
+                        **original_model.generation_config.to_dict(),
+                    )
 
             # Then load the state dict in with "assign" so that the state dict
             # is loaded properly even though the model is initially on meta device.
@@ -579,7 +576,6 @@ class HuggingFaceCheckpointer(Callback):
 
                 new_model_instance = self.transform_model_pre_registration(
                     new_model_instance,
-                    composer_model,
                 )
 
                 components = {'model': new_model_instance}

--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -576,7 +576,7 @@ class HuggingFaceCheckpointer(Callback):
             if self.mlflow_registered_model_name and self._is_last_batch(state):
 
                 new_model_instance = self.transform_model_pre_registration(
-                    new_model_instance
+                    new_model_instance,
                 )
 
                 components = {'model': new_model_instance}

--- a/tests/a_scripts/inference/test_convert_composer_to_hf.py
+++ b/tests/a_scripts/inference/test_convert_composer_to_hf.py
@@ -383,7 +383,9 @@ def test_huggingface_conversion_callback_interval(
     mlflow_logger_mock.model_registry_prefix = ''
     mlflow_logger_mock._experiment_id = 'mlflow-experiment-id'
     mlflow_logger_mock._run_id = 'mlflow-run-id'
-    transform_model_pre_reg_mock = MagicMock(wraps = checkpointer_callback.transform_model_pre_registration)
+    checkpointer_callback.transform_model_pre_registration = MagicMock(
+        wraps=checkpointer_callback.transform_model_pre_registration,
+    )
     trainer = Trainer(
         model=original_model,
         device='gpu',
@@ -408,10 +410,10 @@ def test_huggingface_conversion_callback_interval(
             input_example=ANY,
             metadata={},
         )
-        assert transform_model_pre_reg_mock.call_count == 1
+        assert checkpointer_callback.transform_model_pre_registration.call_count == 1
         assert mlflow_logger_mock.register_model_with_run_id.call_count == 1
     else:
-        assert transform_model_pre_reg_mock.call_count == 0
+        assert checkpointer_callback.transform_model_pre_registration.call_count == 0
         assert mlflow_logger_mock.save_model.call_count == 0
         assert mlflow_logger_mock.register_model_with_run_id.call_count == 0
 

--- a/tests/a_scripts/inference/test_convert_composer_to_hf.py
+++ b/tests/a_scripts/inference/test_convert_composer_to_hf.py
@@ -383,6 +383,7 @@ def test_huggingface_conversion_callback_interval(
     mlflow_logger_mock.model_registry_prefix = ''
     mlflow_logger_mock._experiment_id = 'mlflow-experiment-id'
     mlflow_logger_mock._run_id = 'mlflow-run-id'
+    transform_model_pre_reg_mock = MagicMock(wraps = checkpointer_callback.transform_model_pre_registration)
     trainer = Trainer(
         model=original_model,
         device='gpu',
@@ -407,8 +408,10 @@ def test_huggingface_conversion_callback_interval(
             input_example=ANY,
             metadata={},
         )
+        assert transform_model_pre_reg_mock.call_count == 1
         assert mlflow_logger_mock.register_model_with_run_id.call_count == 1
     else:
+        assert transform_model_pre_reg_mock.call_count == 0
         assert mlflow_logger_mock.save_model.call_count == 0
         assert mlflow_logger_mock.register_model_with_run_id.call_count == 0
 


### PR DESCRIPTION
Allows subclasses of HF Checkpointer to transform the model before MLFlow registration, if they so choose. Also slight change to make `using_peft` an attribute of HF Checkpointer instance, allowing it to be used / set.