### PR TITLE
Add date_string when applying tokenizer chat template

### DIFF
--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -65,6 +65,7 @@ from llmfoundry.data.finetuning.collator import (
     stitch_turns_decoder_only,
     stitch_turns_encoder_decoder,
 )
+from llmfoundry.tokenizers import get_date_string
 # yapf: disable
 from llmfoundry.utils.exceptions import (
     ALLOWED_MESSAGES_KEYS,
@@ -249,11 +250,13 @@ def _slice_chat_formatted_example(
             full_conversation = tokenizer.apply_chat_template(
                 messages_through_current_turn,
                 tokenize=False,
+                date_string=get_date_string(),
             )
             prompt_with_history = tokenizer.apply_chat_template(
                 messages_through_current_turn[:-1],
                 tokenize=False,
                 add_generation_prompt=True,
+                date_string=get_date_string(),
             )
         except Exception as e:
             raise ChatTemplateError(

--- a/llmfoundry/tokenizers/__init__.py
+++ b/llmfoundry/tokenizers/__init__.py
@@ -3,9 +3,11 @@
 
 from llmfoundry.registry import tokenizers
 from llmfoundry.tokenizers.tiktoken import TiktokenTokenizerWrapper
+from llmfoundry.tokenizers.utils import get_date_string
 
 tokenizers.register('tiktoken', func=TiktokenTokenizerWrapper)
 
 __all__ = [
     'TiktokenTokenizerWrapper',
+    'get_date_string',
 ]

--- a/llmfoundry/tokenizers/utils.py
+++ b/llmfoundry/tokenizers/utils.py
@@ -1,0 +1,12 @@
+# Copyright 2024 MosaicML LLM Foundry authors
+# SPDX-License-Identifier: Apache-2.0
+
+import datetime
+
+__all__ = [
+    'get_date_string',
+]
+
+def get_date_string() -> str:
+    """Get the current date string."""
+    return datetime.datetime.now().strftime('%d %b %Y')

--- a/llmfoundry/tokenizers/utils.py
+++ b/llmfoundry/tokenizers/utils.py
@@ -7,6 +7,7 @@ __all__ = [
     'get_date_string',
 ]
 
+
 def get_date_string() -> str:
     """Get the current date string."""
     return datetime.datetime.now().strftime('%d %b %Y')

--- a/scripts/inference/hf_chat.py
+++ b/scripts/inference/hf_chat.py
@@ -19,6 +19,7 @@ from transformers import (
     TextStreamer,
 )
 
+from llmfoundry.tokenizers import get_date_string
 from llmfoundry.utils.exceptions import ChatTemplateError
 
 DEFAULT_SYSTEM_PROMPT = 'You are a friendly chatbot who aims to be helpful and honest.'
@@ -132,6 +133,7 @@ class Conversation:
                 chat_conversation,
                 tokenize=False,
                 add_generation_prompt=False,
+                date_string=get_date_string(),
             )
         except Exception as e:
             raise ChatTemplateError(
@@ -149,6 +151,7 @@ class Conversation:
                 tokenize=True,
                 add_generation_prompt=True,
                 return_tensors='pt',
+                date_string=get_date_string(),
             )
         except Exception as e:
             raise ChatTemplateError(

--- a/tests/data/test_template_tokenization.py
+++ b/tests/data/test_template_tokenization.py
@@ -11,6 +11,7 @@ from llmfoundry.data.finetuning.tasks import (
     dataset_constructor,
     tokenize_formatted_example,
 )
+from llmfoundry.tokenizers import get_date_string
 from llmfoundry.utils.builders import build_tokenizer
 from llmfoundry.utils.exceptions import (
     ALLOWED_PROMPT_KEYS,
@@ -281,7 +282,11 @@ def test_multi_turn_chat_slicing(tokenizer_name: str, messages_format: bool):
     for prompt, response in templated_prompt_response_turns:
         reconstructed_chat += prompt + response
 
-    full_chat = tok.apply_chat_template(convo, tokenize=False)
+    full_chat = tok.apply_chat_template(
+        convo,
+        tokenize=False,
+        date_string=get_date_string(),
+    )
     assert reconstructed_chat == full_chat
 
 

--- a/tests/data/test_template_tokenization.py
+++ b/tests/data/test_template_tokenization.py
@@ -225,8 +225,8 @@ def test_multi_turn_chat_slicing(
     messages_format: bool,
     use_date_string: bool,
 ):
-    # if 'meta-llama' in tokenizer_name:
-    #     pytest.skip('Model is gated. Skipping test.')
+    if 'meta-llama' in tokenizer_name:
+        pytest.skip('Model is gated. Skipping test.')
     is_llama_3_1_instruct = 'Meta-Llama-3.1' in tokenizer_name and 'Instruct' in tokenizer_name
     if is_llama_3_1_instruct and use_date_string:
         pytest.skip(

--- a/tests/data/test_template_tokenization.py
+++ b/tests/data/test_template_tokenization.py
@@ -211,10 +211,27 @@ def test_tokenize_instruct_example_well_formed():
 
 @pytest.mark.parametrize(
     'tokenizer_name',
-    ['EleutherAI/gpt-neox-20b', 'HuggingFaceH4/zephyr-7b-beta', 't5-base'],
+    [
+        'EleutherAI/gpt-neox-20b',
+        'HuggingFaceH4/zephyr-7b-beta',
+        't5-base',
+        'meta-llama/Meta-Llama-3.1-8B-Instruct',
+    ],
 )
 @pytest.mark.parametrize('messages_format', [True, False])
-def test_multi_turn_chat_slicing(tokenizer_name: str, messages_format: bool):
+@pytest.mark.parametrize('use_date_string', [True, False])
+def test_multi_turn_chat_slicing(
+    tokenizer_name: str,
+    messages_format: bool,
+    use_date_string: bool,
+):
+    # if 'meta-llama' in tokenizer_name:
+    #     pytest.skip('Model is gated. Skipping test.')
+    is_llama_3_1_instruct = 'Meta-Llama-3.1' in tokenizer_name and 'Instruct' in tokenizer_name
+    if is_llama_3_1_instruct and use_date_string:
+        pytest.skip(
+            'Llama 3.1 Instruct models use date_string in chat template already. Skipping test.',
+        )
     if messages_format:
         convo = [
             {
@@ -273,6 +290,10 @@ def test_multi_turn_chat_slicing(tokenizer_name: str, messages_format: bool):
 
     tok = transformers.AutoTokenizer.from_pretrained(tokenizer_name)
 
+    # Manually set a chat template to test if the date_string is being used.
+    if use_date_string:
+        tok.chat_template = "{%- if not date_string is defined %}\n    {%- set date_string = \"26 Jul 2024\" %}\n{%- endif %}\n{{- \"Today Date: \" + date_string }}\n"
+
     templated_prompt_response_turns = _slice_chat_formatted_example(
         example,
         tok,
@@ -282,12 +303,18 @@ def test_multi_turn_chat_slicing(tokenizer_name: str, messages_format: bool):
     for prompt, response in templated_prompt_response_turns:
         reconstructed_chat += prompt + response
 
+    date_string = get_date_string()
     full_chat = tok.apply_chat_template(
         convo,
         tokenize=False,
-        date_string=get_date_string(),
+        date_string=date_string,
     )
     assert reconstructed_chat == full_chat
+
+    if is_llama_3_1_instruct or use_date_string:
+        assert date_string in full_chat
+    else:
+        assert date_string not in full_chat
 
 
 def test_fail_chat_template():

--- a/tests/tokenizers/test_tiktoken.py
+++ b/tests/tokenizers/test_tiktoken.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Optional
 import pytest
 import transformers
 
+from llmfoundry.tokenizers import get_date_string
 from llmfoundry.tokenizers.tiktoken import (
     TiktokenTokenizerWrapper,
     bytes_to_unicode,
@@ -516,6 +517,7 @@ def test_chat_formatting(
             dict_chats,
             tokenize=False,
             add_generation_prompt=False,
+            date_string=get_date_string(),
         )
         assert chat_str == MULTI_TURN_CHAT_STRING_NO_SYSTEM_PROMPT[i]
     # Using default system prompt.
@@ -533,6 +535,7 @@ def test_chat_formatting(
             dict_chats,
             tokenize=False,
             add_generation_prompt=False,
+            date_string=get_date_string(),
         )
         assert chat_str == MULTI_TURN_CHAT_STRING_SYSTEM_PROMPT[i]
     for i, dict_chats in enumerate(MULTI_TURN_GENERATE_CHAT_ML):
@@ -540,6 +543,7 @@ def test_chat_formatting(
             dict_chats,
             tokenize=False,
             add_generation_prompt=True,
+            date_string=get_date_string(),
         )
         assert chat_str == MULTI_TURN_GENERATE_STRING[i]
 

--- a/tests/tokenizers/test_tokenizer.py
+++ b/tests/tokenizers/test_tokenizer.py
@@ -1,8 +1,12 @@
 # Copyright 2022 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
+import pytest
+import torch
 from omegaconf import OmegaConf as om
 from transformers import AutoTokenizer
+
+from llmfoundry.tokenizers.utils import get_date_string
 
 
 def get_config(conf_path: str = 'scripts/train/yamls/pretrain/mpt-125m.yaml'):
@@ -80,3 +84,49 @@ def test_load_tokenizer():
     )['attention_mask']
     attn_mask_key = [1, 1, 1, 1] + [0] * (tokenizer.model_max_length - 4)
     assert attention_mask == attn_mask_key
+
+
+@pytest.mark.parametrize(
+    'tokenizer_name',
+    [
+        'EleutherAI/gpt-neox-20b',
+        'meta-llama/Meta-Llama-3-8B-Instruct',
+        'meta-llama/Meta-Llama-3.1-8B-Instruct',
+        'meta-llama/Meta-Llama-3.1-70B-Instruct',
+        'meta-llama/Meta-Llama-3.1-405B-Instruct',
+    ],
+)
+@pytest.mark.parametrize('spoof_chat_template', [True, False])
+def test_tokenizer_date_string(tokenizer_name: str, spoof_chat_template: bool):
+    if 'meta-llama' in tokenizer_name:
+        pytest.skip('Model is gated. Skipping test.')
+
+    is_llama_3_1_instruct = 'Meta-Llama-3.1' in tokenizer_name and 'Instruct' in tokenizer_name
+    if is_llama_3_1_instruct and spoof_chat_template:
+        pytest.skip(
+            'Llama 3.1 Instruct models use date_string in chat template, so no need to spoof. Skipping test.',
+        )
+
+    tokenizer = AutoTokenizer.from_pretrained(tokenizer_name)
+    messages = [{'role': 'system', 'content': ''}]
+    date_string = get_date_string()
+
+    # Manually set a chat template to test if the date_string is being used.
+    if spoof_chat_template:
+        tokenizer.chat_template = "{%- if not date_string is defined %}\n    {%- set date_string = \"26 Jul 2024\" %}\n{%- endif %}\n{{- \"Today Date: \" + date_string }}\n"
+
+    token_ids = tokenizer.apply_chat_template(
+        messages,
+        add_generation_prompt=True,
+        return_tensors='pt',
+        date_string=date_string,
+    )
+
+    assert isinstance(token_ids, torch.Tensor)
+    decoded_text = tokenizer.decode(token_ids.flatten())
+
+    # Only Llama 3.1 instruct family models should use the current date in their chat templates.
+    if is_llama_3_1_instruct or spoof_chat_template:
+        assert date_string in decoded_text
+    else:
+        assert date_string not in decoded_text

--- a/tests/tokenizers/test_tokenizer.py
+++ b/tests/tokenizers/test_tokenizer.py
@@ -96,15 +96,15 @@ def test_load_tokenizer():
         'meta-llama/Meta-Llama-3.1-405B-Instruct',
     ],
 )
-@pytest.mark.parametrize('spoof_chat_template', [True, False])
-def test_tokenizer_date_string(tokenizer_name: str, spoof_chat_template: bool):
+@pytest.mark.parametrize('use_date_string', [True, False])
+def test_tokenizer_date_string(tokenizer_name: str, use_date_string: bool):
     if 'meta-llama' in tokenizer_name:
         pytest.skip('Model is gated. Skipping test.')
 
     is_llama_3_1_instruct = 'Meta-Llama-3.1' in tokenizer_name and 'Instruct' in tokenizer_name
-    if is_llama_3_1_instruct and spoof_chat_template:
+    if is_llama_3_1_instruct and use_date_string:
         pytest.skip(
-            'Llama 3.1 Instruct models use date_string in chat template, so no need to spoof. Skipping test.',
+            'Llama 3.1 Instruct models use date_string in chat template already. Skipping test.',
         )
 
     tokenizer = AutoTokenizer.from_pretrained(tokenizer_name)
@@ -112,7 +112,7 @@ def test_tokenizer_date_string(tokenizer_name: str, spoof_chat_template: bool):
     date_string = get_date_string()
 
     # Manually set a chat template to test if the date_string is being used.
-    if spoof_chat_template:
+    if use_date_string:
         tokenizer.chat_template = "{%- if not date_string is defined %}\n    {%- set date_string = \"26 Jul 2024\" %}\n{%- endif %}\n{{- \"Today Date: \" + date_string }}\n"
 
     token_ids = tokenizer.apply_chat_template(
@@ -126,7 +126,7 @@ def test_tokenizer_date_string(tokenizer_name: str, spoof_chat_template: bool):
     decoded_text = tokenizer.decode(token_ids.flatten())
 
     # Only Llama 3.1 instruct family models should use the current date in their chat templates.
-    if is_llama_3_1_instruct or spoof_chat_template:
+    if is_llama_3_1_instruct or use_date_string:
         assert date_string in decoded_text
     else:
         assert date_string not in decoded_text


### PR DESCRIPTION
Llama 3.1 models take in a `date_string` we can use to set the current date in the chat template. This defaults to 26 Jul 2024 if we don't set it, which is kinda problematic. We pass in `date_string` as the current date to remedy this.

Added unit tests and tested manually on gated llama 3.1 and llama 3 models (see below)
```
pytest -s -v tests/tokenizers/test_tokenizer.py::test_tokenizer_date_string
===================================================================================== test session starts =====================================================================================
platform darwin -- Python 3.10.5, pytest-8.3.2, pluggy-1.5.0 -- /Users/saaketh.narayan/.pyenv/versions/3.10.5/bin/python3.10
cachedir: .pytest_cache
rootdir: /Users/saaketh.narayan/Desktop/llm-foundry
configfile: pyproject.toml
plugins: cov-5.0.0, anyio-4.3.0, split-0.9.0, pytest_codeblocks-0.17.0
collected 10 items

tests/tokenizers/test_tokenizer.py::test_tokenizer_date_string[True-EleutherAI/gpt-neox-20b] [W ProcessGroupGloo.cpp:751] Warning: Unable to resolve hostname to a (local) address. Using the loopback address as fallback. Manually set the network interface to bind to with GLOO_SOCKET_IFNAME. (function operator())
PASSED
tokenizer_config.json: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 51.0k/51.0k [00:00<00:00, 3.06MB/s]
tokenizer.json: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 9.09M/9.09M [00:00<00:00, 13.9MB/s]
special_tokens_map.json: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 73.0/73.0 [00:00<00:00, 343kB/s]
PASSED
tests/tokenizers/test_tokenizer.py::test_tokenizer_date_string[True-meta-llama/Meta-Llama-3.1-8B-Instruct] SKIPPED (Llama 3.1 Instruct models use date_string in chat template, so ...)
tests/tokenizers/test_tokenizer.py::test_tokenizer_date_string[True-meta-llama/Meta-Llama-3.1-70B-Instruct] SKIPPED (Llama 3.1 Instruct models use date_string in chat template, so...)
tests/tokenizers/test_tokenizer.py::test_tokenizer_date_string[True-meta-llama/Meta-Llama-3.1-405B-Instruct] SKIPPED (Llama 3.1 Instruct models use date_string in chat template, s...)
tests/tokenizers/test_tokenizer.py::test_tokenizer_date_string[False-EleutherAI/gpt-neox-20b] No chat template is set for this tokenizer, falling back to a default class-level template. This is very error-prone, because models are often trained with templates different from the class default! Default chat templates are a legacy feature and will be removed in Transformers v4.43, at which point any code depending on them will stop working. We recommend setting a valid chat template before then to ensure that this model continues working without issues.
PASSED
tests/tokenizers/test_tokenizer.py::test_tokenizer_date_string[False-meta-llama/Meta-Llama-3-8B-Instruct] PASSED
tokenizer_config.json: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 55.4k/55.4k [00:00<00:00, 27.2MB/s]
tokenizer.json: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 9.09M/9.09M [00:00<00:00, 12.2MB/s]
special_tokens_map.json: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 296/296 [00:00<00:00, 2.03MB/s]
PASSED
tokenizer_config.json: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 55.4k/55.4k [00:00<00:00, 19.3MB/s]
tokenizer.json: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 9.09M/9.09M [00:00<00:00, 11.3MB/s]
special_tokens_map.json: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 296/296 [00:00<00:00, 2.05MB/s]
PASSED
tokenizer_config.json: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 55.4k/55.4k [00:00<00:00, 20.1MB/s]
tokenizer.json: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 9.09M/9.09M [00:00<00:00, 15.4MB/s]
special_tokens_map.json: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 296/296 [00:00<00:00, 3.75MB/s]
PASSED
```

Manual test for modified `test_multi_turn_chat_slicing` using gated llama 3.1 8b tokenizer:
```
tests/data/test_template_tokenization.py::test_multi_turn_chat_slicing[True-True-EleutherAI/gpt-neox-20b] [W ProcessGroupGloo.cpp:751] Warning: Unable to resolve hostname to a (local) address. Using the loopback address as fallback. Manually set the network interface to bind to with GLOO_SOCKET_IFNAME. (function operator())
PASSED
tests/data/test_template_tokenization.py::test_multi_turn_chat_slicing[True-True-HuggingFaceH4/zephyr-7b-beta] PASSED
tests/data/test_template_tokenization.py::test_multi_turn_chat_slicing[True-True-t5-base] PASSED
tests/data/test_template_tokenization.py::test_multi_turn_chat_slicing[True-True-meta-llama/Meta-Llama-3.1-8B-Instruct] SKIPPED (Llama 3.1 Instruct models use date_string in chat template ...)
tests/data/test_template_tokenization.py::test_multi_turn_chat_slicing[True-False-EleutherAI/gpt-neox-20b] PASSED
tests/data/test_template_tokenization.py::test_multi_turn_chat_slicing[True-False-HuggingFaceH4/zephyr-7b-beta] PASSED
tests/data/test_template_tokenization.py::test_multi_turn_chat_slicing[True-False-t5-base] PASSED
tests/data/test_template_tokenization.py::test_multi_turn_chat_slicing[True-False-meta-llama/Meta-Llama-3.1-8B-Instruct] SKIPPED (Llama 3.1 Instruct models use date_string in chat template...)
tests/data/test_template_tokenization.py::test_multi_turn_chat_slicing[False-True-EleutherAI/gpt-neox-20b] No chat template is set for this tokenizer, falling back to a default class-level template. This is very error-prone, because models are often trained with templates different from the class default! Default chat templates are a legacy feature and will be removed in Transformers v4.43, at which point any code depending on them will stop working. We recommend setting a valid chat template before then to ensure that this model continues working without issues.
PASSED
tests/data/test_template_tokenization.py::test_multi_turn_chat_slicing[False-True-HuggingFaceH4/zephyr-7b-beta] PASSED
tests/data/test_template_tokenization.py::test_multi_turn_chat_slicing[False-True-t5-base] PASSED
tests/data/test_template_tokenization.py::test_multi_turn_chat_slicing[False-True-meta-llama/Meta-Llama-3.1-8B-Instruct] PASSED
tests/data/test_template_tokenization.py::test_multi_turn_chat_slicing[False-False-EleutherAI/gpt-neox-20b] PASSED
tests/data/test_template_tokenization.py::test_multi_turn_chat_slicing[False-False-HuggingFaceH4/zephyr-7b-beta] PASSED
tests/data/test_template_tokenization.py::test_multi_turn_chat_slicing[False-False-t5-base] PASSED
tests/data/test_template_tokenization.py::test_multi_turn_chat_slicing[False-False-meta-llama/Meta-Llama-3.1-8B-Instruct] PASSED
```