### PR TITLE
Make ICL tasks not required for eval

### DIFF
--- a/llmfoundry/command_utils/eval.py
+++ b/llmfoundry/command_utils/eval.py
@@ -272,8 +272,8 @@ def evaluate(cfg: DictConfig) -> tuple[list[Trainer], pd.DataFrame]:
 
     # Mandatory Evaluation Parameters
     icl_tasks = eval_config.icl_tasks or eval_config.icl_tasks_str
-    # if icl_tasks is None:
-    #     raise ValueError('icl_tasks must be specified in the config')
+    if icl_tasks is None:
+        icl_tasks = []
 
     # Optional Evaluation Parameters with default values
     eval_loader_config = eval_config.eval_loader or eval_config.eval_loaders

--- a/llmfoundry/command_utils/eval.py
+++ b/llmfoundry/command_utils/eval.py
@@ -262,7 +262,7 @@ def evaluate(cfg: DictConfig) -> tuple[list[Trainer], pd.DataFrame]:
         EvalConfig,
         EVAL_CONFIG_KEYS,
         transforms=[allow_toplevel_keys],
-        icl_tasks_required=True,
+        icl_tasks_required=False,
     )
 
     model_configs = eval_config.models

--- a/llmfoundry/command_utils/eval.py
+++ b/llmfoundry/command_utils/eval.py
@@ -272,8 +272,8 @@ def evaluate(cfg: DictConfig) -> tuple[list[Trainer], pd.DataFrame]:
 
     # Mandatory Evaluation Parameters
     icl_tasks = eval_config.icl_tasks or eval_config.icl_tasks_str
-    if icl_tasks is None:
-        raise ValueError('icl_tasks must be specified in the config')
+    # if icl_tasks is None:
+    #     raise ValueError('icl_tasks must be specified in the config')
 
     # Optional Evaluation Parameters with default values
     eval_loader_config = eval_config.eval_loader or eval_config.eval_loaders


### PR DESCRIPTION
Currently icl tasks is required as a key to run eval. This doesn't make sense if all I'm trying to do is run an eval dataset via eval_loader(s). So we should set to false instead.