### PR TITLE
Use the pretrained generation config if it exists for HF models

### DIFF
--- a/llmfoundry/models/hf/hf_causal_lm.py
+++ b/llmfoundry/models/hf/hf_causal_lm.py
@@ -233,7 +233,7 @@ class ComposerHFCausalLM(HuggingFaceModelWithFSDP):
 
         # Hugging Face copies the modules into the
         # transformers modules cache. On particular systems, this operation seems to cause contention between
-        # the different processes. To avoid this contention, we first create the config on local rank
+        # the different processes. To avoid this contention, we first create the config and generation config on local rank
         # zero. This will set up the transformers module cache and avoid the future contention.
         if dist.get_local_rank() == 0:
             AutoConfig.from_pretrained(
@@ -244,6 +244,13 @@ class ComposerHFCausalLM(HuggingFaceModelWithFSDP):
                 use_cache=
                 False,  # Necessary due to https://github.com/huggingface/transformers/issues/28056
             )
+            try:
+                GenerationConfig.from_pretrained(
+                    pretrained_model_name_or_path,
+                    use_auth_token=use_auth_token,
+                )
+            except OSError:
+                pass
 
         dist.barrier()
 

--- a/tests/models/hf/test_hf_config.py
+++ b/tests/models/hf/test_hf_config.py
@@ -292,7 +292,7 @@ def test_use_flash():
 
 def test_generation_config(tmp_path: Path):
     # Create a small llama model to edit and save.
-    config = AutoConfig.from_pretrained('meta-llama/Llama-2-7b-hf')
+    config = AutoConfig.from_pretrained('codellama/CodeLlama-7b-hf')
     set_config_overrides(
         config,
         config_overrides={


### PR DESCRIPTION
If you instantiate a model with from_config, the generation config is obtained via `GenerationConfig.from_model_config(model_config)`. This causes models that are not pretrained to not use the correct generation config. 

To address this, we always set the generation config to be the generation config obtained from `pretrained_model_name_or_path` if the generation config exists.