### PR TITLE
Changes for removing unused terms in CE loss fn 

### DIFF
--- a/llmfoundry/models/mpt/modeling_mpt.py
+++ b/llmfoundry/models/mpt/modeling_mpt.py
@@ -79,6 +79,8 @@ from llmfoundry.models.utils.param_init_fns import generic_param_init_fn_  # typ
 from llmfoundry.models.layers.norm import LPLayerNorm  # type: ignore
 # isort: on
 
+from llmfoundry.utils.warnings import VersionedDeprecationWarning
+
 log = logging.getLogger(__name__)
 
 CROSS_ENTROPY_IGNORE_INDEX = -100
@@ -1346,6 +1348,7 @@ def compute_loss_from_logits(
     shift_labels: bool,
     labels: torch.Tensor,
     loss_fn: nn.Module,
+    sample_weighing_factor: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     targets = get_targets(labels) if shift_labels else labels
 
@@ -1358,6 +1361,13 @@ def compute_loss_from_logits(
         loss = losses.sum()
     else:
         loss = losses.sum() / (targets != loss_fn.ignore_index).sum()
+        if sample_weighing_factor is not None:
+            warnings.warn(
+                VersionedDeprecationWarning(
+                    message='sample_weighing_factor has been deprecated!',
+                    remove_version='0.15.0',
+                ),
+            )
 
     return loss
 

--- a/llmfoundry/models/mpt/modeling_mpt.py
+++ b/llmfoundry/models/mpt/modeling_mpt.py
@@ -1346,7 +1346,6 @@ def compute_loss_from_logits(
     shift_labels: bool,
     labels: torch.Tensor,
     loss_fn: nn.Module,
-    sample_weighing_factor: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     targets = get_targets(labels) if shift_labels else labels
 
@@ -1359,12 +1358,6 @@ def compute_loss_from_logits(
         loss = losses.sum()
     else:
         loss = losses.sum() / (targets != loss_fn.ignore_index).sum()
-        if sample_weighing_factor is not None:
-            if sample_weighing_factor.shape[0] > 1:
-                raise ValueError(
-                    'Sample weighing factor is not supported when batch["sample_weighing_factor"].shape[0] > 1.',
-                )
-            loss = loss * sample_weighing_factor[0].item()
 
     return loss
 
@@ -1473,7 +1466,6 @@ class ComposerMPTCausalLM(HuggingFaceModel):
             self.shift_labels,
             batch['labels'],
             self.loss_fn,
-            batch.get('sample_weighing_factor', None),
         )
 
         if self.config.ffn_config['ffn_type'] in ffns_with_megablocks:

--- a/llmfoundry/models/mpt/modeling_mpt.py
+++ b/llmfoundry/models/mpt/modeling_mpt.py
@@ -1365,9 +1365,14 @@ def compute_loss_from_logits(
             warnings.warn(
                 VersionedDeprecationWarning(
                     message='sample_weighing_factor has been deprecated!',
-                    remove_version='0.15.0',
+                    remove_version='0.16.0',
                 ),
             )
+            if sample_weighing_factor.shape[0] > 1:
+                raise ValueError(
+                    'Sample weighing factor is not supported when batch["sample_weighing_factor"].shape[0] > 1.',
+                )
+            loss = loss * sample_weighing_factor[0].item()
 
     return loss
 

--- a/llmfoundry/models/mpt/modeling_mpt.py
+++ b/llmfoundry/models/mpt/modeling_mpt.py
@@ -1365,7 +1365,7 @@ def compute_loss_from_logits(
             warnings.warn(
                 VersionedDeprecationWarning(
                     message='sample_weighing_factor has been deprecated!',
-                    remove_version='0.16.0',
+                    remove_version='0.17.0',
                 ),
             )
             if sample_weighing_factor.shape[0] > 1:


### PR DESCRIPTION
We need to deprecate this in favor of the new changes to account for the correct loss calc. based on tokens in [this PR](https://github.com/mosaicml/llm-foundry/pull/1632) 