### PR TITLE
Change Release Base Images to 

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,8 +7,54 @@ on:
   workflow_dispatch:
 
 jobs:
+  code-quality:
+    uses: ./.github/workflows/code-quality.yaml
+
+  pypi-packaging:
+    name: Build and Publish llm-foundry PyPI Package
+    needs:
+    - code-quality
+    runs-on: linux-ubuntu-latest
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@v3
+
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.9"
+
+    - name: Build source and wheel distributions
+      run: |
+        if [[ "${{ github.ref }}" =~ refs\/tags\/v ]]; then
+          PYPI_PACKAGE_NAME="llm-foundry"
+        else
+          PYPI_PACKAGE_NAME="llm-foundry-test-$(date +%Y%m%d%H%M%S)"
+        fi
+
+        python -m pip install --upgrade build twine
+        python -m build
+        twine check --strict dist/*
+
+    - name: Publish 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      if: contains(github.ref, 'refs/tags/v')
+      with:
+        user: __token__
+        password: ${{ secrets.PROD_PYPI_API_TOKEN }}
+
+    - name: Publish distribution 📦 to Test PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      if: contains(github.ref, 'refs/heads/') || contains(github.ref, 'refs/pull/')
+      with:
+        user: __token__
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
+
   build-docker:
     name: Build llm-foundry Release Docker Image
+    needs:
+    - code-quality
     runs-on: mosaic-8wide
     if: github.repository_owner == 'mosaicml'
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,7 +77,7 @@ jobs:
         TAG_NAME=$(echo "${BRANCH_NAME}" | sed 's/\//_/g')
         echo "BRANCH_NAME=${BRANCH_NAME}" >> $GITHUB_ENV
 
-        # Don't overwrite latest if testing
+        # Don't trigger formal release if manual trigger
         if [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF}" =~ ^refs/tags/v ]]; then
           echo "DOCKER_TAG=mosaicml/llm-foundry:release_${TAG_NAME}" >> $GITHUB_ENV
           echo "AWS_DOCKER_TAG=mosaicml/llm-foundry:release_${TAG_NAME}_aws" >> $GITHUB_ENV

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,10 +77,16 @@ jobs:
         TAG_NAME=$(echo "${BRANCH_NAME}" | sed 's/\//_/g')
         echo "BRANCH_NAME=${BRANCH_NAME}" >> $GITHUB_ENV
 
-        echo "DOCKER_TAG=mosaicml/llm-foundry:release_${TAG_NAME}" >> $GITHUB_ENV
-        echo "AWS_DOCKER_TAG=mosaicml/llm-foundry:release_${TAG_NAME}_aws" >> $GITHUB_ENV
-        echo "LATEST_TAG=mosaicml/llm-foundry:release-latest" >> $GITHUB_ENV
-        echo "AWS_LATEST_TAG=mosaicml/llm-foundry:release_aws-latest" >> $GITHUB_ENV
+        # Don't overwrite latest if testing
+        if [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF}" =~ ^refs/tags/v ]]; then
+          echo "DOCKER_TAG=mosaicml/llm-foundry:release_${TAG_NAME}" >> $GITHUB_ENV
+          echo "AWS_DOCKER_TAG=mosaicml/llm-foundry:release_${TAG_NAME}_aws" >> $GITHUB_ENV
+          echo "LATEST_TAG=mosaicml/llm-foundry:release-latest" >> $GITHUB_ENV
+          echo "AWS_LATEST_TAG=mosaicml/llm-foundry:release_aws-latest" >> $GITHUB_ENV
+        else
+          echo "DOCKER_TAG=mosaicml/llm-foundry:test_release_${TAG_NAME}" >> $GITHUB_ENV
+          echo "AWS_DOCKER_TAG=mosaicml/llm-foundry:test_release_${TAG_NAME}_aws" >> $GITHUB_ENV
+        fi
 
 
     - name: Build and push AWS Docker image

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,54 +7,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  code-quality:
-    uses: ./.github/workflows/code-quality.yaml
-
-  pypi-packaging:
-    name: Build and Publish llm-foundry PyPI Package
-    needs:
-    - code-quality
-    runs-on: linux-ubuntu-latest
-    steps:
-    - name: Checkout source
-      uses: actions/checkout@v3
-
-    - name: Set up Python
-      uses: actions/setup-python@v3
-      with:
-        python-version: "3.9"
-
-    - name: Build source and wheel distributions
-      run: |
-        if [[ "${{ github.ref }}" =~ refs\/tags\/v ]]; then
-          PYPI_PACKAGE_NAME="llm-foundry"
-        else
-          PYPI_PACKAGE_NAME="llm-foundry-test-$(date +%Y%m%d%H%M%S)"
-        fi
-
-        python -m pip install --upgrade build twine
-        python -m build
-        twine check --strict dist/*
-
-    - name: Publish 📦 to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      if: contains(github.ref, 'refs/tags/v')
-      with:
-        user: __token__
-        password: ${{ secrets.PROD_PYPI_API_TOKEN }}
-
-    - name: Publish distribution 📦 to Test PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      if: contains(github.ref, 'refs/heads/') || contains(github.ref, 'refs/pull/')
-      with:
-        user: __token__
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
-
   build-docker:
     name: Build llm-foundry Release Docker Image
-    needs:
-    - code-quality
     runs-on: mosaic-8wide
     if: github.repository_owner == 'mosaicml'
     steps:
@@ -93,7 +47,7 @@ jobs:
           ${{ env.AWS_DOCKER_TAG }}
           ${{ env.AWS_LATEST_TAG }}
         build-args: |
-          BASE_IMAGE=mosaicml/pytorch:2.4.0_cu124-python3.11-ubuntu20.04-aws
+          BASE_IMAGE=mosaicml/llm-foundry:2.4.0_cu124-latest
           BRANCH_NAME=${{ env.BRANCH_NAME }}
           DEP_GROUPS=[all]
           KEEP_FOUNDRY=true
@@ -108,7 +62,7 @@ jobs:
           ${{ env.DOCKER_TAG }}
           ${{ env.LATEST_TAG }}
         build-args: |
-          BASE_IMAGE=mosaicml/pytorch:2.4.0_cu124-python3.11-ubuntu20.04
+          BASE_IMAGE=mosaicml/llm-foundry:2.4.0_cu124-latest
           BRANCH_NAME=${{ env.BRANCH_NAME }}
           DEP_GROUPS=[all]
           KEEP_FOUNDRY=true


### PR DESCRIPTION
This is to speed up release process by making us not need to reinstall all of transformer_engine. Docker caching doesn't work here because of https://github.com/mosaicml/llm-foundry/blob/8e78eb53f37a01ddb249da36438de0f86f7cf688/Dockerfile#L15, where if the branch name is different than main (and it will be since we expect it to be whatever branch is associated with the release), cache will be invaliadted.

Testing:
<img width="928" alt="image" src="https://github.com/user-attachments/assets/9940d2fc-8f79-4248-8293-5cf34b040b65">
