### PR TITLE
Add user error for UnicodeDeocdeError in convert text to mds

### DIFF
--- a/llmfoundry/utils/exceptions.py
+++ b/llmfoundry/utils/exceptions.py
@@ -348,6 +348,14 @@ class InputFolderMissingDataError(UserError):
         super().__init__(message, input_folder=input_folder)
 
 
+class CannotUnicodeDecodeFile(UserError):
+    """Error thrown when the input folder is missing data."""
+
+    def __init__(self, text_file: str) -> None:
+        message = f'Text file {text_file} contains chars that cannot be utf-8 decoded. Please remove or replace these chars.'
+        super().__init__(message, text_file=text_file)
+
+
 class OutputFolderNotEmptyError(UserError):
     """Error thrown when the output folder is not empty."""
 

--- a/tests/a_scripts/data_prep/test_convert_text_to_mds.py
+++ b/tests/a_scripts/data_prep/test_convert_text_to_mds.py
@@ -22,6 +22,7 @@ from llmfoundry.command_utils.data_prep.convert_text_to_mds import (
     write_done_file,
 )
 from llmfoundry.utils.exceptions import (
+    CannotUnicodeDecodeFile,
     DatasetTooSmallError,
     InputFolderMissingDataError,
     OutputFolderNotEmptyError,
@@ -279,6 +280,28 @@ def test_dataset_too_small(tmp_path: pathlib.Path):
             output_folder=str(tmp_path / 'output'),
             input_folder=str(input_folder),
             concat_tokens=2048,
+            eos_text='',
+            bos_text='',
+            no_wrap=False,
+            compression='zstd',
+            processes=1,
+            args_str='Namespace()',
+            reprocess=False,
+            trust_remote_code=False,
+        )
+
+
+def test_decode_invalid_unicode(tmp_path: pathlib.Path):
+    input_folder = tmp_path / 'input'
+    os.makedirs(input_folder, exist_ok=True)
+    with open(input_folder / 'test.txt', 'w', encoding='utf-16') as f:
+        f.write('HELLO WORLD')
+    with pytest.raises(CannotUnicodeDecodeFile):
+        convert_text_to_mds(
+            tokenizer_name='mosaicml/mpt-7b',
+            output_folder=str(tmp_path / 'output'),
+            input_folder=str(input_folder),
+            concat_tokens=1,
             eos_text='',
             bos_text='',
             no_wrap=False,


### PR DESCRIPTION
Addresses the following error:
```
for chunk in iter(partial(f.read, 1000000), ''):
  File "<frozen codecs>", line 322, in decode
[2024-08-15 15:09:09.939000+00:00][15086]: UnicodeDecodeError: 'utf-8' codec can't decode byte 0x95 in position 203337: 
```