### PR TITLE
[kushalkodnad/tokenizer-registry] Introduce new registry for tokenizers

### DIFF
--- a/llmfoundry/registry.py
+++ b/llmfoundry/registry.py
@@ -155,6 +155,19 @@ schedulers = create_registry(
     description=_schedulers_description,
 )
 
+_tokenizers_description = (
+    'The tokenizers registry is used to register tokenizers that implement the transformers.PreTrainedTokenizerBase interface. '
+    +
+    'The tokenizer will be passed to the build_dataloader() and build_composer_model() methods in train.py.'
+)
+tokenizers = create_registry(
+    'llmfoundry',
+    'tokenizers',
+    generic_type=Type[PreTrainedTokenizerBase],
+    entry_points=True,
+    description=_tokenizers_description,
+)
+
 _models_description = (
     """The models registry is used to register classes that implement the ComposerModel interface.
 

--- a/llmfoundry/registry.py
+++ b/llmfoundry/registry.py
@@ -396,6 +396,7 @@ __all__ = [
     'optimizers',
     'algorithms',
     'schedulers',
+    'tokenizers',
     'models',
     'dataset_replication_validators',
     'collators',

--- a/llmfoundry/tokenizers/__init__.py
+++ b/llmfoundry/tokenizers/__init__.py
@@ -1,7 +1,10 @@
 # Copyright 2022 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
+from llmfoundry.registry import tokenizers
 from llmfoundry.tokenizers.tiktoken import TiktokenTokenizerWrapper
+
+tokenizers.register('tiktoken', func=TiktokenTokenizerWrapper)
 
 __all__ = [
     'TiktokenTokenizerWrapper',

--- a/llmfoundry/utils/builders.py
+++ b/llmfoundry/utils/builders.py
@@ -506,57 +506,6 @@ def build_tokenizer(
         with dist.local_rank_zero_download_and_wait(signal_file_path):
             pass
 
-    if tokenizer_name.startswith('tiktoken'):
-        tokenizer = TiktokenTokenizerWrapper(**tokenizer_kwargs)
-    else:
-        tokenizer = AutoTokenizer.from_pretrained(
-            tokenizer_name,
-            **tokenizer_kwargs,
-        )
-
-        # HuggingFace does not respect the model_max_length kwarg, and overrides it with
-        # min(kwargs['model_max_length'], original_config['model_max_length']), so we
-        # explicitly set it here
-        tokenizer.model_max_length = tokenizer_kwargs.get(
-            'model_max_length',
-            int(1e30),
-        )
-
-    if not hasattr(tokenizer, 'eos_token') or tokenizer.eos_token is None:
-        raise ValueError(
-            f'The tokenizer {tokenizer_name} must have an eos_token.',
-        )
-
-    if dist.is_available() and dist.is_initialized(
-    ) and dist.get_world_size() > 1:
-        if dist.get_local_rank() == 0:
-            with open(signal_file_path, 'wb') as f:
-                f.write(b'local_rank0_completed_tokenizer_setup')
-
-        dist.barrier()
-
-        if dist.get_local_rank() == 0:
-            os.remove(signal_file_path)
-
-    return tokenizer
-
-
-def build_tokenizer_from_registry(  # TODO: Rename this to ``build_tokenizer`` once approach is approved
-    tokenizer_name: str,
-    tokenizer_kwargs: Dict[str, Any],
-) -> PreTrainedTokenizerBase:
-    """Builds a tokenizer from the registry."""
-    os.environ['TRANSFORMERS_NO_ADVISORY_WARNINGS'] = '1'
-    os.environ['TOKENIZERS_PARALLELISM'] = 'false'
-
-    signal_file_path = f'.node_{dist.get_node_rank()}_local_rank0_completed_tokenizer_setup'
-
-    if dist.is_available() and dist.is_initialized(
-    ) and dist.get_world_size() > 1:
-        # Make sure the tokenizer files are downloaded and cached first by local rank 0
-        with dist.local_rank_zero_download_and_wait(signal_file_path):
-            pass
-
     if tokenizer_name in registry.tokenizers:
         tokenizer = construct_from_registry(
             name=tokenizer_name,

--- a/llmfoundry/utils/builders.py
+++ b/llmfoundry/utils/builders.py
@@ -540,6 +540,15 @@ def build_tokenizer(
 
     return tokenizer
 
+    # return construct_from_registry(
+    #     name=tokenizer_name,
+    #     registry=registry.tokenizers,
+    #     partial_function=True,
+    #     pre_validation_function=PreTrainedTokenizerBase,
+    #     post_validation_function=None,
+    #     kwargs=tokenizer_kwargs,
+    # )
+
 
 def build_icl_evaluators(
     icl_tasks: Union[str, List[Dict[str, Any]]],

--- a/llmfoundry/utils/builders.py
+++ b/llmfoundry/utils/builders.py
@@ -37,7 +37,6 @@ from llmfoundry.callbacks import EvalGauntlet
 from llmfoundry.data.dataloader import build_dataloader
 from llmfoundry.eval.datasets.in_context_learning_evaluation import \
     get_icl_task_dataloader
-from llmfoundry.tokenizers.tiktoken import TiktokenTokenizerWrapper
 from llmfoundry.utils.config_utils import to_dict_container, to_list_container
 from llmfoundry.utils.registry_utils import construct_from_registry
 

--- a/llmfoundry/utils/builders.py
+++ b/llmfoundry/utils/builders.py
@@ -540,14 +540,63 @@ def build_tokenizer(
 
     return tokenizer
 
-    # return construct_from_registry(
-    #     name=tokenizer_name,
-    #     registry=registry.tokenizers,
-    #     partial_function=True,
-    #     pre_validation_function=PreTrainedTokenizerBase,
-    #     post_validation_function=None,
-    #     kwargs=tokenizer_kwargs,
-    # )
+
+def build_tokenizer_from_registry(  # TODO: Rename this to ``build_tokenizer`` once approach is approved
+    tokenizer_name: str,
+    tokenizer_kwargs: Dict[str, Any],
+) -> PreTrainedTokenizerBase:
+    """Builds a tokenizer from the registry."""
+    os.environ['TRANSFORMERS_NO_ADVISORY_WARNINGS'] = '1'
+    os.environ['TOKENIZERS_PARALLELISM'] = 'false'
+
+    signal_file_path = f'.node_{dist.get_node_rank()}_local_rank0_completed_tokenizer_setup'
+
+    if dist.is_available() and dist.is_initialized(
+    ) and dist.get_world_size() > 1:
+        # Make sure the tokenizer files are downloaded and cached first by local rank 0
+        with dist.local_rank_zero_download_and_wait(signal_file_path):
+            pass
+
+    if tokenizer_name in registry.tokenizers:
+        tokenizer = construct_from_registry(
+            name=tokenizer_name,
+            registry=registry.tokenizers,
+            partial_function=True,
+            pre_validation_function=PreTrainedTokenizerBase,
+            post_validation_function=None,
+            kwargs=tokenizer_kwargs,
+        )
+    else:
+        tokenizer = AutoTokenizer.from_pretrained(
+            tokenizer_name,
+            **tokenizer_kwargs,
+        )
+
+        # HuggingFace does not respect the model_max_length kwarg, and overrides it with
+        # min(kwargs['model_max_length'], original_config['model_max_length']), so we
+        # explicitly set it here
+        tokenizer.model_max_length = tokenizer_kwargs.get(
+            'model_max_length',
+            int(1e30),
+        )
+
+    if not hasattr(tokenizer, 'eos_token') or tokenizer.eos_token is None:
+        raise ValueError(
+            f'The tokenizer {tokenizer_name} must have an eos_token.',
+        )
+
+    if dist.is_available() and dist.is_initialized(
+    ) and dist.get_world_size() > 1:
+        if dist.get_local_rank() == 0:
+            with open(signal_file_path, 'wb') as f:
+                f.write(b'local_rank0_completed_tokenizer_setup')
+
+        dist.barrier()
+
+        if dist.get_local_rank() == 0:
+            os.remove(signal_file_path)
+
+    return tokenizer
 
 
 def build_icl_evaluators(

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -24,6 +24,7 @@ def test_expected_registries_exist():
         'loggers',
         'optimizers',
         'schedulers',
+        'tokenizers',
         'callbacks',
         'algorithms',
         'callbacks_with_config',

--- a/tests/tokenizers/test_registry.py
+++ b/tests/tokenizers/test_registry.py
@@ -1,0 +1,63 @@
+# Copyright 2024 MosaicML LLM Foundry authors
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any, Dict, List, Optional
+
+import pytest
+from transformers import BatchEncoding, PreTrainedTokenizer
+
+from llmfoundry.registry import tokenizers
+from llmfoundry.utils import build_tokenizer
+
+
+class DummyTokenizer(PreTrainedTokenizer):
+    """A dummy tokenizer that inherits from ``PreTrainedTokenizer``."""
+
+    def __init__(
+        self,
+        model_name: Optional[str] = 'dummy',
+        **kwargs: Optional[Dict[str, Any]],
+    ):
+        """Dummy constructor that has no real purpose."""
+        super().__init__(
+            model_name=model_name,
+            eos_token='0',
+            pad_token='1',
+            **kwargs,
+        )
+
+    def get_vocab(self) -> Dict[str, int]:
+        return {}
+
+    def tokenize(self, text: str) -> List[str]:
+        return [text]
+
+    def encode(self, text: str) -> List[int]:
+        return [ord(character) for character in text]
+
+    def decode(self, token_ids: List[int]) -> List[str]:
+        return ''.join([chr(token) for token in token_ids])
+
+    def __call__(self, text: str) -> BatchEncoding:
+        raise NotImplementedError()
+
+
+def test_tokenizer_registry():
+    tokenizers.register('dummy', func=DummyTokenizer)
+    tokenizer = build_tokenizer(tokenizer_name='dummy', tokenizer_kwargs={})
+    assert type(tokenizer) == DummyTokenizer
+
+    text = 'Hello World'
+    tokenized = tokenizer.tokenize(text)
+    assert tokenized == ['Hello World']
+
+    encoded = tokenizer.encode(text)
+    assert encoded == [72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100]
+
+    decoded = tokenizer.decode(encoded)
+    assert text == decoded
+
+    with pytest.raises(
+        NotImplementedError,
+    ):  # Test that ``__call__`` method throws NotImplementedError
+        tokenizer(text=text)

--- a/tests/tokenizers/test_registry.py
+++ b/tests/tokenizers/test_registry.py
@@ -35,7 +35,7 @@ class DummyTokenizer(PreTrainedTokenizer):
     def encode(self, text: str) -> List[int]:
         return [ord(character) for character in text]
 
-    def decode(self, token_ids: List[int]) -> List[str]:
+    def decode(self, token_ids: List[int]) -> str:
         return ''.join([chr(token) for token in token_ids])
 
     def __call__(self, text: str) -> BatchEncoding:

--- a/tests/tokenizers/test_registry.py
+++ b/tests/tokenizers/test_registry.py
@@ -1,10 +1,9 @@
 # Copyright 2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
-import pytest
-from transformers import BatchEncoding, PreTrainedTokenizer
+from transformers import PreTrainedTokenizer
 
 from llmfoundry.registry import tokenizers
 from llmfoundry.utils import build_tokenizer
@@ -29,35 +28,8 @@ class DummyTokenizer(PreTrainedTokenizer):
     def get_vocab(self) -> Dict[str, int]:
         return {}
 
-    def tokenize(self, text: str) -> List[str]:
-        return [text]
-
-    def encode(self, text: str) -> List[int]:
-        return [ord(character) for character in text]
-
-    def decode(self, token_ids: List[int]) -> str:
-        return ''.join([chr(token) for token in token_ids])
-
-    def __call__(self, text: str) -> BatchEncoding:
-        raise NotImplementedError()
-
 
 def test_tokenizer_registry():
     tokenizers.register('dummy', func=DummyTokenizer)
     tokenizer = build_tokenizer(tokenizer_name='dummy', tokenizer_kwargs={})
     assert type(tokenizer) == DummyTokenizer
-
-    text = 'Hello World'
-    tokenized = tokenizer.tokenize(text)
-    assert tokenized == ['Hello World']
-
-    encoded = tokenizer.encode(text)
-    assert encoded == [72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100]
-
-    decoded = tokenizer.decode(encoded)
-    assert text == decoded
-
-    with pytest.raises(
-        NotImplementedError,
-    ):  # Test that ``__call__`` method throws NotImplementedError
-        tokenizer(text=text)


### PR DESCRIPTION
# What Does This PR Do?

The purpose of this PR is to introduce a new registry, specifically for tokenizers. This way, in the `llmfoudry/utils/builders.py` `build_tokenizer()` method, we can build a tokenizer from the registry, as long as the tokenizer inherits the `transformers.PreTrainedTokenizerBase` interface. For instance, the existing `TiktokenTokenizerWrapper` in `llmfoundry/tokenizers/tiktoken.py` can be built from this registry, as opposed to using if-else clauses in `build_tokenizer`, which can become tedious if we add support for more tokenizers.

## File-Specific Changes

### `llmfoundry/registry.py`

This is where I created the `tokenizers` registry. See the brief description of the llmfoundry tokenizers registry, defined in `_tokenizers_description`. Then, I followed the `callbacks` registry creation to do the same thing for `tokenizers` when calling `create_registry`.

### `llmfoundry/utils/builders.py`

The main idea is to replace the if-else clause that currently supports "tiktoken". As long as the tokenizer is a sub-class of `transformers.PreTrainedTokenizerBase`, then the tokenizer will be constructed.

### `llmfoundry/tokenizers/__init__.py`

Following the `callbacks` example, the addition to this file shows how to register a `transformers.PreTrainedTokenizerBase` sub-class to the tokenizers registry. Here, I registered the `tiktoken` tokenizer to the tokenizers registry, because it inherits the same interface.
