### PR TITLE
Propagate `name_or_path` through HF Checkpointer

### DIFF
--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -517,6 +517,7 @@ class HuggingFaceCheckpointer(Callback):
                     new_model_instance.generation_config.update(
                         **original_model.generation_config.to_dict(),
                     )
+                new_model_instance.name_or_path = original_model.name_or_path
 
             # Then load the state dict in with "assign" so that the state dict
             # is loaded properly even though the model is initially on meta device.


### PR DESCRIPTION
Makes sure to propagate model `name_or_path` through HF checkpointer (similar to how we do for generation config).

Note that since [PretrainedConfig](https://huggingface.co/docs/transformers/v4.43.3/en/main_classes/configuration#transformers.PretrainedConfig) always has the attr `name_or_path`, we don't need to check `hasattr`. All instances of PreTrainedModel will have `name_or_path` (which defaults to "").

Note that if the `pretrained_model_name_or_path` is a local path then `name_or_path` will also be a local path. And so when saving out LoRA adapters, for example, the adapter_config.json will have `base_model_name_or_path` as the local path. This PR does not solve this problem. IMO we should add a new optional arg to ComposerHFCausalLM that's the true model name and propagate that through model transforms & HF checkpointer instead of `name_or_path`.