### PR TITLE
Hfcheckpointer optional generation config

### DIFF
--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -588,7 +588,7 @@ class HuggingFaceCheckpointer(Callback):
                     del new_base_model_instance
                 else:
                     new_model_instance = type(original_model)(new_config)
-                    if new_model_instance:
+                    if new_model_instance.generation_config:
                         new_model_instance.generation_config.update(
                             **original_model.generation_config.to_dict(),
                         )

--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -588,7 +588,7 @@ class HuggingFaceCheckpointer(Callback):
                     del new_base_model_instance
                 else:
                     new_model_instance = type(original_model)(new_config)
-                    if new_model_instance.generation_config != None:
+                    if new_model_instance.generation_config is not None:
                         new_model_instance.generation_config.update(
                             **original_model.generation_config.to_dict(),
                         )

--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -588,9 +588,10 @@ class HuggingFaceCheckpointer(Callback):
                     del new_base_model_instance
                 else:
                     new_model_instance = type(original_model)(new_config)
-                    new_model_instance.generation_config.update(
-                        **original_model.generation_config.to_dict(),
-                    )
+                    if new_model_instance:
+                        new_model_instance.generation_config.update(
+                            **original_model.generation_config.to_dict(),
+                        )
 
             # Then load the state dict in with "assign" so that the state dict
             # is loaded properly even though the model is initially on meta device.

--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -588,7 +588,7 @@ class HuggingFaceCheckpointer(Callback):
                     del new_base_model_instance
                 else:
                     new_model_instance = type(original_model)(new_config)
-                    if new_model_instance.generation_config:
+                    if new_model_instance.generation_config != None:
                         new_model_instance.generation_config.update(
                             **original_model.generation_config.to_dict(),
                         )

--- a/tests/a_scripts/inference/test_convert_composer_to_hf.py
+++ b/tests/a_scripts/inference/test_convert_composer_to_hf.py
@@ -1675,12 +1675,9 @@ def test_generation_config_variants(
         save_interval='1ba',
     )
 
-    try:
-        checkpointer._save_checkpoint(
-            state=state,
-            logger=logger,
-            upload_to_save_folder=False,
-            register_to_mlflow=False,
-        )
-    except Exception as e:
-        print(f'Test failed: {e} when generation_config is {generation_config}')
+    checkpointer._save_checkpoint(
+        state=state,
+        logger=logger,
+        upload_to_save_folder=False,
+        register_to_mlflow=False,
+    )

--- a/tests/a_scripts/inference/test_convert_composer_to_hf.py
+++ b/tests/a_scripts/inference/test_convert_composer_to_hf.py
@@ -923,6 +923,7 @@ def _assert_checkpoint_equivalence(
     [('1ba', '1ba', '1ba', 1, 1, 'amp_bf16'),
      ('1ba', '1ba', '1ba', 1, 1, 'amp_fp8')],
 )
+@pytest.mark.parametrize('generation_config', [None, {}, {'max_length': 100}])
 @patch('os.cpu_count', MagicMock(return_value=1))
 @patch(
     'llmfoundry.callbacks.hf_checkpointer.SpawnProcess',
@@ -940,6 +941,7 @@ def test_huggingface_conversion_callback(
     expected_normal_checkpoints: int,
     trainer_precision: str,
     peft_config: Optional[dict],
+    generation_config: Optional[dict],
 ):
     if model == 'mptmoe' and fsdp_state_dict_type is None:
         pytest.skip('mptmoe requires FSDP')
@@ -1022,6 +1024,9 @@ def test_huggingface_conversion_callback(
         tokenizer=tokenizer,
         cfg=model_cfg,
     )
+    if generation_config is not None:
+        original_model.model.generation_config = transformers.GenerationConfig(**generation_config)
+
     optimizer_name = optimizer_config.pop('name')
     optimizer = build_optimizer(
         original_model,
@@ -1054,6 +1059,22 @@ def test_huggingface_conversion_callback(
         save_latest_filename=None,
     )
     trainer.fit()
+
+    if dist.get_global_rank() == 0:
+        checkpointer_callback._save_checkpoint(
+            state=trainer.state,
+            logger=MagicMock(),  # Mock logger for this test
+            upload_to_save_folder=True,
+            register_to_mlflow=True
+        )
+        saved_model_path = os.path.join(tmp_path, 'checkpoints', 'huggingface', f'ba{batches_per_epoch}')
+        loaded_model = transformers.AutoModelForCausalLM.from_pretrained(saved_model_path, trust_remote_code=True)
+
+        if generation_config is None:
+            assert loaded_model.generation_config == transformers.GenerationConfig()
+        else:
+            assert loaded_model.generation_config.to_dict() == generation_config
+
 
     _assert_mlflow_logger_calls(mlflow_logger_mock, peft_config)
 

--- a/tests/a_scripts/inference/test_convert_composer_to_hf.py
+++ b/tests/a_scripts/inference/test_convert_composer_to_hf.py
@@ -1655,12 +1655,10 @@ def test_generation_config_variants(
         def __init__(self, config: PretrainedConfig):
             super().__init__()
             self.config = config
+            self.generation_config = getattr(config, 'generation_config', None)
 
     config = AutoConfig.from_pretrained('gpt2')
-    if generation_config is not None:
-        config.generation_config = generation_config
-    else:
-        config.generation_config = None
+    config.generation_config = generation_config
 
     mock_model = MockModel(config)
     logger = MagicMock()

--- a/tests/a_scripts/inference/test_convert_composer_to_hf.py
+++ b/tests/a_scripts/inference/test_convert_composer_to_hf.py
@@ -1656,7 +1656,6 @@ def test_generation_config_variants(
             super().__init__()
             self.config = config
 
-    # Mock a configuration and model with varying generation_config values
     config = AutoConfig.from_pretrained('gpt2')
     if generation_config is not None:
         config.generation_config = generation_config

--- a/tests/a_scripts/inference/test_convert_composer_to_hf.py
+++ b/tests/a_scripts/inference/test_convert_composer_to_hf.py
@@ -1647,7 +1647,7 @@ def test_license_file_finder(
 
 @pytest.mark.parametrize('generation_config', [None, {}, {'max_length': 200}])
 def test_generation_config_variants(
-    generation_config: Optional[dict[str, Any]]
+    generation_config: Optional[dict[str, Any]],
 ):
 
     class MockModel(nn.Module):
@@ -1664,33 +1664,24 @@ def test_generation_config_variants(
         config.generation_config = None
 
     mock_model = MockModel(config)
-
-    # Instantiate the callback
-    checkpointer = HuggingFaceCheckpointer(
-        save_folder='test',
-        save_interval='1ba',
-    )
-
-    # Mock state and model structure
+    logger = MagicMock()
     state = MagicMock()
     state.timestamp.batch = 1
     state.is_model_ddp = False
     state.model.model = mock_model
     state.model.tokenizer = None
 
-    # Mock logger
-    logger = MagicMock()
+    checkpointer = HuggingFaceCheckpointer(
+        save_folder='test',
+        save_interval='1ba',
+    )
 
-    # Call _save_checkpoint method to see if it handles different generation_config gracefully
     try:
         checkpointer._save_checkpoint(
             state=state,
             logger=logger,
             upload_to_save_folder=False,
             register_to_mlflow=False,
-        )
-        print(
-            f'Test passed: No error when generation_config is {generation_config}'
         )
     except Exception as e:
         print(f'Test failed: {e} when generation_config is {generation_config}')


### PR DESCRIPTION
Current hf_checkpointer assumes that generation config exists, which isn't necessarily the case for certain models. DM for testing!