### PR TITLE
Update CI tests to v0.1.2

### DIFF
--- a/.github/workflows/pr-gpu.yaml
+++ b/.github/workflows/pr-gpu.yaml
@@ -4,7 +4,7 @@ on:
     branches:
     - main
     - release/*
-  pull_request_target:
+  pull_request:
     branches:
     - main
     - release/**

--- a/.github/workflows/pr-gpu.yaml
+++ b/.github/workflows/pr-gpu.yaml
@@ -4,7 +4,7 @@ on:
     branches:
     - main
     - release/*
-  pull_request:
+  pull_request_target:
     branches:
     - main
     - release/**

--- a/.github/workflows/pr-gpu.yaml
+++ b/.github/workflows/pr-gpu.yaml
@@ -27,7 +27,7 @@ jobs:
           markers: "gpu"
           pip_deps: "[all]"
           pytest_command: "coverage run -m pytest"
-          ci_repo_gpu_test_ref: v0.1.2
+          ci_repo_gpu_test_ref: foundry-test
     steps:
     - name: Run PR GPU Tests
       uses: mosaicml/ci-testing/.github/actions/pytest-gpu@v0.1.2
@@ -56,7 +56,7 @@ jobs:
           markers: "gpu"
           pip_deps: "[all]"
           pytest_command: "coverage run -m pytest"
-          ci_repo_gpu_test_ref: v0.1.2
+          ci_repo_gpu_test_ref: foundry-test
     steps:
     - name: Run PR GPU Tests
       uses: mosaicml/ci-testing/.github/actions/pytest-gpu@v0.1.2
@@ -85,7 +85,7 @@ jobs:
           markers: "gpu"
           pip_deps: "[all]"
           pytest_command: "coverage run -m pytest"
-          ci_repo_gpu_test_ref: v0.1.2
+          ci_repo_gpu_test_ref: foundry-test
     steps:
     - name: Run PR GPU Tests
       uses: mosaicml/ci-testing/.github/actions/pytest-gpu@v0.1.2

--- a/.github/workflows/pr-gpu.yaml
+++ b/.github/workflows/pr-gpu.yaml
@@ -27,7 +27,7 @@ jobs:
           markers: "gpu"
           pip_deps: "[all]"
           pytest_command: "coverage run -m pytest"
-          ci_repo_gpu_test_ref: foundry-test
+          ci_repo_gpu_test_ref: v0.1.2
     steps:
     - name: Run PR GPU Tests
       uses: mosaicml/ci-testing/.github/actions/pytest-gpu@v0.1.2
@@ -56,7 +56,7 @@ jobs:
           markers: "gpu"
           pip_deps: "[all]"
           pytest_command: "coverage run -m pytest"
-          ci_repo_gpu_test_ref: foundry-test
+          ci_repo_gpu_test_ref: v0.1.2
     steps:
     - name: Run PR GPU Tests
       uses: mosaicml/ci-testing/.github/actions/pytest-gpu@v0.1.2
@@ -85,7 +85,7 @@ jobs:
           markers: "gpu"
           pip_deps: "[all]"
           pytest_command: "coverage run -m pytest"
-          ci_repo_gpu_test_ref: foundry-test
+          ci_repo_gpu_test_ref: v0.1.2
     steps:
     - name: Run PR GPU Tests
       uses: mosaicml/ci-testing/.github/actions/pytest-gpu@v0.1.2

--- a/.github/workflows/pr-gpu.yaml
+++ b/.github/workflows/pr-gpu.yaml
@@ -27,7 +27,7 @@ jobs:
           markers: "gpu"
           pip_deps: "[all]"
           pytest_command: "coverage run -m pytest"
-          ci_repo_gpu_test_ref: v0.1.0
+          ci_repo_gpu_test_ref: v0.1.2
     steps:
     - name: Run PR GPU Tests
       uses: mosaicml/ci-testing/.github/actions/pytest-gpu@v0.1.2
@@ -56,7 +56,7 @@ jobs:
           markers: "gpu"
           pip_deps: "[all]"
           pytest_command: "coverage run -m pytest"
-          ci_repo_gpu_test_ref: v0.1.0
+          ci_repo_gpu_test_ref: v0.1.2
     steps:
     - name: Run PR GPU Tests
       uses: mosaicml/ci-testing/.github/actions/pytest-gpu@v0.1.2
@@ -85,7 +85,7 @@ jobs:
           markers: "gpu"
           pip_deps: "[all]"
           pytest_command: "coverage run -m pytest"
-          ci_repo_gpu_test_ref: v0.1.0
+          ci_repo_gpu_test_ref: v0.1.2
     steps:
     - name: Run PR GPU Tests
       uses: mosaicml/ci-testing/.github/actions/pytest-gpu@v0.1.2


### PR DESCRIPTION
We were calling `uses: mosaicml/ci-testing/.github/actions/pytest-gpu@v0.1.2` which depends on having scripts in ci-testing ref v0.1.2, which are not in v0.1.0, causing directory not found.