### PR TITLE
Enable cross attention layers

### DIFF
--- a/llmfoundry/models/layers/attention.py
+++ b/llmfoundry/models/layers/attention.py
@@ -464,12 +464,7 @@ class GroupedQueryAttention(nn.Module):
         self.sliding_window_size = sliding_window_size
         self.reuse_kv_layer_idx = reuse_kv_layer_idx
 
-        if kv_dim is not None:
-            self.kv_dim = kv_dim
-            assert fused_qkv is False, 'Cannot use separate kv_dim from d_model for fused_qkv'
-        else:
-            self.kv_dim = self.d_model
-
+        self.kv_dim = kv_dim if kv_dim is not None else self.d_model
         self.head_dim = d_model // n_heads
 
         # Usually, fc_type dict should be passed in through MPTBlock's __init__ function.

--- a/llmfoundry/models/layers/attention.py
+++ b/llmfoundry/models/layers/attention.py
@@ -672,7 +672,10 @@ class GroupedQueryAttention(nn.Module):
             return query, key, value
 
         if self.fused_qkv:
-            assert key_value_states is None, 'Cannot use separate hidden and key_value states for fused_qkv'
+            if key_value_states is not None:
+                raise ValueError(
+                    'Cannot use separate hidden and key_value states when fused_qkv = True.',
+                )
             qkv = self.Wqkv(x)
 
             if self.clip_qkv:

--- a/llmfoundry/models/mpt/configuration_mpt.py
+++ b/llmfoundry/models/mpt/configuration_mpt.py
@@ -95,6 +95,7 @@ class MPTConfig(PretrainedConfig):
                     type (str): Can be one of 'no_scaling', 'linear', or 'dynamic'. 'no_scaling' uses the default implementation for rotary embeddings, 'linear' uses linear scaling as proposed by the Reddit user /u/kaiokendev, and 'dynamic' uses Dynamic NTK scaling as proposed by the Reddit users /u/bloc97 and /u/emozilla.
                     factor (float): Scaling factor to use if using 'linear' or 'dynamic' as rope_scaling.type.
                 kv_n_heads (Optional[int]): For grouped_query_attention only, allow user to specify number of kv heads.
+                kv_dim (Optional[int]): For cross-attention only, allow user to specify different input dimensions for kv projections.
             ffn_config (Dict): A dictionary used to configure the model's ffn module:
                 ffn_type (str): type of ffn to use. Options: mptmlp, mptglu, te_ln_mlp
             init_device (str): The device to use for parameter initialization.

--- a/llmfoundry/models/mpt/configuration_mpt.py
+++ b/llmfoundry/models/mpt/configuration_mpt.py
@@ -336,6 +336,11 @@ class MPTConfig(PretrainedConfig):
             raise NotImplementedError(
                 'sliding window attention only implemented for torch attention and flash attention (v2.3.0 or higher).',
             )
+        if self.attn_config['kv_dim'] is not None and self.attn_config[
+            'fused_qkv']:
+            raise ValueError(
+                'fused_qkv should be False when "kv_dim" is specified.',
+            )
         if self.embedding_fraction > 1 or self.embedding_fraction <= 0:
             raise ValueError(
                 'model.embedding_fraction must be between 0 (exclusive) and 1 (inclusive)!',

--- a/llmfoundry/models/utils/config_defaults.py
+++ b/llmfoundry/models/utils/config_defaults.py
@@ -32,6 +32,7 @@ attn_config_defaults: dict = {
         'type': 'no_scaling',
         'factor': 1.0,
     },
+    'kv_dim': None,
 }
 
 init_config_defaults: dict = {

--- a/tests/models/layers/test_attention.py
+++ b/tests/models/layers/test_attention.py
@@ -5,6 +5,7 @@ import math
 
 import pytest
 import torch
+from composer.utils import reproducibility
 
 from llmfoundry.models.layers.attention import (
     attention_implementations,
@@ -308,18 +309,82 @@ def test_cross_attn_as_self_attn(attn_name: str, dim: int):
     else:
         raise ValueError(f'Unknown attention name: {attn_name}')
 
-    attn_config_unfused = generic_attn_kwargs.copy()
-    attn_config_unfused['fused_qkv'] = False
+    attn_config = generic_attn_kwargs.copy()
+    attn_config['fused_qkv'] = False
 
     attn_layer = build_attention_layer(
         name=attn_name,
-        attn_kwargs=attn_config_unfused,
+        attn_kwargs=attn_config,
     )
 
     x1 = torch.randn(1, 1, dim)
     x2 = x1.detach().clone()
 
-    out_fused, _, _ = attn_layer(hidden_states=x1)
-    out_unfused, _, _ = attn_layer(hidden_states=x1, key_value_states=x2)
+    out_fused, _, _ = attn_layer(x1)
+    out_unfused, _, _ = attn_layer(x1, key_value_states=x2)
+
+    assert torch.allclose(out_fused, out_unfused)
+
+
+@pytest.mark.parametrize(
+    'attn_name',
+    ['multihead_attention', 'grouped_query_attention', 'multiquery_attention'],
+)
+@pytest.mark.parametrize('dim', [1024])
+def test_cross_attn_kv_dim(attn_name: str, dim: int):
+    d_head = 128
+    n_heads = dim // d_head
+
+    generic_attn_kwargs = {
+        'd_model': dim,
+        'n_heads': n_heads,
+        'fc_type': {
+            'name': 'torch',
+        },
+        'device': 'cpu',
+        'attn_pdrop': 0.0,
+        'attn_impl': 'torch',
+        'qk_ln': False,
+        'qk_gn': False,
+        'clip_qkv': None,
+        'softmax_scale': None,
+        'sliding_window_size': -1,
+    }
+
+    if attn_name == 'grouped_query_attention':
+        kv_n_heads = 2
+        generic_attn_kwargs['kv_n_heads'] = kv_n_heads
+    elif attn_name == 'multiquery_attention':
+        kv_n_heads = 1
+    elif attn_name == 'multihead_attention':
+        kv_n_heads = n_heads
+    else:
+        raise ValueError(f'Unknown attention name: {attn_name}')
+
+    # layer with only dim passed in
+    attn_config = generic_attn_kwargs.copy()
+    attn_config['fused_qkv'] = False
+
+    reproducibility.seed_all(42)
+    attn_layer_no_kv = build_attention_layer(
+        name=attn_name,
+        attn_kwargs=attn_config,
+    )
+
+    # layer with kv_dim = dim passed in
+    attn_config = generic_attn_kwargs.copy()
+    attn_config['fused_qkv'] = False
+    attn_config['kv_dim'] = dim
+
+    reproducibility.seed_all(42)
+    attn_layer_kv = build_attention_layer(
+        name=attn_name,
+        attn_kwargs=attn_config,
+    )
+
+    x1 = torch.randn(1, 1, dim)
+
+    out_fused, _, _ = attn_layer_no_kv(x1)
+    out_unfused, _, _ = attn_layer_kv(x1)
 
     assert torch.allclose(out_fused, out_unfused)


### PR DESCRIPTION
- enables encoder decoder models if needed
- enables cross attention for flamingo (needed for multimodal)
- enables different kv dim for kv projections (needed for multimodal)