### PR TITLE
Add defaults to HF checkpointer _save_checkpoint

### DIFF
--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -467,8 +467,8 @@ class HuggingFaceCheckpointer(Callback):
         self,
         state: State,
         logger: Logger,
-        upload_to_save_folder: bool,
-        register_to_mlflow: bool,
+        upload_to_save_folder: bool = True,
+        register_to_mlflow: bool = True,
     ):
         """Save a HuggingFace formatted checkpoint.
 


### PR DESCRIPTION
Just adds defaults so the new args don't break any usage of this function outside of foundry