### PR TITLE
Fix gpu tests test_tp_train and test_huggingface_conversion_callback_interval

### DIFF
--- a/tests/a_scripts/inference/test_convert_composer_to_hf.py
+++ b/tests/a_scripts/inference/test_convert_composer_to_hf.py
@@ -153,11 +153,9 @@ def check_hf_tokenizer_equivalence(
     tokenizer2.__dict__['init_kwargs'].pop('vocab_file', None)
 
     # tokenizer.init_kwargs['merges_file'] is set when loading with AutoTokenizer.from_pretrained, but is set to
-    # None when you save and reload, so here we just check that its the same if it is present in both tokenizers.
-    merges_file_1 = tokenizer1.init_kwargs.get('merges_file', None)
-    merges_file_2 = tokenizer2.init_kwargs.get('merges_file', None)
-    if merges_file_1 is not None and merges_file_2 is not None:
-        assert merges_file_1 == merges_file_2
+    # None when you save and reload the tokenizer only.
+    # Otherwise, merges_file will be the path that the tokenizer was loaded from, which will just be a temporary directory for
+    # the reloaded tokenizer, so we remove it and don't compare it between the two tokenizers.
     tokenizer1.__dict__['init_kwargs'].pop('merges_file', None)
     tokenizer2.__dict__['init_kwargs'].pop('merges_file', None)
 

--- a/tests/a_scripts/inference/test_convert_composer_to_hf.py
+++ b/tests/a_scripts/inference/test_convert_composer_to_hf.py
@@ -152,6 +152,15 @@ def check_hf_tokenizer_equivalence(
     tokenizer1.__dict__['init_kwargs'].pop('vocab_file', None)
     tokenizer2.__dict__['init_kwargs'].pop('vocab_file', None)
 
+    # tokenizer.init_kwargs['merges_file'] is set when loading with AutoTokenizer.from_pretrained, but is set to
+    # None when you save and reload, so here we just check that its the same if it is present in both tokenizers.
+    merges_file_1 = tokenizer1.init_kwargs.get('merges_file', None)
+    merges_file_2 = tokenizer2.init_kwargs.get('merges_file', None)
+    if merges_file_1 is not None and merges_file_2 is not None:
+        assert merges_file_1 == merges_file_2
+    tokenizer1.__dict__['init_kwargs'].pop('merges_file', None)
+    tokenizer2.__dict__['init_kwargs'].pop('merges_file', None)
+
     # vocab_file will be the path that the tokenizer was loaded from, which will just be a temporary directory for
     # the reloaded tokenizer, so we remove it and don't compare it between the two tokenizers
     tokenizer1.__dict__.pop('vocab_file', None)

--- a/tests/tp/test_tp_strategies.py
+++ b/tests/tp/test_tp_strategies.py
@@ -3,9 +3,7 @@
 
 import os
 import pathlib
-import shutil
 from pathlib import Path
-from tempfile import TemporaryDirectory
 from typing import Optional
 
 import pytest
@@ -151,58 +149,45 @@ def get_loss_array(trainer: Trainer):
 @pytest.mark.world_size(4)
 @pytest.mark.parametrize('tp_degree', [2])
 @pytest.mark.parametrize('tp_strategy', ['ffn'])
-def test_tp_train(tp_degree: int, tp_strategy: str):
+def test_tp_train(tp_degree: int, tp_strategy: str, tmp_path: Path):
     """Test that we can train with FSDP-TP."""
-    my_dir = Path('/my-data-dir')
+    # create c4 dataset
+    tp_dataset_name = create_c4_dataset_xxsmall(tmp_path)
 
-    try:
-        # create c4 dataset
-        if my_dir.is_dir() and my_dir.exists():
-            shutil.rmtree(my_dir)
-        my_dir.mkdir(parents=True)
-        tp_dataset_name = create_c4_dataset_xxsmall(my_dir)
+    # Train model with TP and get loss
+    tp_cfg = get_cfg(pathlib.Path(tp_dataset_name), tp_strategy, tp_degree)
+    tp_trainer = train(tp_cfg)
+    tp_trainer.close()
+    tp_loss = get_loss_array(tp_trainer)
 
-        # Train model with TP and get loss
-        tp_cfg = get_cfg(pathlib.Path(tp_dataset_name), tp_strategy, tp_degree)
-        tp_trainer = train(tp_cfg)
-        tp_trainer.close()
-        tp_loss = get_loss_array(tp_trainer)
-
-        # Compare loss and expected loss for TP
-        import numpy as np
-        expected_tp_loss = np.array([
-            12.02126884,
-            11.96996498,
-            12.02957344,
-            11.97966957,
-            11.99677086,
-            11.96347618,
-        ])
-        np.testing.assert_allclose(tp_loss, expected_tp_loss)
-    except Exception as e:
-        raise e
-    finally:
-        # always remove the directory
-        if os.path.isdir(my_dir):
-            shutil.rmtree(my_dir)
+    # Compare loss and expected loss for TP
+    import numpy as np
+    expected_tp_loss = np.array([
+        12.02126884,
+        11.96996498,
+        12.02957344,
+        11.97966957,
+        11.99677086,
+        11.96347618,
+    ])
+    np.testing.assert_allclose(tp_loss, expected_tp_loss)
 
 
 @pytest.mark.gpu
-def test_tp_train_with_one_gpu():
+def test_tp_train_with_one_gpu(tmp_path: Path):
     """Test that when we have one GPU, we train DDP and not FSDP-TP."""
-    with TemporaryDirectory() as tmp_path:
-        # Make `train_cfg`` with a tensor parallelism strategy
-        dataset_name = create_c4_dataset_xxsmall(Path(tmp_path))
-        train_cfg = gpt_tiny_cfg(dataset_name, 'gpu')
-        train_cfg.tp_config = {'strategy': 'ffn'}
+    # Make `train_cfg`` with a tensor parallelism strategy
+    dataset_name = create_c4_dataset_xxsmall(tmp_path)
+    train_cfg = gpt_tiny_cfg(dataset_name, 'gpu')
+    train_cfg.tp_config = {'strategy': 'ffn'}
 
-        # Expect a warning
-        with pytest.warns(
-            UserWarning,
-            match=
-            r'FSDP\+TP is not applicable for single-GPU training. Reverting to DDP.',
-        ):
-            train(train_cfg)
+    # Expect a warning
+    with pytest.warns(
+        UserWarning,
+        match=
+        r'FSDP\+TP is not applicable for single-GPU training. Reverting to DDP.',
+    ):
+        train(train_cfg)
 
 
 @pytest.mark.gpu  # use gpu because `megablocks` only installed with `gpu` dependencies

--- a/tests/tp/test_tp_strategies.py
+++ b/tests/tp/test_tp_strategies.py
@@ -151,8 +151,13 @@ def get_loss_array(trainer: Trainer):
 @pytest.mark.parametrize('tp_strategy', ['ffn'])
 def test_tp_train(tp_degree: int, tp_strategy: str, tmp_path: Path):
     """Test that we can train with FSDP-TP."""
-    # create c4 dataset
+    from composer.utils import dist, get_device
+
+    dist.initialize_dist(get_device(None), timeout=10)
+
     tp_dataset_name = create_c4_dataset_xxsmall(tmp_path)
+
+    tp_dataset_name = dist.all_gather_object(tp_dataset_name)[0]
 
     # Train model with TP and get loss
     tp_cfg = get_cfg(pathlib.Path(tp_dataset_name), tp_strategy, tp_degree)

--- a/tests/tp/test_tp_strategies.py
+++ b/tests/tp/test_tp_strategies.py
@@ -8,6 +8,7 @@ from typing import Optional
 
 import pytest
 from composer import Trainer
+from composer.utils import dist
 from omegaconf import DictConfig
 from omegaconf import OmegaConf as om
 from torch.distributed._tensor import Replicate, Shard
@@ -151,10 +152,6 @@ def get_loss_array(trainer: Trainer):
 @pytest.mark.parametrize('tp_strategy', ['ffn'])
 def test_tp_train(tp_degree: int, tp_strategy: str, tmp_path: Path):
     """Test that we can train with FSDP-TP."""
-    from composer.utils import dist, get_device
-
-    dist.initialize_dist(get_device(None), timeout=10)
-
     tp_dataset_name = create_c4_dataset_xxsmall(tmp_path)
 
     tp_dataset_name = dist.all_gather_object(tp_dataset_name)[0]


### PR DESCRIPTION
### test_tp_train
There's been some flakiness with `test_tp_train` for a while (see https://github.com/mosaicml/llm-foundry/actions/runs/11692900928/job/32563257854, https://github.com/mosaicml/llm-foundry/actions/runs/11370945735/job/31631872040)

```
FAILED tests/tp/test_tp_strategies.py::test_tp_train[ffn-2] - FileExistsError: [Errno 17] File exists: '/my-data-dir'
```
Instead of having each of the processes write to the same path (which probably ends up with conflicts), we just use the tmp_path fixture, which is unique per process.

### test_huggingface_conversion_callback_interval

This test was failing with the following error because the tokenizer `merges_file` differs:
```
tests/a_scripts/inference/test_convert_composer_to_hf.py:621: in test_huggingface_conversion_callback_interval
    check_hf_tokenizer_equivalence(mpt_tokenizer, loaded_tokenizer)
tests/a_scripts/inference/test_convert_composer_to_hf.py:229: in check_hf_tokenizer_equivalence
    assert tokenizer1.__dict__ == tokenizer2.__dict__
```
```
  Full diff:
    {
        '_add_bos_token': False,
        '_add_eos_token': False,
        '_decode_use_source_tokenizer': False,
        '_in_target_context_manager': False,
        '_pad_token_type_id': 0,
        '_processor_class': None,
        'add_prefix_space': False,
        'chat_template': None,
        'clean_up_tokenization_spaces': False,
        'init_inputs': (),
        'init_kwargs': {
            'add_bos_token': False,
            'add_eos_token': False,
            'add_prefix_space': False,
  -         'merges_file': None,
  +         'merges_file': '/root/.cache/huggingface/hub/models--EleutherAI--gpt-neox-20b/snapshots/c292233c833e336628618a88a648727eb3dff0a7/merges.txt',
        },
        'model_input_names': [
            'input_ids',
            'attention_mask',
        ],
        'model_max_length': 1000000000000000019884624838656,
        'padding_side': 'right',
        'split_special_tokens': False,
        'truncation_side': 'right',
        'verbose': False,
```

Not sure why this test didn't fail before on this PR: https://github.com/mosaicml/llm-foundry/pull/1631 It succeed on main initially and then when I re-ran CI it failed: https://github.com/mosaicml/llm-foundry/actions/runs/11692900928/job/32582119409

I'm pretty sure it's because of the transformers bump, particularly this change https://github.com/huggingface/transformers/pull/33793/files#diff-e1a70b5f5963f0967710acb962915d3e09dcc9ae08d8a860ee391d533447c1fdR109 which was merged October 9

Confirmed that in older versions of transformers, the `EleutherAI/gpt-neox-20b` tokenizer.init_kwargs did not have a `merges_file` key. Now, this key is set when loading with `AutoTokenizer.from_pretrained('EleutherAI/gpt-neox-20b')`, but it is None after saving and reloading.
