### PR TITLE
Remove extra bos for prompt/response data with llama3.1

### DIFF
--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -323,7 +323,8 @@ def _tokenize_with_bos_removal(
     # an add_bos_token attr that we can check explicitly, so instead we rely on checking if both the
     # text and the text_target start with bos_token_id to determine whether to strip bos.
     has_bos_token = hasattr(
-        tokenizer, 'bos_token_id'
+        tokenizer,
+        'bos_token_id',
     ) and tokenizer.bos_token_id is not None
     input_ids_starts_with_bos = False
     labels_starts_with_bos = False

--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -328,8 +328,9 @@ def _tokenize_with_bos_removal(
     ) and tokenizer.bos_token_id is not None
     input_ids_starts_with_bos = False
     labels_starts_with_bos = False
-    if has_bos_token and len(tokenized_sample['input_ids']
-                            ) > 0 and len(tokenized_sample['labels']) > 0:
+    if has_bos_token and len(
+        tokenized_sample['input_ids'],
+    ) > 0 and len(tokenized_sample['labels']) > 0:
         input_ids_starts_with_bos = tokenized_sample['input_ids'][
             0] == tokenizer.bos_token_id
         labels_starts_with_bos = tokenized_sample['labels'][

--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -322,12 +322,16 @@ def _tokenize_with_bos_removal(
     # Unfortunately if the tokenizer is PretrainedTokenizerFast, as llama3 is, it does not provide
     # an add_bos_token attr that we can check explicitly, so instead we rely on checking if both the
     # text and the text_target start with bos_token_id to determine whether to strip bos.
-    has_bos_token = hasattr(tokenizer, 'bos_token_id') and tokenizer.bos_token_id is not None
+    has_bos_token = hasattr(
+        tokenizer, 'bos_token_id'
+    ) and tokenizer.bos_token_id is not None
     input_ids_starts_with_bos = False
     labels_starts_with_bos = False
     if has_bos_token:
-        input_ids_starts_with_bos = tokenized_sample['input_ids'][0] == tokenizer.bos_token_id
-        labels_starts_with_bos = tokenized_sample['labels'][0] == tokenizer.bos_token_id
+        input_ids_starts_with_bos = tokenized_sample['input_ids'][
+            0] == tokenizer.bos_token_id
+        labels_starts_with_bos = tokenized_sample['labels'][
+            0] == tokenizer.bos_token_id
     if input_ids_starts_with_bos and labels_starts_with_bos:
         tokenized_sample['labels'] = tokenized_sample['labels'][1:]
 

--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -328,7 +328,8 @@ def _tokenize_with_bos_removal(
     ) and tokenizer.bos_token_id is not None
     input_ids_starts_with_bos = False
     labels_starts_with_bos = False
-    if has_bos_token:
+    if has_bos_token and len(tokenized_sample['input_ids']
+                            ) > 0 and len(tokenized_sample['labels']) > 0:
         input_ids_starts_with_bos = tokenized_sample['input_ids'][
             0] == tokenizer.bos_token_id
         labels_starts_with_bos = tokenized_sample['labels'][


### PR DESCRIPTION
This is a modification to https://github.com/mosaicml/llm-foundry/pull/1003 and the explanation from there still stands. The difference is that llama3.1 does not have an `add_bos_token` attr because it is not a `LlamaTokenizerFast`, but is a `PreTrainedTokenizerFast`.

Existing unit test covers the existing usage, and manual test for llama3.1 is here:
```
In [1]: from llmfoundry.data.finetuning.tasks import _tokenize_with_bos_removal

In [2]: import transformers

In [3]: llama318t = transformers.AutoTokenizer.from_pretrained('meta-llama/Meta-Llama-3.1-8B-Instruct')

In [4]: llama318t(text='hello', text_target='goodbye')
Out[4]: {'input_ids': [128000, 15339], 'attention_mask': [1, 1], 'labels': [128000, 19045, 29474]}

In [5]: _tokenize_with_bos_removal(llama318t, text='hello', text_target='goodbye')
Out[5]: {'input_ids': [128000, 15339], 'attention_mask': [1, 1], 'labels': [19045, 29474]}
```

Before and after loss curve. Similarly to the previous PR, loss is lower after because we're not forcing the model into an unfamiliar use of bos.
<img width="382" alt="Screenshot 2024-08-21 at 6 29 21 PM" src="https://github.com/user-attachments/assets/31d91b2c-fb7c-4199-9cc6-97feca232977">
