### PR TITLE
Revert "Allow for multiple workers when autopacking (#1375)"

### DIFF
--- a/llmfoundry/data/packing.py
+++ b/llmfoundry/data/packing.py
@@ -424,6 +424,8 @@ def profile_packing(
     dataloader_cfg = copy.deepcopy(dataloader_cfg)
     dataloader_cfg.update({
         'drop_last': False,
+        'num_workers': 0,
+        'prefetch_factor': None,
         'persistent_workers': False,
     })
     dataloader_cfg['dataset']['packing_ratio'] = 1.0


### PR DESCRIPTION
This reverts commit d812f20c5472f771f06a9dd561a31d3a88ed26bf.

Resulted in hangs during tokenization. Not totally root caused, reverting for now.