### PR TITLE
Deterministic GCRP Errors 

### DIFF
--- a/tests/a_scripts/data_prep/test_convert_delta_to_json.py
+++ b/tests/a_scripts/data_prep/test_convert_delta_to_json.py
@@ -7,8 +7,11 @@ from argparse import Namespace
 from typing import Any
 from unittest.mock import MagicMock, mock_open, patch
 
+import grpc
+
 from llmfoundry.command_utils.data_prep.convert_delta_to_json import (
     InsufficientPermissionsError,
+    InternalError,
     download,
     fetch,
     fetch_DT,
@@ -524,3 +527,52 @@ class TestConvertDeltaToJsonl(unittest.TestCase):
             format_tablename('hyphenated-catalog.schema.test_table'),
             '`hyphenated-catalog`.`schema`.`test_table`',
         )
+
+    @patch('llmfoundry.command_utils.data_prep.convert_delta_to_json.fetch')
+    @patch(
+        'llmfoundry.command_utils.data_prep.convert_delta_to_json.validate_and_get_cluster_info'
+    )
+    def test_fetch_DT_grpc_error_handling(
+        self, mock_validate_cluster_info: MagicMock, mock_fetch: MagicMock
+    ):
+        # Arrange
+        # Mock the validate_and_get_cluster_info to return test values
+        mock_validate_cluster_info.return_value = ('dbconnect', None, None)
+
+        # Create a grpc.RpcError with StatusCode.INTERNAL and specific details
+        grpc_error = grpc.RpcError()
+        grpc_error.code = lambda: grpc.StatusCode.INTERNAL
+        grpc_error.details = lambda: 'Job aborted due to stage failure: Task failed due to an error.'
+
+        # Configure the fetch function to raise the grpc.RpcError
+        mock_fetch.side_effect = grpc_error
+
+        # Test inputs
+        delta_table_name = 'test_table'
+        json_output_folder = '/tmp/to/jsonl'
+        http_path = None
+        cluster_id = None
+        use_serverless = False
+        DATABRICKS_HOST = 'https://test-host'
+        DATABRICKS_TOKEN = 'test-token'
+
+        # Act & Assert
+        with self.assertRaises(InternalError) as context:
+            fetch_DT(
+                delta_table_name=delta_table_name,
+                json_output_folder=json_output_folder,
+                http_path=http_path,
+                cluster_id=cluster_id,
+                use_serverless=use_serverless,
+                DATABRICKS_HOST=DATABRICKS_HOST,
+                DATABRICKS_TOKEN=DATABRICKS_TOKEN,
+            )
+
+        # Verify that the InternalError contains the expected message
+        self.assertIn('Possible Hardware Failure', str(context.exception))
+        self.assertIn(
+            'Job aborted due to stage failure', str(context.exception)
+        )
+
+        # Verify that fetch was called
+        mock_fetch.assert_called_once()


### PR DESCRIPTION
We've seeing
`"<_MultiThreadedRendezvous of RPC that terminated with:\n\tstatus = StatusCode.INTERNAL\n\tdetails = \"Remote exception occurred:\n\tjava.lang.NoClassDefFoundError: Could not initialize class grpc_shaded.com.linecorp.armeria.internal.common.RequestContextUtil\n\t\tat grpc_shaded.com.linecorp.armeria.common.Re..."`

When hardware failures occue, when spark is not properly connecting. Instead, we should wrap the error and tell the user that it is a potential hardware issue.

https://databricks.atlassian.net/browse/ES-1267659?focusedCommentId=5630601&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-5630601