### PR TITLE
enable correct padding_idx for embedding layers

### DIFF
--- a/llmfoundry/models/mpt/modeling_mpt.py
+++ b/llmfoundry/models/mpt/modeling_mpt.py
@@ -396,6 +396,7 @@ class MPTModel(MPTPreTrainedModel):
         self.wte = SharedEmbedding(
             config.vocab_size,
             config.d_model,
+            padding_idx=config.pad_token_id,
             device=config.init_device,
         )
         if self.learned_pos_emb:

--- a/llmfoundry/models/utils/param_init_fns.py
+++ b/llmfoundry/models/utils/param_init_fns.py
@@ -224,6 +224,9 @@ def embedding_init(
             emb_init_fn_ = init_fn_
 
         emb_init_fn_(module.weight)
+        if module.padding_idx is not None:
+            with torch.no_grad():
+                module.weight[module.padding_idx].fill_(0)
 
         return True
 

--- a/tests/models/utils/test_param_init_fns.py
+++ b/tests/models/utils/test_param_init_fns.py
@@ -199,3 +199,34 @@ def test_emb_init(emb_init_cfg: Optional[tuple[str, Union[int, list[int]]]]):
                 emb_init_uniform_lim,
             ) == 2 and emb_init_uniform_lim[0] == emb_init_uniform_lim[1]:
                 assert (model.emb.weight == emb_init_uniform_lim[0]).all()
+
+
+@pytest.mark.parametrize(
+    'emb_init_cfg',
+    [
+        ('emb_init_std', 5),
+    ],
+)
+def test_emb_padding_init(
+    emb_init_cfg: Optional[tuple[str, Union[int, list[int]]]],
+):
+    cfg: dict[str, Union[int, list[int]]] = {
+        'vocab_size': 64,
+        'in_features': 16,
+        'padding_idx': 0,
+    }
+    if emb_init_cfg is not None:
+        cfg[emb_init_cfg[0]] = emb_init_cfg[1]
+    dict_cfg = om.create(cfg)
+
+    model = nn.Embedding(
+        dict_cfg.vocab_size,
+        dict_cfg.in_features,
+        dict_cfg.padding_idx,
+    )
+
+    model.apply(partial(param_init_fns.get('kaiming_normal_'), **dict_cfg))
+    assert isinstance(model, torch.nn.Embedding)
+
+    if dict_cfg.get('emb_init_std') is not None:
+        assert (model.weight[0] == 0).all()

--- a/tests/models/utils/test_param_init_fns.py
+++ b/tests/models/utils/test_param_init_fns.py
@@ -202,21 +202,17 @@ def test_emb_init(emb_init_cfg: Optional[tuple[str, Union[int, list[int]]]]):
 
 
 @pytest.mark.parametrize(
-    'emb_init_cfg',
-    [
-        ('emb_init_std', 5),
-    ],
+    'padding_idx',
+    [0, 2],
 )
-def test_emb_padding_init(
-    emb_init_cfg: Optional[tuple[str, Union[int, list[int]]]],
-):
+def test_emb_padding_init(padding_idx: int,):
     cfg: dict[str, Union[int, list[int]]] = {
         'vocab_size': 64,
         'in_features': 16,
-        'padding_idx': 0,
+        'n_layers': 2,
+        'padding_idx': padding_idx,
+        'emb_init_std': 5,
     }
-    if emb_init_cfg is not None:
-        cfg[emb_init_cfg[0]] = emb_init_cfg[1]
     dict_cfg = om.create(cfg)
 
     model = nn.Embedding(
@@ -229,4 +225,4 @@ def test_emb_padding_init(
     assert isinstance(model, torch.nn.Embedding)
 
     if dict_cfg.get('emb_init_std') is not None:
-        assert (model.weight[0] == 0).all()
+        assert (model.weight[padding_idx] == 0).all()


### PR DESCRIPTION
- This functionality is primarily needed when you call the `resize_position_embeddings` call for a HF model (ie, adding new tokens to vocab). If the pad_token already exists for the config, you need to ensure that it gets set correctly post `_init_weights` call.
- By default, the behavior remains unchanged from today, since the `pad_token_id` - if not specified by the config, defaults to `None` from here: https://github.com/huggingface/transformers/blob/174890280b340b89c5bfa092f6b4fb0e2dc2d7fc/src/transformers/configuration_utils.py#L326 and the padding_idx is equivalently set to `None` 