### PR TITLE
master_weights_dtype not supported by ComposerHFCausalLM.__init__()

### DIFF
--- a/llmfoundry/command_utils/train.py
+++ b/llmfoundry/command_utils/train.py
@@ -477,7 +477,7 @@ def train(cfg: DictConfig) -> Trainer:
         name=name,
         tokenizer=tokenizer,
         init_context=init_context,
-        master_weights_dtype=model_config.get('master_weights_dtype', None),
+        master_weights_dtype=model_config.pop('master_weights_dtype', None),
         cfg=model_config,
     )
 


### PR DESCRIPTION
Seems like loading a model with this config:
```yaml
model:
  name: hf_causal_lm
  use_flash_attention_2: true
  pretrained: true
  pretrained_model_name_or_path: ${variables.model_name_or_path}
  use_auth_token: true
  master_weights_dtype: bf16             <---- problematic part
```
errors with the following message:
```bash
2024-08-26 22:21:38,493: rank3[430597][MainThread]: INFO: llmfoundry.command_utils.train: Initializing model...
[rank3]: Traceback (most recent call last):
[rank3]:   File "/home/eldar/to_purge/llm-foundry/scripts/train/train.py", line 9, in <module>
[rank3]:     train_from_yaml(yaml_path, args_list)
[rank3]:   File "/home/eldar/to_purge/llm-foundry/llmfoundry/command_utils/train.py", line 606, in train_from_yaml
[rank3]:     return train(yaml_cfg)
[rank3]:            ^^^^^^^^^^^^^^^
[rank3]:   File "/home/eldar/to_purge/llm-foundry/llmfoundry/command_utils/train.py", line 476, in train
[rank3]:     model = build_composer_model(
[rank3]:             ^^^^^^^^^^^^^^^^^^^^^
[rank3]:   File "/home/eldar/to_purge/llm-foundry/llmfoundry/utils/builders.py", line 250, in build_composer_model
[rank3]:     model = construct_from_registry(
[rank3]:             ^^^^^^^^^^^^^^^^^^^^^^^^
[rank3]:   File "/home/eldar/to_purge/llm-foundry/llmfoundry/utils/registry_utils.py", line 160, in construct_from_registry
[rank3]:     constructed_item = registered_constructor(**kwargs)
[rank3]:                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank3]: TypeError: ComposerHFCausalLM.__init__() got an unexpected keyword argument 'master_weights_dtype'
```

This PR simply drops it from the model_config as it won't be used there.