### PR TITLE
Revert "Bump databricks-connect from 14.1.0 to 15.4.3"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ extra_deps['databricks'] = [
     'mosaicml[databricks]>=0.26.0,<0.27',
     'numpy<2',
     'databricks-sql-connector>=3,<4',
-    'databricks-connect==15.4.3',
+    'databricks-connect==14.1.0',
     'lz4>=4,<5',
 ]
 


### PR DESCRIPTION
Reverts mosaicml/llm-foundry#1636

This breaks delta-to-jsonl converter. 
To make the converter works with databricks-connect>=14.3, one needs to refactor the code around ``to_cf`` function in ```llmfoundry/command_utils/data_prep/convert_delta_to_json.py```