### PR TITLE
Add transforms to logged config

### DIFF
--- a/llmfoundry/utils/config_utils.py
+++ b/llmfoundry/utils/config_utils.py
@@ -332,14 +332,14 @@ def make_dataclass_and_log_config(
                 'icl_tasks must be specified in the config',
             )
 
-    # Create copy of config for logging
-    logged_cfg: Dict[str, Any] = copy.deepcopy(unstructured_config)
-
     # Apply transforms to the unstructured config before constructing dataclass
     unstructured_config = apply_transforms_to_config(
         unstructured_config,
         transforms,
     )
+
+    # Create copy of config for logging
+    logged_cfg: Dict[str, Any] = copy.deepcopy(unstructured_config)
 
     arg_config_keys = set(unstructured_config.keys())
     extraneous_keys = set.difference(arg_config_keys, dataclass_fields)


### PR DESCRIPTION
Uses the transformed version of the training config as the logged config. This is because we infer values like device_train_batch_size during transforms. The logged config is later used in callbacks like curriculum learning which should have access to all the [data in TrainConfig](https://github.com/mosaicml/llm-foundry/blob/38dcf1e6e25a05dbd4275402f168bac299b45d6d/llmfoundry/utils/config_utils.py#L95).

Manual run to test that logged_cfg matches the train_cfg values from transforms and curriculum learning callback works.