### PR TITLE
Avoid race condition in convert text to mds script

### DIFF
--- a/llmfoundry/command_utils/data_prep/convert_text_to_mds.py
+++ b/llmfoundry/command_utils/data_prep/convert_text_to_mds.py
@@ -22,7 +22,6 @@ from tqdm import tqdm
 from transformers import AutoTokenizer, PreTrainedTokenizerBase
 
 from llmfoundry.data.data import AbstractConcatTokensDataset
-from llmfoundry.utils.builders import build_tokenizer
 from llmfoundry.utils.data_prep_utils import (
     DownloadingIterable,
     download_file,

--- a/llmfoundry/command_utils/data_prep/convert_text_to_mds.py
+++ b/llmfoundry/command_utils/data_prep/convert_text_to_mds.py
@@ -395,6 +395,8 @@ def convert_text_to_mds(
         reprocess (bool): Whether to always reprocess the given folder of text files
         trust_remote_code (bool): If true, allows custom code to be executed to load the tokenizer
     """
+    # Load the tokenizer once on the main process so that the files are cached to avoid race conditions
+    # in the Hugging Face load code
     AutoTokenizer.from_pretrained(tokenizer_name, trust_remote_code=trust_remote_code)
 
     is_remote_output = is_remote_path(output_folder)

--- a/llmfoundry/command_utils/data_prep/convert_text_to_mds.py
+++ b/llmfoundry/command_utils/data_prep/convert_text_to_mds.py
@@ -21,8 +21,8 @@ from streaming import MDSWriter
 from tqdm import tqdm
 from transformers import AutoTokenizer, PreTrainedTokenizerBase
 
-from llmfoundry.utils.builders import build_tokenizer
 from llmfoundry.data.data import AbstractConcatTokensDataset
+from llmfoundry.utils.builders import build_tokenizer
 from llmfoundry.utils.data_prep_utils import (
     DownloadingIterable,
     download_file,
@@ -397,7 +397,9 @@ def convert_text_to_mds(
     """
     # Load the tokenizer once on the main process so that the files are cached to avoid race conditions
     # in the Hugging Face load code
-    AutoTokenizer.from_pretrained(tokenizer_name, trust_remote_code=trust_remote_code)
+    AutoTokenizer.from_pretrained(
+        tokenizer_name, trust_remote_code=trust_remote_code
+    )
 
     is_remote_output = is_remote_path(output_folder)
     log.info(f'Output is remote: {is_remote_output}')

--- a/llmfoundry/command_utils/data_prep/convert_text_to_mds.py
+++ b/llmfoundry/command_utils/data_prep/convert_text_to_mds.py
@@ -395,10 +395,7 @@ def convert_text_to_mds(
         reprocess (bool): Whether to always reprocess the given folder of text files
         trust_remote_code (bool): If true, allows custom code to be executed to load the tokenizer
     """
-    build_tokenizer(
-        tokenizer_name,
-        tokenizer_kwargs={'trust_remote_code': trust_remote_code},
-    )
+    AutoTokenizer.from_pretrained(tokenizer_name, trust_remote_code=trust_remote_code)
 
     is_remote_output = is_remote_path(output_folder)
     log.info(f'Output is remote: {is_remote_output}')

--- a/llmfoundry/command_utils/data_prep/convert_text_to_mds.py
+++ b/llmfoundry/command_utils/data_prep/convert_text_to_mds.py
@@ -21,6 +21,7 @@ from streaming import MDSWriter
 from tqdm import tqdm
 from transformers import AutoTokenizer, PreTrainedTokenizerBase
 
+from llmfoundry.utils.builders import build_tokenizer
 from llmfoundry.data.data import AbstractConcatTokensDataset
 from llmfoundry.utils.data_prep_utils import (
     DownloadingIterable,
@@ -394,6 +395,11 @@ def convert_text_to_mds(
         reprocess (bool): Whether to always reprocess the given folder of text files
         trust_remote_code (bool): If true, allows custom code to be executed to load the tokenizer
     """
+    build_tokenizer(
+        tokenizer_name,
+        tokenizer_kwargs={'trust_remote_code': trust_remote_code},
+    )
+
     is_remote_output = is_remote_path(output_folder)
     log.info(f'Output is remote: {is_remote_output}')
 

--- a/llmfoundry/command_utils/data_prep/convert_text_to_mds.py
+++ b/llmfoundry/command_utils/data_prep/convert_text_to_mds.py
@@ -398,7 +398,8 @@ def convert_text_to_mds(
     # Load the tokenizer once on the main process so that the files are cached to avoid race conditions
     # in the Hugging Face load code
     AutoTokenizer.from_pretrained(
-        tokenizer_name, trust_remote_code=trust_remote_code
+        tokenizer_name,
+        trust_remote_code=trust_remote_code,
     )
 
     is_remote_output = is_remote_path(output_folder)

--- a/llmfoundry/utils/builders.py
+++ b/llmfoundry/utils/builders.py
@@ -505,6 +505,11 @@ def build_tokenizer(
         with dist.local_rank_zero_download_and_wait(signal_file_path):
             pass
 
+    names = dist.all_gather_object(signal_file_path)
+    print("+"*30)
+    print(names)
+    print("+"*30)
+
     if tokenizer_name in registry.tokenizers:
         tokenizer = construct_from_registry(
             name=tokenizer_name,

--- a/llmfoundry/utils/builders.py
+++ b/llmfoundry/utils/builders.py
@@ -499,16 +499,16 @@ def build_tokenizer(
 
     signal_file_path = dist.get_node_signal_file_name()
 
+    names = dist.all_gather_object(signal_file_path)
+    print("+"*30)
+    print(names)
+    print("+"*30)
+
     if dist.is_available() and dist.is_initialized(
     ) and dist.get_world_size() > 1:
         # Make sure the tokenizer files are downloaded and cached first by local rank 0
         with dist.local_rank_zero_download_and_wait(signal_file_path):
             pass
-
-    names = dist.all_gather_object(signal_file_path)
-    print("+"*30)
-    print(names)
-    print("+"*30)
 
     if tokenizer_name in registry.tokenizers:
         tokenizer = construct_from_registry(

--- a/llmfoundry/utils/builders.py
+++ b/llmfoundry/utils/builders.py
@@ -499,11 +499,6 @@ def build_tokenizer(
 
     signal_file_path = f'.node_{dist.get_node_rank()}_local_rank0_completed_tokenizer_setup'
 
-    names = dist.all_gather_object(signal_file_path)
-    print("+"*30)
-    print(names)
-    print("+"*30)
-
     if dist.is_available() and dist.is_initialized(
     ) and dist.get_world_size() > 1:
         # Make sure the tokenizer files are downloaded and cached first by local rank 0


### PR DESCRIPTION
Loading tokenizers from hf also has a race condition. This PR should avoid it by prepopulating the cache from the main process.

Fails before: `debug-race-9-CBEU3C`
Succeeds after: `debug-race-12-OaxlPc`