### PR TITLE
Allow for multiple workers when autopacking

### DIFF
--- a/llmfoundry/data/packing.py
+++ b/llmfoundry/data/packing.py
@@ -424,8 +424,6 @@ def profile_packing(
     dataloader_cfg = copy.deepcopy(dataloader_cfg)
     dataloader_cfg.update({
         'drop_last': False,
-        'num_workers': 0,
-        'prefetch_factor': None,
         'persistent_workers': False,
     })
     dataloader_cfg['dataset']['packing_ratio'] = 1.0


### PR DESCRIPTION
Uses the dataloader worker settings when autopacking

https://docs.google.com/spreadsheets/d/1ANCjJjxCdKjPoKUNSW2j3kHcRV9hQsmMq-8pQBrk-y0/edit?gid=0#gid=0