### PR TITLE
Move loss generating token counting to the dataloader

### DIFF
--- a/llmfoundry/data/contrastive_pairs/dataloader.py
+++ b/llmfoundry/data/contrastive_pairs/dataloader.py
@@ -249,6 +249,11 @@ def build_pairs_dataloader(
         processed_batch: dict[str, torch.Tensor] = collate_fn(batch)
         if 'labels' in processed_batch:
             del processed_batch['labels']
+
+        if 'total_tokens' in processed_batch:
+            del processed_batch['total_tokens']
+        if 'loss_generating_tokens' in processed_batch:
+            del processed_batch['loss_generating_tokens']
         return processed_batch
 
     dl = DataLoader(

--- a/llmfoundry/data/packing.py
+++ b/llmfoundry/data/packing.py
@@ -514,6 +514,10 @@ def profile_packing(
     big_batch = next(iter(train_dataloader))
 
     # Cut everything down to size
+    if 'total_tokens' in big_batch:
+        del big_batch['total_tokens']
+    if 'loss_generating_tokens' in big_batch:
+        del big_batch['loss_generating_tokens']
     sizes, trimmed_examples = _trim_batch(big_batch)
 
     def profile(raw_batch_size: int) -> tuple[Optional[float], Optional[float]]:

--- a/llmfoundry/data/utils.py
+++ b/llmfoundry/data/utils.py
@@ -117,9 +117,7 @@ def get_tokens_per_batch_func(
 
         loss_generating_tokens = None
         if 'labels' in batch:
-            loss_generating_tokens = int(
-                torch.sum(batch['labels'][...,1:] != CROSS_ENTROPY_IGNORE_INDEX).item(),
-            )
+            loss_generating_tokens = int((batch['labels'][...,1:] != CROSS_ENTROPY_IGNORE_INDEX).sum())
 
         # For encoder decoder models only
         decoder_input_ids_tokens = 0

--- a/llmfoundry/data/utils.py
+++ b/llmfoundry/data/utils.py
@@ -116,8 +116,8 @@ def get_tokens_per_batch_func(
             input_ids_tokens = batch['input_ids'].numel()
 
         loss_generating_tokens = None
-        # if 'labels' in batch:
-        #     loss_generating_tokens = (batch['labels'].shape[0] * (batch['labels'].shape[1] - 1)) - torch.count_nonzero(torch.eq(batch['labels'][...,1:], CROSS_ENTROPY_IGNORE_INDEX))
+        if 'labels' in batch:
+            loss_generating_tokens = (batch['labels'].shape[0] * (batch['labels'].shape[1] - 1)) - torch.count_nonzero(torch.eq(batch['labels'][...,1:], CROSS_ENTROPY_IGNORE_INDEX))
 
         # For encoder decoder models only
         decoder_input_ids_tokens = 0

--- a/llmfoundry/data/utils.py
+++ b/llmfoundry/data/utils.py
@@ -116,8 +116,8 @@ def get_tokens_per_batch_func(
             input_ids_tokens = batch['input_ids'].numel()
 
         loss_generating_tokens = None
-        if 'labels' in batch:
-            loss_generating_tokens = (batch['labels'].shape[0] * (batch['labels'].shape[1] - 1)) - torch.count_nonzero(torch.eq(batch['labels'][...,1:], CROSS_ENTROPY_IGNORE_INDEX))
+        # if 'labels' in batch:
+        #     loss_generating_tokens = (batch['labels'].shape[0] * (batch['labels'].shape[1] - 1)) - torch.count_nonzero(torch.eq(batch['labels'][...,1:], CROSS_ENTROPY_IGNORE_INDEX))
 
         # For encoder decoder models only
         decoder_input_ids_tokens = 0

--- a/llmfoundry/data/utils.py
+++ b/llmfoundry/data/utils.py
@@ -32,7 +32,10 @@ class LossGeneratingTokensCollatorWrapper:
         self.token_counting_func = token_counting_func
 
         self._token_count_batch_keys = [
-            'input_ids', 'attention_mask', 'labels', 'decoder_attention_mask'
+            'input_ids',
+            'attention_mask',
+            'labels',
+            'decoder_attention_mask',
         ]
 
     def __call__(self, examples: list[Any]) -> dict[str, torch.Tensor]:

--- a/llmfoundry/data/utils.py
+++ b/llmfoundry/data/utils.py
@@ -21,12 +21,12 @@ log = logging.getLogger(__name__)
 
 
 class LossGeneratingTokensCollatorWrapper:
-    """Collator wrapper to add sequence_id to batch."""
+    """Collator wrapper to add loss generating token counts to batch."""
 
     def __init__(
         self,
         base_collator: Callable,
-        token_counting_func: Callable,
+        token_counting_func: Callable[[Batch], Union[int, dict[str, int]]],
     ):
         self.base_collator = base_collator
         self.token_counting_func = token_counting_func
@@ -222,7 +222,10 @@ def get_text_collator(
             bos_token_id=bos_token_id,
         )
 
-    collate_fn = LossGeneratingTokensCollatorWrapper(collate_fn, get_tokens_per_batch_func())
+    collate_fn = LossGeneratingTokensCollatorWrapper(
+        collate_fn,
+        get_tokens_per_batch_func(),
+    )
 
     return collate_fn, dataset_batch_size
 
@@ -238,5 +241,8 @@ def get_finetuning_collator(
         tokenizer,
         dataset_batch_size,
     )
-    collate_fn = LossGeneratingTokensCollatorWrapper(collate_fn, get_tokens_per_batch_func())
+    collate_fn = LossGeneratingTokensCollatorWrapper(
+        collate_fn,
+        get_tokens_per_batch_func(),
+    )
     return collate_fn, dataset_batch_size

--- a/llmfoundry/data/utils.py
+++ b/llmfoundry/data/utils.py
@@ -232,7 +232,9 @@ def get_finetuning_collator(
 ) -> tuple[Union[Seq2SeqFinetuningCollator, BinPackCollator,
                  LossGeneratingTokensCollatorWrapper], int]:
     collate_fn, dataset_batch_size = build_collate_fn(
-        dataloader_cfg, tokenizer, dataset_batch_size
+        dataloader_cfg,
+        tokenizer,
+        dataset_batch_size,
     )
     collate_fn = LossGeneratingTokensCollatorWrapper(collate_fn)
     return collate_fn, dataset_batch_size

--- a/llmfoundry/data/utils.py
+++ b/llmfoundry/data/utils.py
@@ -117,7 +117,7 @@ def get_tokens_per_batch_func(
 
         loss_generating_tokens = None
         if 'labels' in batch:
-            loss_generating_tokens = int((batch['labels'][...,1:] != CROSS_ENTROPY_IGNORE_INDEX).sum())
+            loss_generating_tokens = (batch['labels'].shape[0] * (batch['labels'].shape[1] - 1)) - torch.count_nonzero(torch.eq(batch['labels'][...,1:], CROSS_ENTROPY_IGNORE_INDEX))
 
         # For encoder decoder models only
         decoder_input_ids_tokens = 0

--- a/llmfoundry/data/utils.py
+++ b/llmfoundry/data/utils.py
@@ -50,8 +50,8 @@ class LossGeneratingTokensCollatorWrapper:
             output['total_tokens'].append(num_tokens['total'])
             output['loss_generating_tokens'].append(num_tokens['loss_generating'])
 
-        batch['total_tokens'] = output['total_tokens']
-        batch['loss_generating_tokens'] = output['loss_generating_tokens']
+        batch['total_tokens'] = torch.tensor(output['total_tokens'])
+        batch['loss_generating_tokens'] = torch.tensor(output['loss_generating_tokens'])
 
         return batch
 

--- a/llmfoundry/data/utils.py
+++ b/llmfoundry/data/utils.py
@@ -118,15 +118,7 @@ def get_tokens_per_batch_func(
         loss_generating_tokens = None
         if 'labels' in batch:
             loss_generating_tokens = int(
-                torch.sum(batch['labels'] != CROSS_ENTROPY_IGNORE_INDEX).item(),
-            )
-
-            # Subtract one for each example in the batch that starts with a non -100,
-            # because those will be shifted off
-            loss_generating_tokens -= int(
-                torch.sum(
-                    batch['labels'][:, 0] != CROSS_ENTROPY_IGNORE_INDEX,
-                ).item(),
+                torch.sum(batch['labels'][...,1:] != CROSS_ENTROPY_IGNORE_INDEX).item(),
             )
 
         # For encoder decoder models only

--- a/llmfoundry/data/utils.py
+++ b/llmfoundry/data/utils.py
@@ -31,7 +31,9 @@ class LossGeneratingTokensCollatorWrapper:
         self.base_collator = base_collator
         self.token_counting_func = token_counting_func
 
-        self._token_count_batch_keys = ['input_ids', 'attention_mask', 'labels', 'decoder_attention_mask']
+        self._token_count_batch_keys = [
+            'input_ids', 'attention_mask', 'labels', 'decoder_attention_mask'
+        ]
 
     def __call__(self, examples: list[Any]) -> dict[str, torch.Tensor]:
         batch = self.base_collator(examples)
@@ -46,7 +48,7 @@ class LossGeneratingTokensCollatorWrapper:
             row_batch = {}
             for key in self._token_count_batch_keys:
                 if key in batch:
-                    row_batch[key] = batch[key][row:row+1]
+                    row_batch[key] = batch[key][row:row + 1]
 
             num_tokens = self.token_counting_func(row_batch)
             if isinstance(num_tokens, dict):

--- a/llmfoundry/data/utils.py
+++ b/llmfoundry/data/utils.py
@@ -37,7 +37,7 @@ class LossGeneratingTokensCollatorWrapper:
             'loss_generating_tokens': [],
         }
         num_rows = batch['input_ids'].shape[0]
-        for row in num_rows:
+        for row in range(num_rows):
             row_batch = {
                 'input_ids': batch['input_ids'][row],
             }
@@ -50,8 +50,8 @@ class LossGeneratingTokensCollatorWrapper:
             output['total_tokens'].append(num_tokens['total'])
             output['loss_generating_tokens'].append(num_tokens['loss_generating'])
 
-        batch['total_tokens'] = torch.tensor(output['total_tokens'])
-        batch['loss_generating_tokens'] = torch.tensor(output['loss_generating_tokens'])
+        batch['total_tokens'] = output['total_tokens']
+        batch['loss_generating_tokens'] = output['loss_generating_tokens']
 
         return batch
 

--- a/llmfoundry/data/utils.py
+++ b/llmfoundry/data/utils.py
@@ -39,12 +39,12 @@ class LossGeneratingTokensCollatorWrapper:
         num_rows = batch['input_ids'].shape[0]
         for row in range(num_rows):
             row_batch = {
-                'input_ids': batch['input_ids'][row],
+                'input_ids': batch['input_ids'][row].unsqueeze(0),
             }
             if 'attention_mask' in batch:
-                row_batch['attention_mask'] = batch['attention_mask'][row]
+                row_batch['attention_mask'] = batch['attention_mask'][row].unsqueeze(0)
             if 'labels' in batch:
-                row_batch['labels'] = batch['labels'][row]
+                row_batch['labels'] = batch['labels'][row].unsqueeze(0)
 
             num_tokens = get_tokens_per_batch_func()(row_batch)
             output['total_tokens'].append(num_tokens['total'])

--- a/llmfoundry/data/utils.py
+++ b/llmfoundry/data/utils.py
@@ -32,7 +32,7 @@ class LossGeneratingTokensCollatorWrapper:
     def __call__(self, examples: list[Any]) -> dict[str, torch.Tensor]:
         batch = self.base_collator(examples)
 
-        # Add token counts to batch
+        # Add token counts to batch as a list, one for each row, so that microbatch splitting works
         output = {
             'total_tokens': [],
             'loss_generating_tokens': [],

--- a/tests/a_scripts/inference/test_convert_composer_to_hf.py
+++ b/tests/a_scripts/inference/test_convert_composer_to_hf.py
@@ -1573,7 +1573,8 @@ def test_mptmoe_huggingface_conversion_callback(
             # Check output equivalence
             loaded_model = loaded_model.cuda().bfloat16()  # type: ignore
             for k, v in batch.items():
-                batch[k] = v.cuda()
+                if isinstance(v, torch.Tensor):
+                    batch[k] = v.cuda()
             loaded_model_logits = loaded_model(
                 input_ids=batch.get('input_ids', None),
                 attention_mask=batch.get('attention_mask', None),

--- a/tests/data/test_packing.py
+++ b/tests/data/test_packing.py
@@ -16,6 +16,7 @@ from torch.utils.data import DataLoader
 from llmfoundry.data.finetuning.dataloader import build_finetuning_dataloader
 from llmfoundry.data.finetuning.tasks import StreamingFinetuningDataset
 from llmfoundry.data.packing import BinPackCollator, auto_packing_ratio
+from llmfoundry.data.utils import LossGeneratingTokensCollatorWrapper
 from llmfoundry.utils.builders import build_tokenizer
 
 
@@ -253,7 +254,8 @@ def test_packing_with_dataloader(packing_ratio: Any):
     ).dataloader
 
     assert isinstance(loader, DataLoader)
-    pack_collator = loader.collate_fn
+    assert isinstance(loader.collate_fn, LossGeneratingTokensCollatorWrapper)
+    pack_collator = loader.collate_fn.base_collator
     assert isinstance(pack_collator, BinPackCollator)
 
     batch_ix = 0


### PR DESCRIPTION
The previous PR to count loss generating tokens caused a throughput regression because the token counting is on the critical path in the Composer trainer. This PR moves the token counting into the collator so that it can be hidden in the dataloader. It does this by counting tokens per row in the batch, using the existing token counting function (not the most efficient, but doesn't matter because this is not dataloader bottlenecked, and allows reusing the existing code).

This PR should not change token counts or loss, and will barely affect throughput for larger models, but have a significant impact for smaller models.

125m model pretraining throughput, loss, token count, before and after this PR:
<img width="537" alt="Screenshot 2024-11-02 at 3 19 20 PM" src="https://github.com/user-attachments/assets/b02e974f-a5a8-4194-8f2f-0ee60d8a2644">
<img width="463" alt="Screenshot 2024-11-02 at 3 19 26 PM" src="https://github.com/user-attachments/assets/230d2f99-15b3-4443-80f6-437037deadbd">
<img width="475" alt="Screenshot 2024-11-02 at 3 19 34 PM" src="https://github.com/user-attachments/assets/57d76b3b-616c-423a-adba-ba49feddd1c6">

llama finetune throughput, loss, token count, before and after this PR: