### PR TITLE
Dtensor oom

### DIFF
--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -470,33 +470,6 @@ class HuggingFaceCheckpointer(Callback):
         #     return state_dict
 
         # Add hook to move tensors to cpu to avoid CUDA OOM
-        # def tensor_hook(
-        #     module: nn.Module,
-        #     state_dict: Dict[str, Any],
-        #     prefix: str,
-        #     *args: Any,
-        # ) -> Dict[str, Any]:
-        #     dtensor_fqns = []
-        #     for fqn in state_dict.keys():
-        #         tensor = state_dict[fqn]
-        #         if isinstance(tensor, DTensor):
-        #             dtensor_fqns.append(fqn)
-        #             tensor = tensor.full_tensor()  # type: ignore
-        #             if dist.get_global_rank() == 0:
-        #                 # Offload any DTensors to CPU
-        #                 if cpu_offload:
-        #                     tensor = tensor.cpu()
-        #                     tensor = tensor.to(dtype=self.dtype)
-        #                 state_dict[fqn] = tensor
-        #             else:
-        #                 state_dict[fqn] = None
-        #         elif isinstance(tensor, torch.Tensor):
-        #             state_dict[fqn] = tensor.to(dtype=self.dtype)
-        #         del tensor
-        #     if dist.get_global_rank() != 0:
-        #         state_dict = {}
-        #     return state_dict
-    
         def tensor_hook(
             module: nn.Module,
             state_dict: Dict[str, Any],
@@ -510,18 +483,45 @@ class HuggingFaceCheckpointer(Callback):
                     dtensor_fqns.append(fqn)
                     tensor = tensor.full_tensor()  # type: ignore
                     if dist.get_global_rank() == 0:
+                        # Offload any DTensors to CPU
                         if cpu_offload:
                             tensor = tensor.cpu()
+                            tensor = tensor.to(dtype=self.dtype)
                         state_dict[fqn] = tensor
+                    else:
+                        state_dict[fqn] = None
+                elif isinstance(tensor, torch.Tensor):
+                    state_dict[fqn] = tensor.to(dtype=self.dtype)
+                del tensor
             if dist.get_global_rank() != 0:
-                for fqn in dtensor_fqns:
-                    del state_dict[fqn]
-
-            for fqn in state_dict.keys():
-                if isinstance(state_dict[fqn], torch.Tensor):
-                    state_dict[fqn] = state_dict[fqn].to(dtype=self.dtype)
-
+                state_dict = {}
             return state_dict
+    
+        # def tensor_hook(
+        #     module: nn.Module,
+        #     state_dict: Dict[str, Any],
+        #     prefix: str,
+        #     *args: Any,
+        # ) -> Dict[str, Any]:
+        #     dtensor_fqns = []
+        #     for fqn in state_dict.keys():
+        #         tensor = state_dict[fqn]
+        #         if isinstance(tensor, DTensor):
+        #             dtensor_fqns.append(fqn)
+        #             tensor = tensor.full_tensor()  # type: ignore
+        #             if dist.get_global_rank() == 0:
+        #                 if cpu_offload:
+        #                     tensor = tensor.cpu()
+        #                 state_dict[fqn] = tensor
+        #     if dist.get_global_rank() != 0:
+        #         for fqn in dtensor_fqns:
+        #             del state_dict[fqn]
+
+        #     for fqn in state_dict.keys():
+        #         if isinstance(state_dict[fqn], torch.Tensor):
+        #             state_dict[fqn] = state_dict[fqn].to(dtype=self.dtype)
+
+        #     return state_dict
 
         hooks = []
         for _, module in state_dict_model.named_modules():

--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -465,8 +465,7 @@ class HuggingFaceCheckpointer(Callback):
 
         hooks = []
         for _, module in state_dict_model.named_modules():
-            if isinstance(module, FSDP):
-                hooks.append(module._register_state_dict_hook(tensor_hook),)
+            hooks.append(module._register_state_dict_hook(tensor_hook),)
 
         state_dict = get_model_state_dict(
             state_dict_model,

--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -483,8 +483,6 @@ class HuggingFaceCheckpointer(Callback):
             if dist.get_global_rank() != 0:
                 state_dict = {}
             return state_dict
-        
-        assert False
 
         hooks = []
         for _, module in state_dict_model.named_modules():

--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -483,6 +483,8 @@ class HuggingFaceCheckpointer(Callback):
             if dist.get_global_rank() != 0:
                 state_dict = {}
             return state_dict
+        
+        assert False
 
         hooks = []
         for _, module in state_dict_model.named_modules():

--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -487,19 +487,20 @@ class HuggingFaceCheckpointer(Callback):
                         if cpu_offload:
                             tensor = tensor.cpu()
                         state_dict[fqn] = tensor
+                    else:
+                        state_dict[fqn] = None
                 # Convert the state dict to the requested precision
-                if isinstance(tensor, torch.Tensor):
-                    state_dict[fqn] = tensor.to(dtype=self.dtype)
+                # if isinstance(tensor, torch.Tensor):
+                #     state_dict[fqn] = tensor.to(dtype=self.dtype)
                 del tensor
             if dist.get_global_rank() != 0:
-                for fqn in dtensor_fqns:
-                    del state_dict[fqn]
+                state_dict = {}
             return state_dict
 
         hooks = []
         for _, module in state_dict_model.named_modules():
-            # if isinstance(module, FSDP):
-            hooks.append(module._register_state_dict_hook(tensor_hook),)
+            if isinstance(module, FSDP):
+                hooks.append(module._register_state_dict_hook(tensor_hook),)
 
 
         state_dict = get_model_state_dict(

--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -435,26 +435,26 @@ class HuggingFaceCheckpointer(Callback):
 
         cpu_offload = True
 
-        def dtensor_to_tensor_hook(
-            module: nn.Module,
-            state_dict: Dict[str, Any],
-            prefix: str,
-            *args: Any,
-        ) -> Dict[str, Any]:
-            dtensor_fqns = []
-            for fqn in state_dict.keys():
-                tensor = state_dict[fqn]
-                if isinstance(tensor, DTensor):
-                    dtensor_fqns.append(fqn)
-                    tensor = tensor.full_tensor()  # type: ignore
-                    if dist.get_global_rank() == 0:
-                        if cpu_offload:
-                            tensor = tensor.cpu()
-                        state_dict[fqn] = tensor
-            if dist.get_global_rank() != 0:
-                for fqn in dtensor_fqns:
-                    del state_dict[fqn]
-            return state_dict
+        # def dtensor_to_tensor_hook(
+        #     module: nn.Module,
+        #     state_dict: Dict[str, Any],
+        #     prefix: str,
+        #     *args: Any,
+        # ) -> Dict[str, Any]:
+        #     dtensor_fqns = []
+        #     for fqn in state_dict.keys():
+        #         tensor = state_dict[fqn]
+        #         if isinstance(tensor, DTensor):
+        #             dtensor_fqns.append(fqn)
+        #             tensor = tensor.full_tensor()  # type: ignore
+        #             if dist.get_global_rank() == 0:
+        #                 if cpu_offload:
+        #                     tensor = tensor.cpu()
+        #                 state_dict[fqn] = tensor
+        #     if dist.get_global_rank() != 0:
+        #         for fqn in dtensor_fqns:
+        #             del state_dict[fqn]
+        #     return state_dict
         
         # def tensor_dtype_hook(
         #     module: nn.Module,
@@ -469,38 +469,38 @@ class HuggingFaceCheckpointer(Callback):
         #         del tensor
         #     return state_dict
 
-        # # Add hook to move tensors to cpu to avoid CUDA OOM
-        # def tensor_hook(
-        #     module: nn.Module,
-        #     state_dict: Dict[str, Any],
-        #     prefix: str,
-        #     *args: Any,
-        # ) -> Dict[str, Any]:
-        #     dtensor_fqns = []
-        #     for fqn in state_dict.keys():
-        #         tensor = state_dict[fqn]
-        #         if isinstance(tensor, DTensor):
-        #             dtensor_fqns.append(fqn)
-        #             tensor = tensor.full_tensor()  # type: ignore
-        #             if dist.get_global_rank() == 0:
-        #                 # Offload any DTensors to CPU
-        #                 if cpu_offload:
-        #                     tensor = tensor.cpu()
-        #                 state_dict[fqn] = tensor
-        #             else:
-        #                 state_dict[fqn] = None
-        #         # Convert the state dict to the requested precision
-        #         if isinstance(tensor, torch.Tensor):
-        #             state_dict[fqn] = tensor.to(dtype=self.dtype)
-        #         del tensor
-        #     if dist.get_global_rank() != 0:
-        #         state_dict = {}
-        #     return state_dict
+        # Add hook to move tensors to cpu to avoid CUDA OOM
+        def tensor_hook(
+            module: nn.Module,
+            state_dict: Dict[str, Any],
+            prefix: str,
+            *args: Any,
+        ) -> Dict[str, Any]:
+            dtensor_fqns = []
+            for fqn in state_dict.keys():
+                tensor = state_dict[fqn]
+                if isinstance(tensor, DTensor):
+                    dtensor_fqns.append(fqn)
+                    tensor = tensor.full_tensor()  # type: ignore
+                    if dist.get_global_rank() == 0:
+                        # Offload any DTensors to CPU
+                        if cpu_offload:
+                            tensor = tensor.cpu()
+                        state_dict[fqn] = tensor
+                # Convert the state dict to the requested precision
+                if isinstance(tensor, torch.Tensor):
+                    state_dict[fqn] = tensor.to(dtype=self.dtype)
+                del tensor
+            if dist.get_global_rank() != 0:
+                for fqn in dtensor_fqns:
+                    del state_dict[fqn]
+            return state_dict
 
         hooks = []
         for _, module in state_dict_model.named_modules():
-            if isinstance(module, FSDP):
-                hooks.append(module._register_state_dict_hook(dtensor_to_tensor_hook),)
+            # if isinstance(module, FSDP):
+            hooks.append(module._register_state_dict_hook(tensor_hook),)
+
 
         state_dict = get_model_state_dict(
             state_dict_model,


### PR DESCRIPTION
Previously we were accidentally keeping extra copies of dtensors in GPU memory, which would cause an OOM. This bug was introduced in https://github.com/mosaicml/llm-foundry/pull/1384. This PR fixes it by not creating extra copies of the full tensor on GPU.

Manual tests:
- [Done] Tested a previous run with dtensors that would OOM
- [Done] Tested a normal run with fp32 and bf16 and confirmed checkpoint sizes were correct to make sure the dtype conversion is still getting applied (there are also unit tests for this)