### PR TITLE
Add prepare fsdp back

### DIFF
--- a/llmfoundry/models/hf/hf_base.py
+++ b/llmfoundry/models/hf/hf_base.py
@@ -395,6 +395,9 @@ class BaseHuggingFaceModel(HuggingFaceModel):
                 pretrained_lora_id_or_path,
             )
 
+        if prepare_for_fsdp:
+            cls.prepare_inner_model(model, init_device)
+
         return model
 
     def get_peft_config(self, peft_config_dict: dict[str, Any]) -> 'PeftConfig':

--- a/tests/models/hf/test_hf_base.py
+++ b/tests/models/hf/test_hf_base.py
@@ -1,0 +1,21 @@
+from llmfoundry.models.hf.hf_base import BaseHuggingFaceModel
+
+def test_build_inner_model_fsdp():
+    model = BaseHuggingFaceModel.build_inner_model(
+        pretrained_model_name_or_path='codellama/CodeLlama-7b-hf',
+        pretrained_lora_id_or_path=None,
+        trust_remote_code=False,
+        init_device='cpu',
+        use_flash_attention_2=False,
+        use_auth_token=False,
+        config_overrides={
+            'num_hidden_layers': 2,
+            'hidden_size': 32,
+            'intermediate_size': 64,
+        },
+        load_in_8bit=False,
+        pretrained=False,
+        prepare_for_fsdp=True,
+    )
+
+    assert model.fsdp_wrap_fn(model.model.layers[0])

--- a/tests/models/hf/test_hf_base.py
+++ b/tests/models/hf/test_hf_base.py
@@ -1,3 +1,6 @@
+# Copyright 2024 MosaicML LLM Foundry authors
+# SPDX-License-Identifier: Apache-2.0
+
 from llmfoundry.models.hf.hf_base import BaseHuggingFaceModel
 
 

--- a/tests/models/hf/test_hf_base.py
+++ b/tests/models/hf/test_hf_base.py
@@ -1,5 +1,6 @@
 from llmfoundry.models.hf.hf_base import BaseHuggingFaceModel
 
+
 def test_build_inner_model_fsdp():
     model = BaseHuggingFaceModel.build_inner_model(
         pretrained_model_name_or_path='codellama/CodeLlama-7b-hf',


### PR DESCRIPTION
https://github.com/mosaicml/llm-foundry/pull/1467 accidentally removed usage of `prepare_for_fsdp` in `build_inner_model`. This adds it back, and adds a test for it.