### PR TITLE
Register mosaic logger

### DIFF
--- a/llmfoundry/loggers/__init__.py
+++ b/llmfoundry/loggers/__init__.py
@@ -6,6 +6,7 @@ from composer.loggers import (
     MLFlowLogger,
     TensorboardLogger,
     WandBLogger,
+    MosaicMLLogger,
 )
 
 from llmfoundry.registry import loggers
@@ -18,3 +19,4 @@ loggers.register(
     func=InMemoryLogger,
 )  # for backwards compatibility
 loggers.register('mlflow', func=MLFlowLogger)
+loggers.register('mosaicml', func=MosaicMLLogger)

--- a/llmfoundry/loggers/__init__.py
+++ b/llmfoundry/loggers/__init__.py
@@ -4,9 +4,9 @@
 from composer.loggers import (
     InMemoryLogger,
     MLFlowLogger,
+    MosaicMLLogger,
     TensorboardLogger,
     WandBLogger,
-    MosaicMLLogger,
 )
 
 from llmfoundry.registry import loggers

--- a/tests/loggers/test_mosaic_ml_logger.py
+++ b/tests/loggers/test_mosaic_ml_logger.py
@@ -8,7 +8,8 @@ from llmfoundry.utils.builders import build_logger
 
 def test_mosaic_ml_logger_constructs():
     mosaic_ml_logger = build_logger(
-        'mosaicml', kwargs={'ignore_exceptions': True}
+        'mosaicml',
+        kwargs={'ignore_exceptions': True},
     )
 
     assert isinstance(mosaic_ml_logger, MosaicMLLogger)

--- a/tests/loggers/test_mosaic_ml_logger.py
+++ b/tests/loggers/test_mosaic_ml_logger.py
@@ -1,0 +1,9 @@
+from llmfoundry.utils.builders import build_logger
+
+from composer.loggers import MosaicMLLogger
+
+def test_mosaic_ml_logger_constructs():
+    mosaic_ml_logger = build_logger('mosaicml', kwargs={'ignore_exceptions': True})
+
+    assert isinstance(mosaic_ml_logger, MosaicMLLogger)
+    assert mosaic_ml_logger.ignore_exceptions == True

--- a/tests/loggers/test_mosaic_ml_logger.py
+++ b/tests/loggers/test_mosaic_ml_logger.py
@@ -1,9 +1,15 @@
-from llmfoundry.utils.builders import build_logger
+# Copyright 2024 MosaicML LLM Foundry authors
+# SPDX-License-Identifier: Apache-2.0
 
 from composer.loggers import MosaicMLLogger
 
+from llmfoundry.utils.builders import build_logger
+
+
 def test_mosaic_ml_logger_constructs():
-    mosaic_ml_logger = build_logger('mosaicml', kwargs={'ignore_exceptions': True})
+    mosaic_ml_logger = build_logger(
+        'mosaicml', kwargs={'ignore_exceptions': True}
+    )
 
     assert isinstance(mosaic_ml_logger, MosaicMLLogger)
     assert mosaic_ml_logger.ignore_exceptions == True


### PR DESCRIPTION
Allows creating the MosaicMLLogger directly instead of automatically, which allows specifying kwargs for its construction.

Manual test run: `manual-logger-2-mrqCkr`