### PR TITLE
Peft fsdp

### DIFF
--- a/llmfoundry/models/hf/hf_base.py
+++ b/llmfoundry/models/hf/hf_base.py
@@ -121,7 +121,7 @@ class BaseHuggingFaceModel(HuggingFaceModel):
 
         # Prepare for FSDP needs to happen after the super init, so that any model
         # architecture changes are completed
-        self.prepare_inner_model(model, init_device)
+        self.prepare_inner_model(self.model, init_device)
 
     def loss(self, outputs: ModelOutput, batch: Mapping):
         if self.config.use_return_dict:

--- a/llmfoundry/models/hf/hf_base.py
+++ b/llmfoundry/models/hf/hf_base.py
@@ -92,8 +92,6 @@ class BaseHuggingFaceModel(HuggingFaceModel):
 
         model = self.transform_model(model)
 
-        self.prepare_inner_model(model, init_device)
-
         metrics, eval_metrics = self.build_metrics(
             use_train_metrics=use_train_metrics,
             additional_train_metrics=additional_train_metrics,
@@ -120,6 +118,10 @@ class BaseHuggingFaceModel(HuggingFaceModel):
             peft_config=peft_config_object,
             should_save_peft_only=should_save_peft_only,
         )
+
+        # Prepare for FSDP needs to happen after the super init, so that any model
+        # architecture changes are completed
+        self.prepare_inner_model(model, init_device)
 
     def loss(self, outputs: ModelOutput, batch: Mapping):
         if self.config.use_return_dict:

--- a/llmfoundry/models/hf/hf_base.py
+++ b/llmfoundry/models/hf/hf_base.py
@@ -69,7 +69,7 @@ class BaseHuggingFaceModel(HuggingFaceModel):
         config_overrides: Optional[dict[str, Any]] = None,
         use_logits: bool = True,
         shift_labels: bool = False,
-        peft_config: Optional['PeftConfig'] = None,
+        peft_config: Optional[dict[str, Any]] = None,
         allow_embedding_resizing: bool = False,
         use_train_metrics: bool = True,
         additional_train_metrics: Optional[list] = None,

--- a/llmfoundry/models/hf/hf_fsdp.py
+++ b/llmfoundry/models/hf/hf_fsdp.py
@@ -197,17 +197,23 @@ def prepare_hf_causal_lm_model_for_fsdp(
     # PEFT layers should be individually wrapped
     # TODO: Revisit this if we enforce use_orig_params=True, which seems to support
     # mixed frozen/unfrozen FSDP modules
+    print("+"*30)
     if hasattr(model, 'peft_type') and model.peft_type is not None:
         peft_type = model.peft_type.lower()
+        print(peft_type)
         active_adapters = [adapter.lower() for adapter in model.active_adapters]
+        print(active_adapters)
         for name, module in model.named_modules():
             if peft_type in name.lower() and any(
                 adapter in name.lower() for adapter in active_adapters
             ):
+                print(name)
                 has_parameters = next(module.parameters(), None) is not None
                 has_buffers = next(module.buffers(), None) is not None
                 if has_parameters or has_buffers:
+                    print('wrap')
                     module._fsdp_wrap = True
+    print("+"*30)
 
     # FSDP Wrap and Activation Checkpoint every model block
     model.fsdp_wrap_fn = lambda module: isinstance(module, block_type)

--- a/llmfoundry/models/hf/hf_fsdp.py
+++ b/llmfoundry/models/hf/hf_fsdp.py
@@ -197,23 +197,17 @@ def prepare_hf_causal_lm_model_for_fsdp(
     # PEFT layers should be individually wrapped
     # TODO: Revisit this if we enforce use_orig_params=True, which seems to support
     # mixed frozen/unfrozen FSDP modules
-    print("+"*30)
     if hasattr(model, 'peft_type') and model.peft_type is not None:
         peft_type = model.peft_type.lower()
-        print(peft_type)
         active_adapters = [adapter.lower() for adapter in model.active_adapters]
-        print(active_adapters)
         for name, module in model.named_modules():
             if peft_type in name.lower() and any(
                 adapter in name.lower() for adapter in active_adapters
             ):
-                print(name)
                 has_parameters = next(module.parameters(), None) is not None
                 has_buffers = next(module.buffers(), None) is not None
                 if has_parameters or has_buffers:
-                    print('wrap')
                     module._fsdp_wrap = True
-    print("+"*30)
 
     # FSDP Wrap and Activation Checkpoint every model block
     model.fsdp_wrap_fn = lambda module: isinstance(module, block_type)

--- a/tests/models/hf/test_hf_peft_wrapping.py
+++ b/tests/models/hf/test_hf_peft_wrapping.py
@@ -36,6 +36,7 @@ def test_peft_wraps():
             if has_parameters or has_buffers:
                 assert m._fsdp_wrap
 
+
 def test_causal_lm_peft_wraps():
     model = ComposerHFCausalLM(
         tokenizer=None,
@@ -43,7 +44,10 @@ def test_causal_lm_peft_wraps():
         pretrained=False,
         trust_remote_code=True,
         config_overrides={'n_layers': 2},
-        peft_config={'peft_type': 'LORA', 'task_type': 'CAUSAL_LM'},
+        peft_config={
+            'peft_type': 'LORA',
+            'task_type': 'CAUSAL_LM',
+        },
     )
 
     for n, m in model.named_modules():
@@ -52,6 +56,7 @@ def test_causal_lm_peft_wraps():
             has_buffers = any(True for _ in m.buffers())
             if has_parameters or has_buffers:
                 assert m._fsdp_wrap
+
 
 @pytest.mark.world_size(2)
 @pytest.mark.gpu

--- a/tests/models/hf/test_hf_peft_wrapping.py
+++ b/tests/models/hf/test_hf_peft_wrapping.py
@@ -11,6 +11,7 @@ import transformers
 from composer import Trainer
 from peft import LoraConfig, get_peft_model
 
+from llmfoundry.models.hf.hf_causal_lm import ComposerHFCausalLM
 from llmfoundry.models.hf.hf_fsdp import prepare_hf_model_for_fsdp
 from llmfoundry.utils.builders import build_composer_model, build_tokenizer
 
@@ -35,6 +36,22 @@ def test_peft_wraps():
             if has_parameters or has_buffers:
                 assert m._fsdp_wrap
 
+def test_causal_lm_peft_wraps():
+    model = ComposerHFCausalLM(
+        tokenizer=None,
+        pretrained_model_name_or_path='mosaicml/mpt-7b',
+        pretrained=False,
+        trust_remote_code=True,
+        config_overrides={'n_layers': 2},
+        peft_config={'peft_type': 'LORA', 'task_type': 'CAUSAL_LM'},
+    )
+
+    for n, m in model.named_modules():
+        if 'lora' in n and 'default' in n:
+            has_parameters = any(True for _ in m.parameters())
+            has_buffers = any(True for _ in m.buffers())
+            if has_parameters or has_buffers:
+                assert m._fsdp_wrap
 
 @pytest.mark.world_size(2)
 @pytest.mark.gpu


### PR DESCRIPTION
In the refactor in #1467, we accidentally moved the prepare for fsdp call before the super init. This results in peft models not being wrapped correctly, because the peft model change happens in the super init. This PR moves the prepare for fsdp call after the super init (same behavior as before #1467), and adds a unit test for the correct behavior.

Manual test (this oomd before this PR due to incorrect wrapping): `updated-image-6-9W2TKE`