### PR TITLE
tokenizer is never built when converting finetuning dataset

### DIFF
--- a/llmfoundry/command_utils/data_prep/convert_finetuning_dataset.py
+++ b/llmfoundry/command_utils/data_prep/convert_finetuning_dataset.py
@@ -165,7 +165,6 @@ def convert_finetuning_dataset(
         decoder_only_format=not encoder_decoder,
     )
 
-    tokenizer = None
     tokenizer_kwargs = tokenizer_kwargs
     tokenizer_kwargs.update({'model_max_length': max_seq_len})
     if tokenizer:


### PR DESCRIPTION
```python
    tokenizer = None                                                      <--- because of this line
    tokenizer_kwargs = tokenizer_kwargs
    tokenizer_kwargs.update({'model_max_length': max_seq_len})
    if tokenizer:
        tokenizer = build_tokenizer(tokenizer, tokenizer_kwargs)          <--- tokenizer is never built
```