### PR TITLE
Condition the meta initialization for hf_causal_lm on pretrain

### DIFF
--- a/llmfoundry/models/hf/hf_causal_lm.py
+++ b/llmfoundry/models/hf/hf_causal_lm.py
@@ -284,7 +284,7 @@ class ComposerHFCausalLM(HuggingFaceModelWithFSDP):
         # the different processes. To avoid this contention, we first create the model (on meta device) on local rank
         # zero. This will set up the transformers model cache and avoid the future contention.
         if dist.get_local_rank() == 0:
-            if os.path.isdir(pretrained_model_name_or_path):
+            if pretrained and os.path.isdir(pretrained_model_name_or_path):
                 with init_empty_weights(include_buffers=False):
                     with warnings.catch_warnings():
                         warnings.simplefilter('ignore', UserWarning)


### PR DESCRIPTION
Before this change, there is an error if the pretrained_model_name_or_path does not have model weights (like safetensors, etc.)

After this change, we can pass in a pretrained_model_name_or_path that only has config files if you are not initializing the model with pretrained weights. 

Manually tested in interactive via:
```
huggingface-cli download meta-llama/Meta-Llama-3-8B config.json --local-dir /local-model/
```
and setting `pretrained_model_name_or_path` to `/local-model`