### PR TITLE
Consistent Naming EnviromentLoggingCallback

### DIFF
--- a/llmfoundry/callbacks/__init__.py
+++ b/llmfoundry/callbacks/__init__.py
@@ -57,7 +57,7 @@ callbacks.register('eval_output_logging', func=EvalOutputLogging)
 callbacks.register('mbmoe_tok_per_expert', func=MegaBlocksMoE_TokPerExpert)
 callbacks.register('run_timeout', func=RunTimeoutCallback)
 callbacks.register('loss_perp_v_len', func=LossPerpVsContextLengthLogger)
-callbacks.register('env_logger', func=EnvironmentLoggingCallback)
+callbacks.register('env_logging', func=EnvironmentLoggingCallback)
 
 callbacks_with_config.register('async_eval', func=AsyncEval)
 callbacks_with_config.register('curriculum_learning', func=CurriculumLearning)


### PR DESCRIPTION
Minor fix to have consistent naming between the registry and the callback name