### PR TITLE
Raise error when not enough data when converting text to MDS 

### DIFF
--- a/llmfoundry/command_utils/data_prep/convert_text_to_mds.py
+++ b/llmfoundry/command_utils/data_prep/convert_text_to_mds.py
@@ -29,6 +29,7 @@ from llmfoundry.utils.data_prep_utils import (
     merge_shard_groups,
 )
 from llmfoundry.utils.exceptions import (
+    DatasetTooSmallError,
     InputFolderMissingDataError,
     OutputFolderNotEmptyError,
 )
@@ -472,9 +473,7 @@ def convert_text_to_mds(
     index_path = os.path.join(local_output_folder, 'index.json')
     with open(index_path, 'r') as index_file:
         if not json.load(index_file)['shards']:
-            raise ValueError(
-                'Input data was too small, no shards written to output folder.',
-            )
+            raise DatasetTooSmallError(input_folder)
 
     # Write a done file with the args and object names
     write_done_file(local_output_folder, args_str, object_names)

--- a/llmfoundry/command_utils/data_prep/convert_text_to_mds.py
+++ b/llmfoundry/command_utils/data_prep/convert_text_to_mds.py
@@ -473,7 +473,7 @@ def convert_text_to_mds(
     index_path = os.path.join(local_output_folder, 'index.json')
     with open(index_path, 'r') as index_file:
         if not json.load(index_file)['shards']:
-            raise DatasetTooSmallError(input_folder)
+            raise DatasetTooSmallError()
 
     # Write a done file with the args and object names
     write_done_file(local_output_folder, args_str, object_names)

--- a/llmfoundry/command_utils/data_prep/convert_text_to_mds.py
+++ b/llmfoundry/command_utils/data_prep/convert_text_to_mds.py
@@ -1,6 +1,7 @@
 # Copyright 2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 import logging
 import math
 import os
@@ -467,6 +468,11 @@ def convert_text_to_mds(
             compression,
             trust_remote_code,
         )
+
+    index_path = os.path.join(local_output_folder, 'index.json')
+    with open(index_path, 'r') as index_file:
+        if not json.load(index_file)['shards']:
+            raise ValueError('Input data was too small, no shards written to output folder.')
 
     # Write a done file with the args and object names
     write_done_file(local_output_folder, args_str, object_names)

--- a/llmfoundry/command_utils/data_prep/convert_text_to_mds.py
+++ b/llmfoundry/command_utils/data_prep/convert_text_to_mds.py
@@ -472,7 +472,9 @@ def convert_text_to_mds(
     index_path = os.path.join(local_output_folder, 'index.json')
     with open(index_path, 'r') as index_file:
         if not json.load(index_file)['shards']:
-            raise ValueError('Input data was too small, no shards written to output folder.')
+            raise ValueError(
+                'Input data was too small, no shards written to output folder.'
+            )
 
     # Write a done file with the args and object names
     write_done_file(local_output_folder, args_str, object_names)

--- a/llmfoundry/command_utils/data_prep/convert_text_to_mds.py
+++ b/llmfoundry/command_utils/data_prep/convert_text_to_mds.py
@@ -473,7 +473,7 @@ def convert_text_to_mds(
     with open(index_path, 'r') as index_file:
         if not json.load(index_file)['shards']:
             raise ValueError(
-                'Input data was too small, no shards written to output folder.'
+                'Input data was too small, no shards written to output folder.',
             )
 
     # Write a done file with the args and object names

--- a/llmfoundry/utils/exceptions.py
+++ b/llmfoundry/utils/exceptions.py
@@ -352,9 +352,9 @@ class MisconfiguredHfDatasetError(UserError):
 class DatasetTooSmallError(UserError):
     """Error thrown when the dataset is too small to be processed."""
 
-    def __init__(self, dataset_path: str) -> None:
-        message = f'Your dataset in {dataset_path} is too small to be converted to MDS.'
-        super().__init__(message, dataset_path=dataset_path)
+    def __init__(self) -> None:
+        message = f'Your dataset is too small to be converted to MDS.'
+        super().__init__(message)
 
 
 class RunTimeoutError(InternalError):

--- a/llmfoundry/utils/exceptions.py
+++ b/llmfoundry/utils/exceptions.py
@@ -353,7 +353,7 @@ class DatasetTooSmallError(UserError):
     """Error thrown when the dataset is too small to be processed."""
 
     def __init__(self) -> None:
-        message = f'Your dataset is too small to be converted to MDS.'
+        message = f'Your dataset is too small and produced no complete samples during preprocessing. Please provide more data.'
         super().__init__(message)
 
 

--- a/llmfoundry/utils/exceptions.py
+++ b/llmfoundry/utils/exceptions.py
@@ -28,6 +28,7 @@ __all__ = [
     'InputFolderMissingDataError',
     'OutputFolderNotEmptyError',
     'MisconfiguredHfDatasetError',
+    'DatasetTooSmallError',
     'RunTimeoutError',
 ]
 
@@ -346,6 +347,14 @@ class MisconfiguredHfDatasetError(UserError):
         message = f'Your dataset (name={dataset_name}, split={split}) is misconfigured. ' + \
             'Please check your dataset format and make sure you can load your dataset locally.'
         super().__init__(message, dataset_name=dataset_name, split=split)
+
+
+class DatasetTooSmallError(UserError):
+    """Error thrown when the dataset is too small to be processed."""
+
+    def __init__(self, dataset_path: str) -> None:
+        message = f'Your dataset in {dataset_path} is too small to be converted to MDS.'
+        super().__init__(message, dataset_path=dataset_path)
 
 
 class RunTimeoutError(InternalError):

--- a/tests/a_scripts/data_prep/test_convert_text_to_mds.py
+++ b/tests/a_scripts/data_prep/test_convert_text_to_mds.py
@@ -22,6 +22,7 @@ from llmfoundry.command_utils.data_prep.convert_text_to_mds import (
     write_done_file,
 )
 from llmfoundry.utils.exceptions import (
+    DatasetTooSmallError,
     InputFolderMissingDataError,
     OutputFolderNotEmptyError,
 )
@@ -272,10 +273,7 @@ def test_dataset_too_small(tmp_path: pathlib.Path):
     os.makedirs(input_folder, exist_ok=True)
     with open(input_folder / 'test.txt', 'w') as f:
         f.write('a')
-    with pytest.raises(
-        ValueError,
-        match='Input data was too small, no shards written to output folder.',
-    ):
+    with pytest.raises(DatasetTooSmallError):
         convert_text_to_mds(
             tokenizer_name='mosaicml/mpt-7b',
             output_folder=str(tmp_path / 'output'),

--- a/tests/a_scripts/data_prep/test_convert_text_to_mds.py
+++ b/tests/a_scripts/data_prep/test_convert_text_to_mds.py
@@ -267,6 +267,29 @@ def test_input_folder_not_exist(tmp_path: pathlib.Path):
         )
 
 
+
+def test_dataset_too_small(tmp_path: pathlib.Path):
+    input_folder = tmp_path / 'input'
+    os.makedirs(input_folder, exist_ok=True)
+    with open(input_folder / 'test.txt', 'w') as f:
+        f.write('a')
+    with pytest.raises(ValueError, match='Input data was too small, no shards written to output folder.'):
+        convert_text_to_mds(
+            tokenizer_name='mosaicml/mpt-7b',
+            output_folder=str(tmp_path / 'output'),
+            input_folder=str(input_folder),
+            concat_tokens=2048,
+            eos_text='',
+            bos_text='',
+            no_wrap=False,
+            compression='zstd',
+            processes=1,
+            args_str='Namespace()',
+            reprocess=False,
+            trust_remote_code=False,
+        )
+
+
 def test_is_already_processed(tmp_path: pathlib.Path):
     tmp_path_str = str(tmp_path)
     args_str = 'Namespace(x = 5)'

--- a/tests/a_scripts/data_prep/test_convert_text_to_mds.py
+++ b/tests/a_scripts/data_prep/test_convert_text_to_mds.py
@@ -274,7 +274,7 @@ def test_dataset_too_small(tmp_path: pathlib.Path):
         f.write('a')
     with pytest.raises(
         ValueError,
-        match='Input data was too small, no shards written to output folder.'
+        match='Input data was too small, no shards written to output folder.',
     ):
         convert_text_to_mds(
             tokenizer_name='mosaicml/mpt-7b',

--- a/tests/a_scripts/data_prep/test_convert_text_to_mds.py
+++ b/tests/a_scripts/data_prep/test_convert_text_to_mds.py
@@ -267,13 +267,15 @@ def test_input_folder_not_exist(tmp_path: pathlib.Path):
         )
 
 
-
 def test_dataset_too_small(tmp_path: pathlib.Path):
     input_folder = tmp_path / 'input'
     os.makedirs(input_folder, exist_ok=True)
     with open(input_folder / 'test.txt', 'w') as f:
         f.write('a')
-    with pytest.raises(ValueError, match='Input data was too small, no shards written to output folder.'):
+    with pytest.raises(
+        ValueError,
+        match='Input data was too small, no shards written to output folder.'
+    ):
         convert_text_to_mds(
             tokenizer_name='mosaicml/mpt-7b',
             output_folder=str(tmp_path / 'output'),


### PR DESCRIPTION
In response to https://databricks.atlassian.net/browse/MCLOUD-4727, where users were seeing that if they didn't have enough data, no MDS shards would be made, but no error is thrown until much later.