### PR TITLE
Changes for dataset swap callback

### DIFF
--- a/llmfoundry/callbacks/dataset_swap_callback.py
+++ b/llmfoundry/callbacks/dataset_swap_callback.py
@@ -8,7 +8,7 @@ the future.
 """
 
 import logging
-from typing import Any
+from dataclasses import dataclass
 
 from composer.core import State
 from composer.loggers import Logger
@@ -21,6 +21,12 @@ from llmfoundry.utils.warnings import experimental_class
 log = logging.getLogger(__name__)
 
 __all__ = ['DatasetSwap']
+
+
+@dataclass
+class DatasetSwapStateDict:
+    dataset_index: int
+    all_dataset_configs: list
 
 
 @experimental_class('DatasetSwap callback')
@@ -104,11 +110,11 @@ class DatasetSwap(CallbackWithConfig):
             self.all_dataset_configs.append(self.current_dataset_config)
 
     def state_dict(self):
-        return {
-            'dataset_index': self.dataset_index,
-            'all_dataset_configs': self.all_dataset_configs,
-        }
+        return DatasetSwapStateDict(
+            dataset_index=self.dataset_index,
+            all_dataset_configs=self.all_dataset_configs,
+        )
 
-    def load_state_dict(self, state: dict[str, Any]):
-        self.saved_dataset_index = state.get('dataset_index', 0)
-        self.all_dataset_configs = state.get('all_dataset_configs', [])
+    def load_state_dict(self, state: DatasetSwapStateDict):
+        self.saved_dataset_index = getattr(state, 'dataset_index', 0)
+        self.all_dataset_configs = getattr(state, 'all_dataset_configs', [])

--- a/llmfoundry/callbacks/dataset_swap_callback.py
+++ b/llmfoundry/callbacks/dataset_swap_callback.py
@@ -110,11 +110,19 @@ class DatasetSwap(CallbackWithConfig):
             self.all_dataset_configs.append(self.current_dataset_config)
 
     def state_dict(self):
-        return DatasetSwapStateDict(
-            dataset_index=self.dataset_index,
-            all_dataset_configs=self.all_dataset_configs,
-        )
+        return {
+            'callback_state':
+                DatasetSwapStateDict(
+                    dataset_index=self.dataset_index,
+                    all_dataset_configs=self.all_dataset_configs,
+                ),
+        }
 
-    def load_state_dict(self, state: DatasetSwapStateDict):
-        self.saved_dataset_index = getattr(state, 'dataset_index', 0)
-        self.all_dataset_configs = getattr(state, 'all_dataset_configs', [])
+    def load_state_dict(self, state: dict[str, DatasetSwapStateDict]):
+        _dummy_obj = DatasetSwapStateDict(
+            dataset_index=0,
+            all_dataset_configs=[],
+        )
+        _state_obj = state.get('callback_state', _dummy_obj)
+        self.saved_dataset_index = getattr(_state_obj, 'dataset_index')
+        self.all_dataset_configs = getattr(_state_obj, 'all_dataset_configs')


### PR DESCRIPTION
With the 2.4 upgrade for DCP on pytorch, it flattens all state dict elements which are instances of typing.Mapping or lists before saving. However, during loading, we are expected either Mapping / lists, instead of flattened elements for the runs. This is leading to errors, for eg: initial run `134m-draft-10tpr-train-BNMzsm` and follow-up run `134m-draft-cl-10tpr-train-7ecT7Q`. 

a quick workaround is to make the statedict as a dataclass, so that it does not get traversed (ie, flattened). Runs with fixes enabled here: initial run `134m-draft-10tpr-train-12VvIx` and follow-up run `134m-cl-draft-10tpr-train-7fsU4r`. 

![Screenshot 2024-10-04 at 13 36 10](https://github.com/user-attachments/assets/c4638a99-3396-4049-92e7-084571f3c257)