### PR TITLE
Insufficient Permissions Error when trying to access table

### DIFF
--- a/llmfoundry/command_utils/data_prep/convert_delta_to_json.py
+++ b/llmfoundry/command_utils/data_prep/convert_delta_to_json.py
@@ -216,7 +216,14 @@ def run_query(
     spark: Optional['SparkSession'] = None,
     collect: bool = True,
 ) -> Optional[Union[list['Row'], 'DataFrame', 'SparkDataFrame']]:
-    """Run SQL query via databricks-connect or databricks-sql."""
+    """Run SQL query via databricks-connect or databricks-sql.
+    Args:
+        query (str): sql query
+        method (str): select from dbsql and dbconnect
+        cursor (Optional[Cursor]): connection.cursor
+        spark (Optional[SparkSession]): spark session
+        collect (bool): whether to get the underlying data from spark dataframe
+    """
     if method == 'dbsql':
         if cursor is None:
             raise ValueError(f'cursor cannot be None if using method dbsql')

--- a/llmfoundry/command_utils/data_prep/convert_delta_to_json.py
+++ b/llmfoundry/command_utils/data_prep/convert_delta_to_json.py
@@ -234,27 +234,7 @@ def run_query(
     elif method == 'dbconnect':
         if spark == None:
             raise ValueError(f'sparkSession is required for dbconnect')
-
-        try:
-            df = spark.sql(query)
-        except Exception as e:
-            from pyspark.errors import AnalysisException
-            if isinstance(e, AnalysisException):
-                if 'INSUFFICIENT_PERMISSIONS' in e.message:  # pyright: ignore
-                    match = re.search(
-                        r"Schema\s+'([^']+)'",
-                        e.message,  # pyright: ignore
-                    )
-                    if match:
-                        schema_name = match.group(1)
-                        action = f'using the schema {schema_name}'
-                    else:
-                        action = 'using the schema'
-                    raise InsufficientPermissionsError(action=action,) from e
-            raise RuntimeError(
-                f'Error in querying into schema. Restart sparkSession and try again',
-            ) from e
-
+        df = spark.sql(query)
         if collect:
             return df.collect()
         return df

--- a/llmfoundry/command_utils/data_prep/convert_delta_to_json.py
+++ b/llmfoundry/command_utils/data_prep/convert_delta_to_json.py
@@ -451,10 +451,15 @@ def fetch(
     try:
         # Get total rows
         nrows = get_total_rows(tablename, method, cursor, sparkSession)
-        
+
         # Get columns info
-        columns, order_by, columns_str = get_columns_info(tablename, method, cursor, sparkSession)
-        
+        columns, order_by, columns_str = get_columns_info(
+            tablename,
+            method,
+            cursor,
+            sparkSession,
+        )
+
         if method == 'dbconnect' and sparkSession is not None:
             log.info(f'{processes=}')
             df = sparkSession.table(tablename)
@@ -488,18 +493,18 @@ def fetch(
                 )
 
     except Exception as e:
-        from pyspark.errors import AnalysisException
         from databricks.sql.exc import ServerOperationError
+        from pyspark.errors import AnalysisException
 
         if isinstance(e, (AnalysisException, ServerOperationError)):
             if 'INSUFFICIENT_PERMISSIONS' in str(e):
                 raise InsufficientPermissionsError(str(e)) from e
-        
+
         if isinstance(e, InsufficientPermissionsError):
             raise
 
         # For any other exception, raise a general error
-        raise RuntimeError(f"Error processing {tablename}: {str(e)}") from e
+        raise RuntimeError(f'Error processing {tablename}: {str(e)}') from e
 
     finally:
         if cursor is not None:

--- a/llmfoundry/command_utils/data_prep/convert_delta_to_json.py
+++ b/llmfoundry/command_utils/data_prep/convert_delta_to_json.py
@@ -493,13 +493,7 @@ def fetch(
 
         if isinstance(e, (AnalysisException, ServerOperationError)):
             if 'INSUFFICIENT_PERMISSIONS' in str(e):
-                match = re.search(r"(?:Table|Schema)\s+'([^']+)'", str(e))
-                if match:
-                    object_name = match.group(1)
-                    action = f'accessing {object_name}'
-                else:
-                    action = f'accessing {tablename}'
-                raise InsufficientPermissionsError(action=action) from e
+                raise InsufficientPermissionsError(str(e)) from e
         
         if isinstance(e, InsufficientPermissionsError):
             raise

--- a/llmfoundry/utils/exceptions.py
+++ b/llmfoundry/utils/exceptions.py
@@ -456,6 +456,5 @@ class HighLossError(UserError):
 class InsufficientPermissionsError(UserError):
     """Error thrown when the user does not have sufficient permissions."""
 
-    def __init__(self, action: str) -> None:
-        message = f'Insufficient permissions when {action}. Please check your permissions.'
-        super().__init__(message, action=action)
+    def __init__(self, message: str) -> None:
+        super().__init__(message)

--- a/llmfoundry/utils/exceptions.py
+++ b/llmfoundry/utils/exceptions.py
@@ -457,4 +457,12 @@ class InsufficientPermissionsError(UserError):
     """Error thrown when the user does not have sufficient permissions."""
 
     def __init__(self, message: str) -> None:
+        self.message = message
         super().__init__(message)
+
+    def __reduce__(self):
+        # Return a tuple of class, a tuple of arguments, and optionally state
+        return (InsufficientPermissionsError, (self.message,))
+
+    def __str__(self):
+        return self.message

--- a/tests/utils/test_exceptions.py
+++ b/tests/utils/test_exceptions.py
@@ -4,7 +4,7 @@
 import contextlib
 import inspect
 import pickle
-from typing import Any, Optional
+from typing import Any, Optional, get_type_hints
 
 import pytest
 
@@ -16,10 +16,11 @@ def create_exception_object(
 ):
 
     def get_init_annotations(cls: type):
-        if hasattr(inspect, 'get_annotations'):
-            return inspect.get_annotations(cls.__init__)
-        else:
-            return getattr(cls.__init__, '__annotations__', {})
+        try:
+            return get_type_hints(cls.__init__)
+        except (AttributeError, TypeError):
+            # Handle cases where __init__ does not exist or has no annotations
+            return {}
 
     # First, try to get annotations from the class itself
     required_args = get_init_annotations(exception_class)


### PR DESCRIPTION
To resolve this when permissions thrown by spark are not properly wrapped.

Instead of regex every variant of security perm errors, it's a lot easier to just rewarp the errors thrown by spark. Three scenerios were manually tested and passed:

User doesn't have access to catalog
User doesn't have access to schema (but has access for catalog)
User doesn't have SELECT for table (has access to catalog + schema)

This way, it's a lot easier to catch the permission spark errors.
