### PR TITLE
Remove type ignore

### DIFF
--- a/llmfoundry/utils/builders.py
+++ b/llmfoundry/utils/builders.py
@@ -127,8 +127,7 @@ def build_eval_loaders(
             # Load the eval data to fail fast. metrics will get added
             # later in add_metrics_to_eval_loaders, after the model is loaded
             metric_names=[],
-            # TODO: Fix type in Composer
-            device_eval_microbatch_size=device_eval_batch_size,  # type: ignore
+            device_eval_microbatch_size=device_eval_batch_size,
         )
         evaluators.append(eval_loader)
     return evaluators


### PR DESCRIPTION
The typing issue has been fixed in composer, so the type ignore is no longer needed.