### PR TITLE
Update ci-testing to 0.2.2

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -34,7 +34,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: mosaicml/ci-testing
-        ref: a4cdd8b21b00adb8c9e13f9e7f56aa0f858072dd
+        ref: ee73688ebed3852932da5d5800889889cf54cae1
         path: ./ci-testing
     - uses: ./ci-testing/.github/actions/code-quality
       with:

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -34,7 +34,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: mosaicml/ci-testing
-        ref: 53965d9417983a49003182cfca64286b448f80b3
+        ref: a4cdd8b21b00adb8c9e13f9e7f56aa0f858072dd
         path: ./ci-testing
     - uses: ./ci-testing/.github/actions/code-quality
       with:

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -34,7 +34,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: mosaicml/ci-testing
-        ref: v0.1.2
+        ref: 53965d9417983a49003182cfca64286b448f80b3
         path: ./ci-testing
     - uses: ./ci-testing/.github/actions/code-quality
       with:

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -34,7 +34,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: mosaicml/ci-testing
-        ref: ee73688ebed3852932da5d5800889889cf54cae1
+        ref: v0.2.2
         path: ./ci-testing
     - uses: ./ci-testing/.github/actions/code-quality
       with:

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: mosaicml/ci-testing
-        ref: v0.1.2
+        ref: 53965d9417983a49003182cfca64286b448f80b3
         path: ./ci-testing
     - uses: ./ci-testing/.github/actions/coverage
       with:

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: mosaicml/ci-testing
-        ref: a4cdd8b21b00adb8c9e13f9e7f56aa0f858072dd
+        ref: ee73688ebed3852932da5d5800889889cf54cae1
         path: ./ci-testing
     - uses: ./ci-testing/.github/actions/coverage
       with:

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: mosaicml/ci-testing
-        ref: 53965d9417983a49003182cfca64286b448f80b3
+        ref: a4cdd8b21b00adb8c9e13f9e7f56aa0f858072dd
         path: ./ci-testing
     - uses: ./ci-testing/.github/actions/coverage
       with:

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: mosaicml/ci-testing
-        ref: ee73688ebed3852932da5d5800889889cf54cae1
+        ref: v0.2.2
         path: ./ci-testing
     - uses: ./ci-testing/.github/actions/coverage
       with:

--- a/.github/workflows/pr-cpu.yaml
+++ b/.github/workflows/pr-cpu.yaml
@@ -27,8 +27,6 @@ jobs:
           markers: "not gpu"
           pytest_command: "coverage run -m pytest"
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
     - name: Run PR CPU Tests
       uses: mosaicml/ci-testing/.github/actions/pytest-cpu@v0.2.2
       with:

--- a/.github/workflows/pr-cpu.yaml
+++ b/.github/workflows/pr-cpu.yaml
@@ -30,7 +30,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Run PR CPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-cpu@53965d9417983a49003182cfca64286b448f80b3
+      uses: mosaicml/ci-testing/.github/actions/pytest-cpu@a4cdd8b21b00adb8c9e13f9e7f56aa0f858072dd
       with:
         name: ${{ matrix.name }}
         container: ${{ matrix.container }}

--- a/.github/workflows/pr-cpu.yaml
+++ b/.github/workflows/pr-cpu.yaml
@@ -30,7 +30,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Run PR CPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-cpu@a4cdd8b21b00adb8c9e13f9e7f56aa0f858072dd
+      uses: mosaicml/ci-testing/.github/actions/pytest-cpu@try-again
       with:
         name: ${{ matrix.name }}
         container: ${{ matrix.container }}

--- a/.github/workflows/pr-cpu.yaml
+++ b/.github/workflows/pr-cpu.yaml
@@ -17,6 +17,7 @@ jobs:
   pytest-cpu:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
+    container: ${{ matrix.container }}
     strategy:
       matrix:
         include:

--- a/.github/workflows/pr-cpu.yaml
+++ b/.github/workflows/pr-cpu.yaml
@@ -30,7 +30,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Run PR CPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-cpu@ee73688ebed3852932da5d5800889889cf54cae1
+      uses: mosaicml/ci-testing/.github/actions/pytest-cpu@v0.2.2
       with:
         name: ${{ matrix.name }}
         container: ${{ matrix.container }}

--- a/.github/workflows/pr-cpu.yaml
+++ b/.github/workflows/pr-cpu.yaml
@@ -30,7 +30,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Run PR CPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-cpu@try-again
+      uses: mosaicml/ci-testing/.github/actions/pytest-cpu@ee73688ebed3852932da5d5800889889cf54cae1
       with:
         name: ${{ matrix.name }}
         container: ${{ matrix.container }}

--- a/.github/workflows/pr-cpu.yaml
+++ b/.github/workflows/pr-cpu.yaml
@@ -29,7 +29,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Run PR CPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-cpu@v0.1.2
+      uses: mosaicml/ci-testing/.github/actions/pytest-cpu@53965d9417983a49003182cfca64286b448f80b3
       with:
         name: ${{ matrix.name }}
         container: ${{ matrix.container }}

--- a/.github/workflows/pr-gpu.yaml
+++ b/.github/workflows/pr-gpu.yaml
@@ -27,10 +27,10 @@ jobs:
           markers: "gpu"
           pip_deps: "[all]"
           pytest_command: "coverage run -m pytest"
-          ci_repo_gpu_test_ref: a4cdd8b21b00adb8c9e13f9e7f56aa0f858072dd
+          ci_repo_gpu_test_ref: ee73688ebed3852932da5d5800889889cf54cae1
     steps:
     - name: Run PR GPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@a4cdd8b21b00adb8c9e13f9e7f56aa0f858072dd
+      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@ee73688ebed3852932da5d5800889889cf54cae1
       with:
         container: ${{ matrix.container }}
         git_repo: mosaicml/llm-foundry
@@ -56,10 +56,10 @@ jobs:
           markers: "gpu"
           pip_deps: "[all]"
           pytest_command: "coverage run -m pytest"
-          ci_repo_gpu_test_ref: a4cdd8b21b00adb8c9e13f9e7f56aa0f858072dd
+          ci_repo_gpu_test_ref: ee73688ebed3852932da5d5800889889cf54cae1
     steps:
     - name: Run PR GPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@a4cdd8b21b00adb8c9e13f9e7f56aa0f858072dd
+      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@ee73688ebed3852932da5d5800889889cf54cae1
       with:
         container: ${{ matrix.container }}
         git_repo: mosaicml/llm-foundry
@@ -85,10 +85,10 @@ jobs:
           markers: "gpu"
           pip_deps: "[all]"
           pytest_command: "coverage run -m pytest"
-          ci_repo_gpu_test_ref: a4cdd8b21b00adb8c9e13f9e7f56aa0f858072dd
+          ci_repo_gpu_test_ref: ee73688ebed3852932da5d5800889889cf54cae1
     steps:
     - name: Run PR GPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@a4cdd8b21b00adb8c9e13f9e7f56aa0f858072dd
+      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@ee73688ebed3852932da5d5800889889cf54cae1
       with:
         container: ${{ matrix.container }}
         git_repo: mosaicml/llm-foundry

--- a/.github/workflows/pr-gpu.yaml
+++ b/.github/workflows/pr-gpu.yaml
@@ -27,10 +27,10 @@ jobs:
           markers: "gpu"
           pip_deps: "[all]"
           pytest_command: "coverage run -m pytest"
-          ci_repo_gpu_test_ref: 53965d9417983a49003182cfca64286b448f80b3
+          ci_repo_gpu_test_ref: a4cdd8b21b00adb8c9e13f9e7f56aa0f858072dd
     steps:
     - name: Run PR GPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@53965d9417983a49003182cfca64286b448f80b3
+      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@a4cdd8b21b00adb8c9e13f9e7f56aa0f858072dd
       with:
         container: ${{ matrix.container }}
         git_repo: mosaicml/llm-foundry
@@ -56,10 +56,10 @@ jobs:
           markers: "gpu"
           pip_deps: "[all]"
           pytest_command: "coverage run -m pytest"
-          ci_repo_gpu_test_ref: 53965d9417983a49003182cfca64286b448f80b3
+          ci_repo_gpu_test_ref: a4cdd8b21b00adb8c9e13f9e7f56aa0f858072dd
     steps:
     - name: Run PR GPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@53965d9417983a49003182cfca64286b448f80b3
+      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@a4cdd8b21b00adb8c9e13f9e7f56aa0f858072dd
       with:
         container: ${{ matrix.container }}
         git_repo: mosaicml/llm-foundry
@@ -85,10 +85,10 @@ jobs:
           markers: "gpu"
           pip_deps: "[all]"
           pytest_command: "coverage run -m pytest"
-          ci_repo_gpu_test_ref: 53965d9417983a49003182cfca64286b448f80b3
+          ci_repo_gpu_test_ref: a4cdd8b21b00adb8c9e13f9e7f56aa0f858072dd
     steps:
     - name: Run PR GPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@53965d9417983a49003182cfca64286b448f80b3
+      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@a4cdd8b21b00adb8c9e13f9e7f56aa0f858072dd
       with:
         container: ${{ matrix.container }}
         git_repo: mosaicml/llm-foundry

--- a/.github/workflows/pr-gpu.yaml
+++ b/.github/workflows/pr-gpu.yaml
@@ -18,7 +18,6 @@ jobs:
     name: ${{ matrix.name }}
     if: github.repository_owner == 'mosaicml'
     runs-on: linux-ubuntu-latest
-    container: ${{ matrix.container }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pr-gpu.yaml
+++ b/.github/workflows/pr-gpu.yaml
@@ -4,7 +4,7 @@ on:
     branches:
     - main
     - release/*
-  pull_request:
+  pull_request_target:
     branches:
     - main
     - release/**
@@ -27,10 +27,10 @@ jobs:
           markers: "gpu"
           pip_deps: "[all]"
           pytest_command: "coverage run -m pytest"
-          ci_repo_gpu_test_ref: ee73688ebed3852932da5d5800889889cf54cae1
+          ci_repo_gpu_test_ref: v0.2.2
     steps:
     - name: Run PR GPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@ee73688ebed3852932da5d5800889889cf54cae1
+      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@v0.2.2
       with:
         container: ${{ matrix.container }}
         git_repo: mosaicml/llm-foundry
@@ -56,10 +56,10 @@ jobs:
           markers: "gpu"
           pip_deps: "[all]"
           pytest_command: "coverage run -m pytest"
-          ci_repo_gpu_test_ref: ee73688ebed3852932da5d5800889889cf54cae1
+          ci_repo_gpu_test_ref: v0.2.2
     steps:
     - name: Run PR GPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@ee73688ebed3852932da5d5800889889cf54cae1
+      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@v0.2.2
       with:
         container: ${{ matrix.container }}
         git_repo: mosaicml/llm-foundry
@@ -85,10 +85,10 @@ jobs:
           markers: "gpu"
           pip_deps: "[all]"
           pytest_command: "coverage run -m pytest"
-          ci_repo_gpu_test_ref: ee73688ebed3852932da5d5800889889cf54cae1
+          ci_repo_gpu_test_ref: v0.2.2
     steps:
     - name: Run PR GPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@ee73688ebed3852932da5d5800889889cf54cae1
+      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@v0.2.2
       with:
         container: ${{ matrix.container }}
         git_repo: mosaicml/llm-foundry

--- a/.github/workflows/pr-gpu.yaml
+++ b/.github/workflows/pr-gpu.yaml
@@ -4,7 +4,7 @@ on:
     branches:
     - main
     - release/*
-  pull_request_target:
+  pull_request:
     branches:
     - main
     - release/**
@@ -27,10 +27,10 @@ jobs:
           markers: "gpu"
           pip_deps: "[all]"
           pytest_command: "coverage run -m pytest"
-          ci_repo_gpu_test_ref: v0.1.2
+          ci_repo_gpu_test_ref: 53965d9417983a49003182cfca64286b448f80b3
     steps:
     - name: Run PR GPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@v0.1.2
+      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@53965d9417983a49003182cfca64286b448f80b3
       with:
         container: ${{ matrix.container }}
         git_repo: mosaicml/llm-foundry
@@ -56,10 +56,10 @@ jobs:
           markers: "gpu"
           pip_deps: "[all]"
           pytest_command: "coverage run -m pytest"
-          ci_repo_gpu_test_ref: v0.1.2
+          ci_repo_gpu_test_ref: 53965d9417983a49003182cfca64286b448f80b3
     steps:
     - name: Run PR GPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@v0.1.2
+      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@53965d9417983a49003182cfca64286b448f80b3
       with:
         container: ${{ matrix.container }}
         git_repo: mosaicml/llm-foundry
@@ -85,10 +85,10 @@ jobs:
           markers: "gpu"
           pip_deps: "[all]"
           pytest_command: "coverage run -m pytest"
-          ci_repo_gpu_test_ref: v0.1.2
+          ci_repo_gpu_test_ref: 53965d9417983a49003182cfca64286b448f80b3
     steps:
     - name: Run PR GPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@v0.1.2
+      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@53965d9417983a49003182cfca64286b448f80b3
       with:
         container: ${{ matrix.container }}
         git_repo: mosaicml/llm-foundry

--- a/.github/workflows/pr-gpu.yaml
+++ b/.github/workflows/pr-gpu.yaml
@@ -18,6 +18,7 @@ jobs:
     name: ${{ matrix.name }}
     if: github.repository_owner == 'mosaicml'
     runs-on: linux-ubuntu-latest
+    container: ${{ matrix.container }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/smoketest.yaml
+++ b/.github/workflows/smoketest.yaml
@@ -32,7 +32,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: mosaicml/ci-testing
-        ref: 53965d9417983a49003182cfca64286b448f80b3
+        ref: v0.2.2
         path: ./ci-testing
     - uses: ./ci-testing/.github/actions/smoketest
       with:

--- a/.github/workflows/smoketest.yaml
+++ b/.github/workflows/smoketest.yaml
@@ -32,7 +32,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: mosaicml/ci-testing
-        ref: v0.1.2
+        ref: 53965d9417983a49003182cfca64286b448f80b3
         path: ./ci-testing
     - uses: ./ci-testing/.github/actions/smoketest
       with:

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,7 @@ extra_deps['dev'] = [
 
 extra_deps['databricks'] = [
     'mosaicml[databricks]>=0.24.1,<0.25',
+    'numpy<2',
     'databricks-sql-connector>=3,<4',
     'databricks-connect==14.1.0',
     'lz4>=4,<5',


### PR DESCRIPTION
Updates ci-testing to 0.2.2, which includes switching from pip to uv. Also adds a numpy<2 pin to the databricks dependency group, as the databricks-sql-connector package requires numpy<2.