### PR TITLE
Log original config

### DIFF
--- a/llmfoundry/utils/config_utils.py
+++ b/llmfoundry/utils/config_utils.py
@@ -341,8 +341,6 @@ def make_dataclass_and_log_config(
         transforms,
     )
 
-    logged_cfg.update(unstructured_config, merge=True)
-
     arg_config_keys = set(unstructured_config.keys())
     extraneous_keys = set.difference(arg_config_keys, dataclass_fields)
 


### PR DESCRIPTION
Follow-up to #1351. This PR changes the logging behavior to log the originally submitted config. The current behavior applies transformations, then merges them into the original config. Because of the merging, the logged config might not be a valid config, making reproducible runs harder.