### PR TITLE
Fix dataset download location

### DIFF
--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -93,6 +93,7 @@ from llmfoundry.utils.exceptions import (
     UnknownExampleTypeError,
 )
 #  yapf: enable
+from llmfoundry.utils.file_utils import dist_mkdtemp
 from llmfoundry.utils.logging_utils import SpecificWarningFilter
 
 log = logging.getLogger(__name__)
@@ -888,6 +889,8 @@ class DatasetConstructor:
 
         signal_file_path = dist.get_node_signal_file_name()
 
+        download_folder = dist_mkdtemp()
+
         # Non local rank 0 ranks will wait here for local rank 0 to finish the data processing.
         # Once local rank 0 is done, the datasets are all cached on disk, and all other ranks
         # can just read them.
@@ -913,7 +916,7 @@ class DatasetConstructor:
                 if not os.path.isdir(dataset_name):
                     # dataset_name is not a local dir path, download if needed.
                     local_dataset_dir = os.path.join(
-                        tempfile.mkdtemp(),
+                        download_folder,
                         dataset_name,
                     )
 

--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -34,7 +34,6 @@ those keys are strings (i.e. text).
 import importlib
 import logging
 import os
-import tempfile
 import warnings
 from collections.abc import Mapping
 from functools import partial

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ install_requires = [
     'mlflow>=2.14.1,<2.18',
     'accelerate>=0.25,<0.34',  # for HF inference `device_map`
     'transformers>=4.43.2,<4.44',
-    'mosaicml-streaming==0.9.0', # DO NOT MERGE
+    'mosaicml-streaming>=0.9.0,<0.10',
     'torch>=2.4.0,<2.4.1',
     'datasets>=2.19,<2.20',
     'fsspec==2023.6.0',  # newer version results in a bug in datasets that duplicates data

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ install_requires = [
     'mlflow>=2.14.1,<2.18',
     'accelerate>=0.25,<0.34',  # for HF inference `device_map`
     'transformers>=4.43.2,<4.44',
-    'mosaicml-streaming>=0.9.0,<0.10',
+    'mosaicml-streaming==0.9.0', # DO NOT MERGE
     'torch>=2.4.0,<2.4.1',
     'datasets>=2.19,<2.20',
     'fsspec==2023.6.0',  # newer version results in a bug in datasets that duplicates data

--- a/tests/data/test_dataloader.py
+++ b/tests/data/test_dataloader.py
@@ -63,6 +63,11 @@ from tests.data_utils import (
 )
 from tests.test_utils import generate_exclusive_test_params
 
+@pytest.fixture(autouse=True)
+def clean_streaming():
+    clean_stale_shared_memory()
+    yield
+    clean_stale_shared_memory()
 
 def get_config(conf_path: str = 'yamls/mpt/125m.yaml'):
     os.environ['TOKENIZERS_PARALLELISM'] = 'false'

--- a/tests/data/test_dataloader.py
+++ b/tests/data/test_dataloader.py
@@ -63,11 +63,6 @@ from tests.data_utils import (
 )
 from tests.test_utils import generate_exclusive_test_params
 
-@pytest.fixture(autouse=True)
-def clean_streaming():
-    clean_stale_shared_memory()
-    yield
-    clean_stale_shared_memory()
 
 def get_config(conf_path: str = 'yamls/mpt/125m.yaml'):
     os.environ['TOKENIZERS_PARALLELISM'] = 'false'
@@ -1521,6 +1516,7 @@ def test_ft_dataloader_with_extra_keys():
                 device_batch_size=device_batch_size,
             ).dataloader
 
+# TODO: Change this back to xfail after figuring out why it caused CI to hang
 @pytest.mark.skip
 def test_text_dataloader_with_extra_keys():
     max_seq_len = 1024

--- a/tests/data/test_dataloader.py
+++ b/tests/data/test_dataloader.py
@@ -455,7 +455,7 @@ def test_finetuning_dataloader_safe_load(
 
     tokenizer = build_tokenizer('gpt2', {})
 
-    with patch('llmfoundry.data.finetuning.tasks.tempfile.mkdtemp', return_value=str(tmp_path)):
+    with patch('llmfoundry.utils.file_utils.tempfile.mkdtemp', return_value=str(tmp_path)), patch('os.cpu_count', return_value=1):
         with expectation:
             _ = build_finetuning_dataloader(
                 tokenizer=tokenizer,

--- a/tests/data/test_dataloader.py
+++ b/tests/data/test_dataloader.py
@@ -1521,7 +1521,7 @@ def test_ft_dataloader_with_extra_keys():
                 device_batch_size=device_batch_size,
             ).dataloader
 
-@pytest.mark.xfail
+@pytest.mark.skip
 def test_text_dataloader_with_extra_keys():
     max_seq_len = 1024
     cfg = {


### PR DESCRIPTION
Fixes an error in the previous PR by making sure all ranks use the same dataset download location to avoid contention between the ranks operating on the same hugging face dataset.

Example before: `ds-go-away-sl-1-7-egU4ZP`
Example after: `ds-go-away-sl-2-8-p1nLOh`