### PR TITLE
Sort callbacks so that CheckpointSaver goes before HuggingFaceCheckpointer

### DIFF
--- a/llmfoundry/command_utils/train.py
+++ b/llmfoundry/command_utils/train.py
@@ -548,6 +548,15 @@ def train(cfg: DictConfig) -> Trainer:
         spin_dataloaders=train_cfg.spin_dataloaders,
     )
 
+    from composer.callbacks.checkpoint_saver import CheckpointSaver
+
+    print('before', trainer.state.callbacks)
+
+
+    trainer.state.callbacks = sorted(trainer.state.callbacks, key=lambda c: 0 if isinstance(c, CheckpointSaver) else 1 if isinstance(c, HuggingFaceCheckpointer) else 2)
+
+    print('after', trainer.state.callbacks)
+
     # Optionally just save an HF checkpoint
     if train_cfg.only_hf_checkpoint:
         hf_checkpointer_callbacks = [

--- a/llmfoundry/command_utils/train.py
+++ b/llmfoundry/command_utils/train.py
@@ -196,7 +196,7 @@ def _sort_callbacks(trainer: Trainer):
     """
 
     def _sort_key(c: Callback) -> int:
-        # CheckpointSaver goes first because the blocking time is shortest while upload is async.
+        # CheckpointSaver goes before HuggingFaceCheckpointer because the blocking time is shortest while upload is async.
         if isinstance(c, CheckpointSaver):
             return 1
         if isinstance(c, HuggingFaceCheckpointer):

--- a/llmfoundry/command_utils/train.py
+++ b/llmfoundry/command_utils/train.py
@@ -198,10 +198,10 @@ def _sort_callbacks(trainer: Trainer):
     def _sort_key(c: Callback) -> int:
         # CheckpointSaver goes first because the blocking time is shortest while upload is async.
         if isinstance(c, CheckpointSaver):
-            return 0
-        if isinstance(c, HuggingFaceCheckpointer):
             return 1
-        return 2
+        if isinstance(c, HuggingFaceCheckpointer):
+            return 2
+        return 0
 
     trainer.state.callbacks = sorted(trainer.state.callbacks, key=_sort_key)
 


### PR DESCRIPTION
Sort the callbacks so that CheckpointSaver goes first, then HuggingFaceCheckpointer, and finally all other callbacks. This saves time during final checkpoint saving and uploading.

A rough sketch on the reordering based on Llama 70B profiling:
Before
<img width="530" alt="image" src="https://github.com/user-attachments/assets/08e633ea-6376-486b-8520-1e5757a77f6d">

After
<img width="499" alt="image" src="https://github.com/user-attachments/assets/51d1dc5a-83d3-48e3-90de-9eab6dce3078">


e2e run in staging: `ift-meta-llama-3-8b-aoprwt-reordered-q01HKT`
