### PR TITLE
Use fun default composer run names

### DIFF
--- a/llmfoundry/command_utils/train.py
+++ b/llmfoundry/command_utils/train.py
@@ -312,9 +312,9 @@ def train(cfg: DictConfig) -> Trainer:
 
     # Optional parameters will be set to default values if not specified.
     env_run_name: Optional[str] = os.environ.get('RUN_NAME', None)
-    run_name: str = (
+    run_name: Optional[str] = (
         train_cfg.run_name if train_cfg.run_name else env_run_name
-    ) or 'llm'
+    )
     is_state_dict_sharded: bool = (
         fsdp_config.get('state_dict_type', 'full') == 'sharded'
     ) if fsdp_config else False

--- a/llmfoundry/command_utils/train.py
+++ b/llmfoundry/command_utils/train.py
@@ -323,9 +323,8 @@ def train(cfg: DictConfig) -> Trainer:
     save_filename: str = train_cfg.save_filename if train_cfg.save_filename else 'ep{epoch}-ba{batch}-rank{rank}.pt'
 
     # Enable autoresume from model checkpoints if possible
-    is_user_set_run_name: bool = train_cfg.run_name is not None or run_name is not None
     autoresume_default: bool = False
-    if is_user_set_run_name and \
+    if run_name is not None and \
         train_cfg.save_folder is not None \
         and not train_cfg.save_overwrite \
         and not train_cfg.save_weights_only:

--- a/llmfoundry/command_utils/train.py
+++ b/llmfoundry/command_utils/train.py
@@ -311,10 +311,11 @@ def train(cfg: DictConfig) -> Trainer:
     eval_gauntlet_config = train_cfg.eval_gauntlet or train_cfg.eval_gauntlet_str
 
     # Optional parameters will be set to default values if not specified.
-    env_run_name: Optional[str] = os.environ.get('RUN_NAME', None)
-    run_name: Optional[str] = (
-        train_cfg.run_name if train_cfg.run_name else env_run_name
-    )
+    run_name: Optional[
+        str] = train_cfg.run_name if train_cfg.run_name else os.environ.get(
+            'RUN_NAME',
+            None,
+        )
     is_state_dict_sharded: bool = (
         fsdp_config.get('state_dict_type', 'full') == 'sharded'
     ) if fsdp_config else False
@@ -322,7 +323,7 @@ def train(cfg: DictConfig) -> Trainer:
     save_filename: str = train_cfg.save_filename if train_cfg.save_filename else 'ep{epoch}-ba{batch}-rank{rank}.pt'
 
     # Enable autoresume from model checkpoints if possible
-    is_user_set_run_name: bool = train_cfg.run_name is not None or env_run_name is not None
+    is_user_set_run_name: bool = train_cfg.run_name is not None or run_name is not None
     autoresume_default: bool = False
     if is_user_set_run_name and \
         train_cfg.save_folder is not None \


### PR DESCRIPTION
Our previous default "llm" is depressingly literal, and because it does not change, it is hard to distinguish runs from the same environment.

https://github.com/mosaicml/composer/blob/main/composer/trainer/trainer.py#L549 composer generates some really fun and random run names, we should take advantage of this.

### Testing
Tested on interactive by unsetting COMPOSER_RUN_NAME and RUN_NAME env vars.

created a run called `1729664919-daring-lori`
<img width="935" alt="image" src="https://github.com/user-attachments/assets/fdffda47-6743-4d12-843f-d77d5b3740e1">
