### PR TITLE
Allow flash attention up to 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ extra_deps['tensorboard'] = [
 
 # Flash 2 group kept for backwards compatibility
 extra_deps['gpu-flash2'] = [
-    'flash-attn==2.5.8',
+    'flash-attn>=2.5.8,<3',
 ]
 
 extra_deps['gpu'] = copy.deepcopy(extra_deps['gpu-flash2'])


### PR DESCRIPTION
Allows flash attention version up to 3 to make the docker image/install version correspondence less brittle (i.e. if we bump the flash attention version in the docker image to 2.6, the foundry install won't instantly break)