### PR TITLE
Ensure log messages are properly formatted again

### DIFF
--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -124,6 +124,7 @@ def _register_model_with_run_id_multiprocess(
         logging.basicConfig(
             format=
             f'%(asctime)s: rank{dist.get_global_rank()}[%(process)d][%(threadName)s]: %(levelname)s: %(name)s: %(message)s',
+            force=True,
         )
         logging.getLogger('composer').setLevel(composer_logging_level)
 

--- a/llmfoundry/command_utils/data_prep/convert_text_to_mds.py
+++ b/llmfoundry/command_utils/data_prep/convert_text_to_mds.py
@@ -515,6 +515,7 @@ def _configure_logging(logging_level: str):
     logging.basicConfig(
         format=
         f'%(asctime)s: [%(process)d][%(threadName)s]: %(levelname)s: %(name)s: %(message)s',
+        force=True,
     )
     logging_level = logging_level.upper()
     logging.getLogger('llmfoundry').setLevel(logging_level)

--- a/llmfoundry/command_utils/eval.py
+++ b/llmfoundry/command_utils/eval.py
@@ -272,6 +272,7 @@ def evaluate(cfg: DictConfig) -> tuple[list[Trainer], pd.DataFrame]:
             # 2022-06-29 11:22:26,152: rank0[822018][MainThread]: INFO: Message here
             format=
             f'%(asctime)s: rank{dist.get_global_rank()}[%(process)d][%(threadName)s]: %(levelname)s: %(name)s: %(message)s',
+            force=True,
         )
         logging.getLogger('llmfoundry').setLevel(
             eval_config.python_log_level.upper(),

--- a/llmfoundry/command_utils/train.py
+++ b/llmfoundry/command_utils/train.py
@@ -227,6 +227,7 @@ def train(cfg: DictConfig) -> Trainer:
             # 2022-06-29 11:22:26,152: rank0[822018][MainThread]: INFO: Message here
             format=
             f'%(asctime)s: rank{dist.get_global_rank()}[%(process)d][%(threadName)s]: %(levelname)s: %(name)s: %(message)s',
+            force=True,
         )
         logging.getLogger('llmfoundry').setLevel(
             train_cfg.python_log_level.upper(),

--- a/scripts/inference/endpoint_generate.py
+++ b/scripts/inference/endpoint_generate.py
@@ -25,7 +25,11 @@ from composer.utils import (
 
 from llmfoundry.utils import prompt_files as utils
 
-logging.basicConfig(level=logging.INFO, format='%(asctime)s %(message)s')
+logging.basicConfig(
+    format=
+    f'%(asctime)s: [%(process)d][%(threadName)s]: %(levelname)s: %(name)s: %(message)s',
+    force=True,
+)
 log = logging.getLogger(__name__)
 
 ENDPOINT_API_KEY_ENV: str = 'ENDPOINT_API_KEY'

--- a/scripts/misc/download_model.py
+++ b/scripts/misc/download_model.py
@@ -31,8 +31,9 @@ DEPRECATED_HF_TOKEN_ENV_VAR = 'HUGGING_FACE_HUB_TOKEN'
 HF_TOKEN_ENV_VAR = 'HF_TOKEN'
 
 logging.basicConfig(
-    format=f'%(asctime)s: %(levelname)s: %(name)s: %(message)s',
-    level=logging.INFO,
+    format=
+    f'%(asctime)s: [%(process)d][%(threadName)s]: %(levelname)s: %(name)s: %(message)s',
+    force=True,
 )
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
Some other packages (TE) mess with the log formatting we had, so this PR reinstates our formatting.

Tested offline