### PR TITLE
Enabled generalizing build_inner_model in ComposerHFCausalLM

### DIFF
--- a/llmfoundry/models/hf/hf_causal_lm.py
+++ b/llmfoundry/models/hf/hf_causal_lm.py
@@ -234,10 +234,13 @@ class ComposerHFCausalLM(HuggingFaceModelWithFSDP):
                 + 'Please `pip install llm-foundry[gpu]`.',
             )
 
-        assert hasattr(
-            model_cls,
-            'from_pretrained',
-        ), 'HF Model class is not supported, check arguments to function call!'
+        if not (
+            hasattr(model_cls, 'from_pretrained') and
+            hasattr(model_cls, 'from_config')
+        ):
+            raise AttributeError(
+                f'{model_cls=} has missing `from_pretrained` and `from_config` support.',
+            )
 
         # Hugging Face copies the modules into the
         # transformers modules cache. On particular systems, this operation seems to cause contention between

--- a/llmfoundry/models/hf/hf_causal_lm.py
+++ b/llmfoundry/models/hf/hf_causal_lm.py
@@ -24,6 +24,7 @@ from transformers import (
     AutoConfig,
     AutoModelForCausalLM,
     GenerationConfig,
+    PretrainedConfig,
     PreTrainedModel,
     PreTrainedTokenizerBase,
 )
@@ -194,8 +195,8 @@ class ComposerHFCausalLM(HuggingFaceModelWithFSDP):
         config_overrides: Dict[str, Any],
         load_in_8bit: bool,
         pretrained: bool,
-        config_fn: Optional[Callable] = AutoConfig,
-        model_fn: Optional[Callable] = AutoModelForCausalLM,
+        config_fn: Optional[PretrainedConfig] = AutoConfig,
+        model_fn: Optional[PreTrainedModel] = AutoModelForCausalLM,
         prepare_for_fsdp: bool = False,
     ) -> Union[PreTrainedModel, 'PeftModel']:
         """Builds the inner model for the ComposerHFCausalLM.
@@ -210,7 +211,9 @@ class ComposerHFCausalLM(HuggingFaceModelWithFSDP):
             config_overrides (Dict[str, Any]): The configuration overrides.
             load_in_8bit (bool): Whether to load in 8-bit.
             pretrained (bool): Whether the model is pretrained.
-            prepare_for_fsdp (bool, optional): Whether to prepare the model for FSDP wrapping. Default: False.
+            config_fn (PretrainedConfig): HF class for configs. Default: ``AutoConfig``.
+            model_fn (PreTrainedModel): HF class for models. Default: ``AutoModelForCausalLM``.
+            prepare_for_fsdp (bool, optional): Whether to prepare the model for FSDP wrapping. Default: ``False``.
 
         Returns:
             Union[PreTrainedModel, 'PeftModel']: The built inner model.

--- a/llmfoundry/models/hf/hf_causal_lm.py
+++ b/llmfoundry/models/hf/hf_causal_lm.py
@@ -13,7 +13,6 @@ from typing import (
     List,
     Optional,
     Tuple,
-    Type,
     Union,
 )
 
@@ -27,6 +26,7 @@ from transformers import (
     PreTrainedModel,
     PreTrainedTokenizerBase,
 )
+from transformers.models.auto.auto_factory import _BaseAutoModelClass
 
 from llmfoundry.metrics import (
     DEFAULT_CAUSAL_LM_EVAL_METRICS,
@@ -194,7 +194,8 @@ class ComposerHFCausalLM(HuggingFaceModelWithFSDP):
         config_overrides: Dict[str, Any],
         load_in_8bit: bool,
         pretrained: bool,
-        model_cls: Union[Type, Type[PreTrainedModel]] = AutoModelForCausalLM,
+        model_cls: Union[_BaseAutoModelClass,
+                         PreTrainedModel] = AutoModelForCausalLM,
         prepare_for_fsdp: bool = False,
     ) -> Union[PreTrainedModel, 'PeftModel']:
         """Builds the inner model for the ComposerHFCausalLM.

--- a/llmfoundry/models/hf/hf_causal_lm.py
+++ b/llmfoundry/models/hf/hf_causal_lm.py
@@ -13,6 +13,7 @@ from typing import (
     List,
     Optional,
     Tuple,
+    Type,
     Union,
 )
 
@@ -21,7 +22,6 @@ from composer.utils import dist
 from torchmetrics import Metric
 from transformers import (
     AutoConfig,
-    AutoModel,
     AutoModelForCausalLM,
     GenerationConfig,
     PreTrainedModel,
@@ -194,7 +194,7 @@ class ComposerHFCausalLM(HuggingFaceModelWithFSDP):
         config_overrides: Dict[str, Any],
         load_in_8bit: bool,
         pretrained: bool,
-        model_cls: Union[AutoModel, PreTrainedModel] = AutoModelForCausalLM,
+        model_cls: Union[Type, Type[PreTrainedModel]] = AutoModelForCausalLM,
         prepare_for_fsdp: bool = False,
     ) -> Union[PreTrainedModel, 'PeftModel']:
         """Builds the inner model for the ComposerHFCausalLM.
@@ -209,7 +209,7 @@ class ComposerHFCausalLM(HuggingFaceModelWithFSDP):
             config_overrides (Dict[str, Any]): The configuration overrides.
             load_in_8bit (bool): Whether to load in 8-bit.
             pretrained (bool): Whether the model is pretrained.
-            model_cls (Union[AutoModel, PreTrainedModel]): HF class for models. Default: ``AutoModelForCausalLM``.
+            model_cls (Union[Type, Type[PreTrainedModel]]): HF class for models. Default: ``AutoModelForCausalLM``.
             prepare_for_fsdp (bool, optional): Whether to prepare the model for FSDP wrapping. Default: ``False``.
 
         Returns:
@@ -239,7 +239,7 @@ class ComposerHFCausalLM(HuggingFaceModelWithFSDP):
             hasattr(model_cls, 'from_config')
         ):
             raise AttributeError(
-                f'{model_cls=} has missing `from_pretrained` and `from_config` support.',
+                f'{model_cls=} is missing `from_pretrained` and `from_config` support.',
             )
 
         # Hugging Face copies the modules into the


### PR DESCRIPTION
- Will allow the static function to be called externally
    - Users can now use this function (instead of re-writing it for all transformer classes)
    - Can call hyper-specfic function classes as well. 