### PR TITLE
Change accumulate_train_batch_on_tokens default to True

### DIFF
--- a/llmfoundry/utils/config_utils.py
+++ b/llmfoundry/utils/config_utils.py
@@ -121,7 +121,7 @@ class TrainConfig:
     dist_timeout: Union[int, float] = 600.0
     fsdp_config: Optional[dict[str, Any]] = None
     tp_config: Optional[dict[str, Any]] = None
-    accumulate_train_batch_on_tokens: bool = False
+    accumulate_train_batch_on_tokens: bool = True
 
     # Evaluation parameters
     eval_interval: Union[int, str] = 1


### PR DESCRIPTION
Following #1610, update the default value of `accumulate_train_batch_on_tokens` to `True`, for a more mathematically correct default. Note: this will slightly change loss curves for models trained with padding. The old behavior can be recovered if desired. by simply setting this to `False` explicitly. See #1610 and https://github.com/mosaicml/composer/pull/3677 for more discussion of this change.