### PR TITLE
Add HuggingFaceCheckpointer option for only registering final checkpoint

### DIFF
--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -165,7 +165,8 @@ class HuggingFaceCheckpointer(Callback):
             be flattened when editing MPT files.
         final_register_only (bool): If true, only register the model in the MLFlow
             registry on the last batch and do not save the HuggingFace checkpoint. If
-            registration fails, then we will fallback to saving the HuggingFace checkpoint.
+            registration fails or mlflow_registered_model_name is not set, then we will
+            fallback to saving the HuggingFace checkpoint.
     """
 
     def __init__(
@@ -470,6 +471,14 @@ class HuggingFaceCheckpointer(Callback):
         upload_to_save_folder: bool,
         register_to_mlflow: bool,
     ):
+        """Save a HuggingFace formatted checkpoint.
+
+        Args:
+            state (State): The training state.
+            logger (Logger): The logger.
+            upload_to_save_folder (bool): Whether to upload the HF checkpoint to the save folder.
+            register_to_mlflow (bool): Whether to register the model to MLFlow
+        """
         del logger  # unused
 
         self.last_checkpoint_batch = state.timestamp.batch

--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -10,6 +10,7 @@ import re
 import shutil
 import tempfile
 import time
+import warnings
 from multiprocessing.context import SpawnProcess
 from pathlib import Path
 from typing import Any, Optional, Sequence, Union
@@ -195,10 +196,10 @@ class HuggingFaceCheckpointer(Callback):
         # mlflow config setup
         self.mlflow_registered_model_name = mlflow_registered_model_name
         if self.final_register_only and self.mlflow_registered_model_name is None:
-            raise ValueError(
+            warnings.warn(
                 'final_register_only is True, but mlflow_registered_model_name is not set. '
                 +
-                'Please set mlflow_registered_model_name to a valid model name.',
+                f'Falling back to saving the HuggingFace checkpoint to {save_folder=}.',
             )
         if mlflow_logging_config is None:
             mlflow_logging_config = {}

--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -268,7 +268,7 @@ class HuggingFaceCheckpointer(Callback):
             self._save_checkpoint(
                 state,
                 logger,
-                register_to_mflow=(
+                register_to_mlflow=(
                     self.mlflow_registered_model_name is not None and
                     is_last_batch
                 ),
@@ -333,7 +333,7 @@ class HuggingFaceCheckpointer(Callback):
                     state,
                     logger,
                     upload_to_save_folder=True,
-                    register_to_mflow=False,
+                    register_to_mlflow=False,
                 )
 
             # Clean up temporary save directory; all processes are done with it.
@@ -456,7 +456,7 @@ class HuggingFaceCheckpointer(Callback):
         state: State,
         logger: Logger,
         upload_to_save_folder: bool,
-        register_to_mflow: bool,
+        register_to_mlflow: bool,
     ):
         del logger  # unused
 
@@ -639,7 +639,7 @@ class HuggingFaceCheckpointer(Callback):
         dist.barrier()
 
         if dist.get_global_rank() == 0:
-            if register_to_mflow:
+            if register_to_mlflow:
                 new_model_instance = self.transform_model_pre_registration(
                     new_model_instance,
                 )

--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -268,7 +268,10 @@ class HuggingFaceCheckpointer(Callback):
             self._save_checkpoint(
                 state,
                 logger,
-                register_to_mflow=is_last_batch,
+                register_to_mflow=(
+                    self.mlflow_registered_model_name is not None and
+                    is_last_batch
+                ),
                 upload_to_save_folder=not (
                     self.final_register_only and is_last_batch
                 ),

--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -193,14 +193,16 @@ class HuggingFaceCheckpointer(Callback):
 
         self.final_register_only = final_register_only
 
-        # mlflow config setup
         self.mlflow_registered_model_name = mlflow_registered_model_name
         if self.final_register_only and self.mlflow_registered_model_name is None:
+            self.final_register_only = False
             warnings.warn(
-                'final_register_only is True, but mlflow_registered_model_name is not set. '
+                'final_register_only is set to True, but mlflow_registered_model_name is not set. '
                 +
-                f'Falling back to saving the HuggingFace checkpoint to {save_folder=}.',
+                f'Defaulting to final_register_only=False and saving the HuggingFace checkpoint to {save_folder=}.',
             )
+
+        # mlflow config setup
         if mlflow_logging_config is None:
             mlflow_logging_config = {}
         if self.mlflow_registered_model_name is not None:
@@ -281,9 +283,8 @@ class HuggingFaceCheckpointer(Callback):
                     self.mlflow_registered_model_name is not None and
                     is_last_batch
                 ),
-                upload_to_save_folder=not (
-                    self.final_register_only and is_last_batch
-                ),
+                upload_to_save_folder=not self.final_register_only or
+                not is_last_batch,
             )
         elif event == Event.INIT:
             if not isinstance(state.model, HuggingFaceModel):

--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -327,7 +327,6 @@ class HuggingFaceCheckpointer(Callback):
             # Wait for all child processes spawned by the callback to finish.
             timeout = 3600
             wait_start = time.time()
-            state.device
             while not self._all_register_processes_done(state.device):
                 wait_time = time.time() - wait_start
                 if wait_time > timeout:

--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -188,10 +188,17 @@ class HuggingFaceCheckpointer(Callback):
         }[precision]
         self.flatten_imports = flatten_imports
         self.using_peft = False
+
         self.final_register_only = final_register_only
 
         # mlflow config setup
         self.mlflow_registered_model_name = mlflow_registered_model_name
+        if self.final_register_only and self.mlflow_registered_model_name is None:
+            raise ValueError(
+                'final_register_only is True, but mlflow_registered_model_name is not set. '
+                +
+                'Please set mlflow_registered_model_name to a valid model name.',
+            )
         if mlflow_logging_config is None:
             mlflow_logging_config = {}
         if self.mlflow_registered_model_name is not None:

--- a/llmfoundry/command_utils/train.py
+++ b/llmfoundry/command_utils/train.py
@@ -588,7 +588,7 @@ def train(cfg: DictConfig) -> Trainer:
             trainer.state,
             trainer.logger,
             upload_to_save_folder=True,
-            register_to_mlflow=False,
+            register_to_mlflow=True,
         )
         return trainer
 

--- a/llmfoundry/command_utils/train.py
+++ b/llmfoundry/command_utils/train.py
@@ -588,7 +588,7 @@ def train(cfg: DictConfig) -> Trainer:
             trainer.state,
             trainer.logger,
             upload_to_save_folder=True,
-            register_to_mflow=False,
+            register_to_mlflow=False,
         )
         return trainer
 

--- a/llmfoundry/command_utils/train.py
+++ b/llmfoundry/command_utils/train.py
@@ -584,7 +584,12 @@ def train(cfg: DictConfig) -> Trainer:
             )
 
         hf_checkpointer_callback = hf_checkpointer_callbacks[0]
-        hf_checkpointer_callback._save_checkpoint(trainer.state, trainer.logger)
+        hf_checkpointer_callback._save_checkpoint(
+            trainer.state,
+            trainer.logger,
+            upload_to_save_folder=True,
+            register_to_mflow=False,
+        )
         return trainer
 
     if train_cfg.only_composer_checkpoint:

--- a/tests/a_scripts/inference/test_convert_composer_to_hf.py
+++ b/tests/a_scripts/inference/test_convert_composer_to_hf.py
@@ -317,6 +317,7 @@ class MockSpawnProcess:
     def __init__(self, target: Callable, kwargs: dict[str, Any]):
         self.target = target
         self.kwargs = kwargs
+        self.exitcode = 0
 
     def start(self):
         self.target(**self.kwargs)


### PR DESCRIPTION
This would allow us to avoid saving an extra final checkpoint at the end of training.


Example Usage
```
  hf_checkpointer:
    precision: bfloat16
    save_folder: ./local_checkpoints
    save_interval: 1h
    mlflow_logging_config:
      task: llm/v1/chat
      metadata:
        task: llm/v1/chat
        pretrained_model_name: meta-llama/Meta-Llama-3-8B
        databricks_model_family: LlamaForCausalLM (llama-3)
        databricks_model_source: genai-fine-tuning
        databricks_model_size_parameters: 8b
    mlflow_registered_model_name: ift-meta-llama-3-8b-ohuja8
    final_register_only: true
  ```


Branch for testing: `final-register-only-fallback` This adds https://github.com/irenedea/llm-foundry/commit/f63b5e0eff0d0b052e28dcd8711af332da0e024e which raises an error.

fallback: `test-final-register-only-fallback-ATwQG5`
normal: `test-final-register-only-SKerij`


