### PR TITLE
Delete unneeded inner base model in PEFT HF Checkpointer

### DIFF
--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -585,6 +585,7 @@ class HuggingFaceCheckpointer(Callback):
                         new_base_model_instance,
                         original_model.peft_config[active_adapter],
                     )
+                    del new_base_model_instance
                 else:
                     new_model_instance = type(original_model)(new_config)
                     new_model_instance.generation_config.update(


### PR DESCRIPTION
We don't need the inner base model when HF checkpointing PEFT models. This can cause unnecessary memory usage later on.