### PR TITLE
Get a shared file system safe signal file name

### DIFF
--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -827,7 +827,7 @@ class DatasetConstructor:
         Returns:
             Dataset: The tokenized dataset.
         """
-        signal_file_path = f'.node_{dist.get_node_rank()}_local_rank0_data_prep_completed'
+        signal_file_path = dist.get_node_signal_file_name()
 
         # Non local rank 0 ranks will wait here for local rank 0 to finish the data processing.
         # Once local rank 0 is done, the datasets are all cached on disk, and all other ranks

--- a/llmfoundry/models/hf/hf_causal_lm.py
+++ b/llmfoundry/models/hf/hf_causal_lm.py
@@ -363,7 +363,7 @@ class ComposerHFCausalLM(HuggingFaceModelWithFSDP):
                 f'init_device="{init_device}" must be either "cpu" or "meta".',
             )
 
-        signal_file_path = f'.node_{dist.get_node_rank()}_local_rank0_completed'
+        signal_file_path = dist.get_node_signal_file_name()
         if dist.get_local_rank() == 0:
             with open(signal_file_path, 'wb') as f:
                 f.write(b'local_rank0_completed_download')

--- a/llmfoundry/utils/builders.py
+++ b/llmfoundry/utils/builders.py
@@ -498,7 +498,7 @@ def build_tokenizer(
     os.environ['TRANSFORMERS_NO_ADVISORY_WARNINGS'] = '1'
     os.environ['TOKENIZERS_PARALLELISM'] = 'false'
 
-    signal_file_path = f'.node_{dist.get_node_rank()}_local_rank0_completed_tokenizer_setup'
+    signal_file_path = dist.get_node_signal_file_name()
 
     if dist.is_available() and dist.is_initialized(
     ) and dist.get_world_size() > 1:


### PR DESCRIPTION
Use the previously added utils to get a signal file name that is safe on shared file systems. Previously the name would clash.

Tested simple train and load (don't have a multinode shared fs to actually test that part on):
train: dist-utils-train-1-UExzEF
load: dist-utils-load-2-Uoq35b

See also https://github.com/mosaicml/composer/pull/3485