### PR TITLE
Correct error message for inference wrapper

### DIFF
--- a/llmfoundry/models/inference_api_wrapper/openai_causal_lm.py
+++ b/llmfoundry/models/inference_api_wrapper/openai_causal_lm.py
@@ -102,7 +102,7 @@ class OpenAIEvalInterface(InferenceAPIEvalWrapper):
                 break
             except RateLimitError as e:
                 if 'You exceeded your current quota' in str(
-                    e._message,
+                    e.message,
                 ):  # pyright: ignore
                     raise e
                 delay *= 2 * (1 + random.random())


### PR DESCRIPTION
Correct error message for inference wrapper. Afaict openai uses `.message` not `._message` with the version we install (1.3.8) - https://github.com/openai/openai-python/releases/tag/v1.3.8. All future versions also use `.message`