### PR TITLE
Bump composer to 0.24.1 + FSDP config device_mesh deprecation

### DIFF
--- a/scripts/eval/yamls/dbrx-gauntlet/dbrx-18b.yaml
+++ b/scripts/eval/yamls/dbrx-gauntlet/dbrx-18b.yaml
@@ -55,8 +55,7 @@ models:
 precision: amp_bf16
 fsdp_config:
   verbose: false
-  device_mesh:
-  - 8
+  data_parallel_shard_degree: 8
   mixed_precision: PURE
   state_dict_type: sharded
   use_orig_params: true

--- a/scripts/eval/yamls/dbrx-gauntlet/dbrx-35b.yaml
+++ b/scripts/eval/yamls/dbrx-gauntlet/dbrx-35b.yaml
@@ -55,8 +55,7 @@ models:
 precision: amp_bf16
 fsdp_config:
   verbose: false
-  device_mesh:
-  - 8
+  data_parallel_shard_degree: 8
   mixed_precision: PURE
   state_dict_type: sharded
   use_orig_params: true

--- a/scripts/eval/yamls/dbrx-gauntlet/dbrx-73b.yaml
+++ b/scripts/eval/yamls/dbrx-gauntlet/dbrx-73b.yaml
@@ -55,8 +55,7 @@ models:
 precision: amp_bf16
 fsdp_config:
   verbose: false
-  device_mesh:
-  - 8
+  data_parallel_shard_degree: 8
   mixed_precision: PURE
   state_dict_type: sharded
   use_orig_params: true

--- a/scripts/eval/yamls/dbrx-gauntlet/dbrx-9b.yaml
+++ b/scripts/eval/yamls/dbrx-gauntlet/dbrx-9b.yaml
@@ -55,8 +55,7 @@ models:
 precision: amp_bf16
 fsdp_config:
   verbose: false
-  device_mesh:
-  - 8
+  data_parallel_shard_degree: 8
   mixed_precision: PURE
   state_dict_type: sharded
   use_orig_params: true

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ classifiers = [
 ]
 
 install_requires = [
-    'mosaicml[libcloud,wandb,oci,gcs,mlflow]>=0.23.4,<0.24',
+    'mosaicml[libcloud,wandb,oci,gcs,mlflow]>=0.24.0,<0.25',
     'mlflow>=2.14.1,<2.16',
     'accelerate>=0.25,<0.34',  # for HF inference `device_map`
     'transformers>=4.43.2,<4.44',
@@ -91,14 +91,14 @@ extra_deps['dev'] = [
 ]
 
 extra_deps['databricks'] = [
-    'mosaicml[databricks]>=0.23.4,<0.24',
+    'mosaicml[databricks]>=0.24.0,<0.25',
     'databricks-sql-connector>=3,<4',
     'databricks-connect==14.1.0',
     'lz4>=4,<5',
 ]
 
 extra_deps['tensorboard'] = [
-    'mosaicml[tensorboard]>=0.23.4,<0.24',
+    'mosaicml[tensorboard]>=0.24.0,<0.25',
 ]
 
 # Flash 2 group kept for backwards compatibility
@@ -109,7 +109,7 @@ extra_deps['gpu-flash2'] = [
 extra_deps['gpu'] = copy.deepcopy(extra_deps['gpu-flash2'])
 
 extra_deps['peft'] = [
-    'mosaicml[peft]>=0.23.4,<0.24',
+    'mosaicml[peft]>=0.24.0,<0.25',
 ]
 
 extra_deps['openai'] = [

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ classifiers = [
 ]
 
 install_requires = [
-    'mosaicml[libcloud,wandb,oci,gcs,mlflow]>=0.24.0,<0.25',
+    'mosaicml[libcloud,wandb,oci,gcs,mlflow]>=0.24.1,<0.25',
     'mlflow>=2.14.1,<2.16',
     'accelerate>=0.25,<0.34',  # for HF inference `device_map`
     'transformers>=4.43.2,<4.44',
@@ -91,14 +91,14 @@ extra_deps['dev'] = [
 ]
 
 extra_deps['databricks'] = [
-    'mosaicml[databricks]>=0.24.0,<0.25',
+    'mosaicml[databricks]>=0.24.1,<0.25',
     'databricks-sql-connector>=3,<4',
     'databricks-connect==14.1.0',
     'lz4>=4,<5',
 ]
 
 extra_deps['tensorboard'] = [
-    'mosaicml[tensorboard]>=0.24.0,<0.25',
+    'mosaicml[tensorboard]>=0.24.1,<0.25',
 ]
 
 # Flash 2 group kept for backwards compatibility
@@ -109,7 +109,7 @@ extra_deps['gpu-flash2'] = [
 extra_deps['gpu'] = copy.deepcopy(extra_deps['gpu-flash2'])
 
 extra_deps['peft'] = [
-    'mosaicml[peft]>=0.24.0,<0.25',
+    'mosaicml[peft]>=0.24.1,<0.25',
 ]
 
 extra_deps['openai'] = [

--- a/tests/a_scripts/inference/test_convert_composer_to_hf.py
+++ b/tests/a_scripts/inference/test_convert_composer_to_hf.py
@@ -1283,11 +1283,12 @@ def test_mptmoe_huggingface_conversion_callback(
         'activation_checkpointing_reentrant': False,
         'activation_cpu_offload': False,
         'limit_all_gathers': True,
-        'device_mesh': [1, 4] if sharding_strategy == 'HYBRID_SHARD' else [
-            4,
-        ],
         'use_orig_params': True,
+        'data_parallel_shard_degree': 4,
     }
+
+    if sharding_strategy == 'HYBRID_SHARD':
+        fsdp_config['data_parallel_shard_degree'] = 1
 
     tiny_dataset_folder_path = os.path.join(os.getcwd(), 'test-ift-data-small')
     tiny_dataset_path = os.path.join(tiny_dataset_folder_path, 'train.jsonl')

--- a/tests/utils/test_config_utils.py
+++ b/tests/utils/test_config_utils.py
@@ -1,10 +1,13 @@
 # Copyright 2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
-from llmfoundry.utils.config_utils import update_config_with_batch_size_info, process_init_device
-from composer.utils import dist
 from unittest.mock import patch
+
 import pytest
+from composer.utils import dist
+
+from llmfoundry.utils.config_utils import (process_init_device,
+                                           update_config_with_batch_size_info,)
 
 
 def test_update_config_with_batch_size_info():
@@ -17,13 +20,14 @@ def test_update_config_with_batch_size_info():
     assert config['device_train_grad_accum'] == 3
     assert config['device_eval_batch_size'] == 2
 
+
 @pytest.mark.parametrize('shard_degree_specified', [True, False])
 @pytest.mark.parametrize('replicate_degree_specified', [True, False])
 @pytest.mark.parametrize('should_shard_only', [True, False])
 def test_moe_fsdp_config_ffn_config(
     shard_degree_specified: bool,
     replicate_degree_specified: bool,
-    should_shard_only: bool
+    should_shard_only: bool,
 ):
     model_cfg = {
         'moe_world_size': 4,
@@ -31,7 +35,7 @@ def test_moe_fsdp_config_ffn_config(
         'fc_type': 'torch',
         'ffn_config': {
             'ffn_type': 'mb_moe',
-        }
+        },
     }
     fsdp_config = {}
     if shard_degree_specified and replicate_degree_specified:
@@ -51,12 +55,14 @@ def test_moe_fsdp_config_ffn_config(
             fsdp_config['data_parallel_replicate_degree'] = 1
         else:
             fsdp_config['data_parallel_replicate_degree'] = 2
-    
+
     # Ensure the ffn_config's device_mesh is set correctly using the fsdp_config
     with patch('composer.utils.dist.get_world_size', return_value=8):
         _ = process_init_device(model_cfg, fsdp_config)
 
-        if should_shard_only or (not shard_degree_specified and not replicate_degree_specified):
+        if should_shard_only or (
+            not shard_degree_specified and not replicate_degree_specified
+        ):
             assert model_cfg['ffn_config']['device_mesh'] == [8]
         else:
             assert model_cfg['ffn_config']['device_mesh'] == [2, 4]

--- a/tests/utils/test_config_utils.py
+++ b/tests/utils/test_config_utils.py
@@ -10,7 +10,6 @@ from llmfoundry.utils.config_utils import (
     update_config_with_batch_size_info,
 )
 
-
 def test_update_config_with_batch_size_info():
     config = {}
     config = update_config_with_batch_size_info(config, 1, 2, 3)
@@ -35,7 +34,7 @@ def test_moe_fsdp_config_ffn_config(
         'lbl_process_group': 'not_real',
         'fc_type': 'torch',
         'ffn_config': {
-            'ffn_type': 'mb_moe',
+            'ffn_type': 'torch_moe',
         },
     }
     fsdp_config = {}
@@ -58,7 +57,7 @@ def test_moe_fsdp_config_ffn_config(
             fsdp_config['data_parallel_replicate_degree'] = 2
 
     # Ensure the ffn_config's device_mesh is set correctly using the fsdp_config
-    with patch('composer.utils.dist.get_world_size', return_value=8):
+    with patch('composer.utils.dist.get_world_size', return_value=8), patch('catalogue.Registry.__contains__', True):
         _ = process_init_device(model_cfg, fsdp_config)
 
         if should_shard_only or (

--- a/tests/utils/test_config_utils.py
+++ b/tests/utils/test_config_utils.py
@@ -1,7 +1,10 @@
 # Copyright 2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
-from llmfoundry.utils.config_utils import update_config_with_batch_size_info
+from llmfoundry.utils.config_utils import update_config_with_batch_size_info, process_init_device
+from composer.utils import dist
+from unittest.mock import patch
+import pytest
 
 
 def test_update_config_with_batch_size_info():
@@ -13,3 +16,47 @@ def test_update_config_with_batch_size_info():
     assert config['device_train_microbatch_size'] == 2
     assert config['device_train_grad_accum'] == 3
     assert config['device_eval_batch_size'] == 2
+
+@pytest.mark.parametrize('shard_degree_specified', [True, False])
+@pytest.mark.parametrize('replicate_degree_specified', [True, False])
+@pytest.mark.parametrize('should_shard_only', [True, False])
+def test_moe_fsdp_config_ffn_config(
+    shard_degree_specified: bool,
+    replicate_degree_specified: bool,
+    should_shard_only: bool
+):
+    model_cfg = {
+        'moe_world_size': 4,
+        'lbl_process_group': 'not_real',
+        'fc_type': 'torch',
+        'ffn_config': {
+            'ffn_type': 'mb_moe',
+        }
+    }
+    fsdp_config = {}
+    if shard_degree_specified and replicate_degree_specified:
+        if should_shard_only:
+            fsdp_config['data_parallel_shard_degree'] = 8
+            fsdp_config['data_parallel_replicate_degree'] = 1
+        else:
+            fsdp_config['data_parallel_shard_degree'] = 4
+            fsdp_config['data_parallel_replicate_degree'] = 2
+    elif shard_degree_specified:
+        if should_shard_only:
+            fsdp_config['data_parallel_shard_degree'] = 8
+        else:
+            fsdp_config['data_parallel_shard_degree'] = 4
+    elif replicate_degree_specified:
+        if should_shard_only:
+            fsdp_config['data_parallel_replicate_degree'] = 1
+        else:
+            fsdp_config['data_parallel_replicate_degree'] = 2
+    
+    # Ensure the ffn_config's device_mesh is set correctly using the fsdp_config
+    with patch('composer.utils.dist.get_world_size', return_value=8):
+        _ = process_init_device(model_cfg, fsdp_config)
+
+        if should_shard_only or (not shard_degree_specified and not replicate_degree_specified):
+            assert model_cfg['ffn_config']['device_mesh'] == [8]
+        else:
+            assert model_cfg['ffn_config']['device_mesh'] == [2, 4]

--- a/tests/utils/test_config_utils.py
+++ b/tests/utils/test_config_utils.py
@@ -10,6 +10,7 @@ from llmfoundry.utils.config_utils import (
     update_config_with_batch_size_info,
 )
 
+
 def test_update_config_with_batch_size_info():
     config = {}
     config = update_config_with_batch_size_info(config, 1, 2, 3)
@@ -34,7 +35,7 @@ def test_moe_fsdp_config_ffn_config(
         'lbl_process_group': 'not_real',
         'fc_type': 'torch',
         'ffn_config': {
-            'ffn_type': 'torch_moe',
+            'ffn_type': 'mb_moe',
         },
     }
     fsdp_config = {}
@@ -57,7 +58,8 @@ def test_moe_fsdp_config_ffn_config(
             fsdp_config['data_parallel_replicate_degree'] = 2
 
     # Ensure the ffn_config's device_mesh is set correctly using the fsdp_config
-    with patch('composer.utils.dist.get_world_size', return_value=8), patch('catalogue.Registry.__contains__', True):
+    with patch('composer.utils.dist.get_world_size', return_value=8
+              ), patch('catalogue.Registry.__contains__', return_value=True):
         _ = process_init_device(model_cfg, fsdp_config)
 
         if should_shard_only or (

--- a/tests/utils/test_config_utils.py
+++ b/tests/utils/test_config_utils.py
@@ -4,10 +4,11 @@
 from unittest.mock import patch
 
 import pytest
-from composer.utils import dist
 
-from llmfoundry.utils.config_utils import (process_init_device,
-                                           update_config_with_batch_size_info,)
+from llmfoundry.utils.config_utils import (
+    process_init_device,
+    update_config_with_batch_size_info,
+)
 
 
 def test_update_config_with_batch_size_info():

--- a/tests/utils/test_config_utils.py
+++ b/tests/utils/test_config_utils.py
@@ -58,8 +58,10 @@ def test_moe_fsdp_config_ffn_config(
             fsdp_config['data_parallel_replicate_degree'] = 2
 
     # Ensure the ffn_config's device_mesh is set correctly using the fsdp_config
-    with patch('composer.utils.dist.get_world_size', return_value=8
-              ), patch('catalogue.Registry.__contains__', return_value=True):
+    with patch(
+        'composer.utils.dist.get_world_size',
+        return_value=8,
+    ), patch('catalogue.Registry.__contains__', return_value=True):
         _ = process_init_device(model_cfg, fsdp_config)
 
         if should_shard_only or (


### PR DESCRIPTION
Bump composer to 0.24.1, and as part of that, we replace parts of code that assume `device_mesh` is a key specified in the fsdp_config dict.

Added unit test for correct fsdp_config --> ffn_config device mesh parsing

This also resolves issues we were seeing with not using device mesh in regression tests.
Successfully reran failing regressions, which succeeded.