### PR TITLE
Add allowed keys to chat hf dataset format 

### DIFF
--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -141,18 +141,13 @@ def _get_example_type(example: Example) -> ExampleType:
     if not isinstance(example, Mapping):
         raise InvalidExampleTypeError(str(type(example)))
     if (
-        len(example.keys()) == 1 and any(
-            allowed_message_key in example
-            for allowed_message_key in ALLOWED_MESSAGES_KEYS
-        )
-    ):
-        return 'chat'
-    elif (
         len(example.keys()) == 2 and
         any(p in example for p in ALLOWED_PROMPT_KEYS) and
         any(r in example for r in ALLOWED_RESPONSE_KEYS)
     ):
         return 'prompt_response'
+    elif (all(key in ALLOWED_MESSAGES_KEYS for key in example.keys())):
+        return 'chat'
     else:
         keys = str(set(example.keys()))
         raise UnknownExampleTypeError(keys)

--- a/llmfoundry/utils/exceptions.py
+++ b/llmfoundry/utils/exceptions.py
@@ -34,7 +34,7 @@ __all__ = [
 
 ALLOWED_RESPONSE_KEYS = {'response', 'completion'}
 ALLOWED_PROMPT_KEYS = {'prompt'}
-ALLOWED_MESSAGES_KEYS = {'messages'}
+ALLOWED_MESSAGES_KEYS = {'messages', 'dataset', 'id'}
 
 FailureLocation = Union[Literal['TrainDataloader'], Literal['EvalDataloader']]
 FailureAttribution = Union[Literal['UserError'], Literal['InternalError'],


### PR DESCRIPTION
# Description
Add `dataset` and `id` to allowed keys for chat formatted hf datasets. Enables us to finetune on datasets like [tulu-v2](https://huggingface.co/datasets/allenai/tulu-v2-sft-mixture/tree/main)


# Tests
Before - `tulu-ft-llama3-8b-instruct-trainer-2CHlea` 🔴 
```
[rank6]: UnknownExampleTypeError: Found keys {'dataset', 'id', 'messages'} in dataset.
[rank6]: Unknown example type. For prompt and response finetuning, the valid prompt keys
[rank6]: are {'prompt'} and the valid response keys are {'response', 'completion'}. For
[rank6]: chat finetuning, the allowed keys are {'messages'}
```
After - `tulu-ft-llama3-8b-instruct-trainer-V5i6u6` ✅ 
