### PR TITLE
Infer step size for Embeddings

### DIFF
--- a/llmfoundry/models/llm_embed/modeling_llm_embed.py
+++ b/llmfoundry/models/llm_embed/modeling_llm_embed.py
@@ -69,7 +69,7 @@ class ContrastiveConfig:
     temperature: Union[int, float] = 1
     vector_representation: str = 'avg'
     normalize_output: bool = True
-    pos_step_size: int = -1 # keep for backwards compatibility
+    pos_step_size: int = -1  # keep for backwards compatibility
     gather_in_batch_negatives: bool = False
     use_legacy_gradient_passthrough: bool = False
     infonce_process_group_size: Optional[int] = None
@@ -143,7 +143,7 @@ class ContrastiveModel(HuggingFaceModel):
             tokenizer=tokenizer,
             use_logits=False,
             metrics=train_metrics,
-            eval_metrics=self.eval_metrics, # type: ignore
+            eval_metrics=self.eval_metrics,  # type: ignore
             shift_labels=False,
             allow_embedding_resizing=True,
         )
@@ -203,9 +203,11 @@ class ContrastiveModel(HuggingFaceModel):
                 load_in_8bit=self.load_in_8bit,
                 **self.kwargs,
             )
+            print(f"construct_model: Loaded pretrained model '{self.pretrained_model_name_or_path}'")
         else:
             model = MPTForCausalLM(MPTConfig(**self.kwargs))
             self.is_mpt = True
+            print("construct_model: Initialized MPTForCausalLM model")
         return model
 
     def _update_step_size_if_needed(self, batch: MutableMapping) -> None:
@@ -214,14 +216,14 @@ class ContrastiveModel(HuggingFaceModel):
             return
 
         input_shape = batch['input_ids'].shape
+        print(f"_update_step_size_if_needed: input_shape = {input_shape}")
         if input_shape[1] > 2:
             # We have hard negatives, batch shape is [batch, sample of query+positive passage+negative passages, tokens].
             self.step_size = input_shape[1]
-            log.info(
-                f'Detected hard negatives, updated step_size to {self.step_size}',
-            )
+            print(f"Detected hard negatives, updated step_size to {self.step_size}")
         else:
             self.step_size = 2
+            print(f"No hard negatives detected, set step_size to {self.step_size}")
 
     def format_queries_batch(
         self,
@@ -234,9 +236,12 @@ class ContrastiveModel(HuggingFaceModel):
         negatives per passage.
         """
         queries = {}
+        indices = list(range(0, batch['input_ids'].size(0), self.step_size))
+        print(f"format_queries_batch: indices = {indices}")
         for key in batch:
-            indices = list(range(0, batch[key].size(0), self.step_size))
             queries[key] = batch[key][indices, :]
+            print(f"queries[{key}].shape = {queries[key].shape}")
+        print(f"queries_last_hidden_state.shape = {last_hidden_state[indices, :, :].shape}")
         return queries, last_hidden_state[indices, :, :]
 
     def format_passages_batch(
@@ -251,14 +256,18 @@ class ContrastiveModel(HuggingFaceModel):
         """
         passages = {}
         num_blocks = batch['input_ids'].size(0) // self.step_size
+        print(f"format_passages_batch: num_blocks = {num_blocks}")
         index = torch.arange(
             1,
             num_blocks * self.step_size + 1,
             device=last_hidden_state.device,
         ).view(num_blocks, self.step_size)
         index = index[:, :self.step_size - 1].reshape(-1)
+        print(f"format_passages_batch: index = {index}")
         for key in batch:
             passages[key] = batch[key][index]
+            print(f"passages[{key}].shape = {passages[key].shape}")
+        print(f"passages_last_hidden_state.shape = {last_hidden_state[index, :, :].shape}")
         return passages, last_hidden_state[index, :, :]
 
     def forward(self, batch: MutableMapping) -> CausalLMOutputWithPast:
@@ -268,12 +277,16 @@ class ContrastiveModel(HuggingFaceModel):
             len(x.shape) > 2 else x
 
         for key in batch:
+            original_shape = batch[key].shape
             batch[key] = collapse_dims(batch[key])
+            print(f"forward: batch[{key}] collapsed from {original_shape} to {batch[key].shape}")
 
-        return self.model(
+        outputs = self.model(
             output_hidden_states=True,
             **batch,
         )
+        print(f"forward: outputs.logits.shape = {outputs.logits.shape}")
+        return outputs
 
     def _cat_gather(self, t: torch.Tensor, group: Any = None) -> torch.Tensor:
         """Applies an all gather operation necessary for InfoNCELoss.
@@ -289,7 +302,7 @@ class ContrastiveModel(HuggingFaceModel):
             extra_kwargs = {'group': group} if group is not None else {}
             all_tensors = all_gather(t, **extra_kwargs)
             all_tensors = torch.cat(all_tensors)
-
+        print(f"_cat_gather: all_tensors.shape = {all_tensors.shape}")
         return all_tensors
 
     def get_hidden_state(self, outputs: CausalLMOutputWithPast) -> torch.Tensor:
@@ -325,6 +338,7 @@ class ContrastiveModel(HuggingFaceModel):
             Tuple[torch.Tensor, torch.Tensor]: The encoded representations of queries and passages.
         """
         hidden_state = self.get_hidden_state(outputs)
+        print(f"_compute_scores: hidden_state.shape = {hidden_state.shape}")
         zero = self.handle_language_head(outputs)
         (
             queries_batch,
@@ -334,9 +348,13 @@ class ContrastiveModel(HuggingFaceModel):
             passages_batch,
             passages_last_hidden_state,
         ) = self.format_passages_batch(batch, hidden_state)
+        print(f"queries_last_hidden_state.shape = {queries_last_hidden_state.shape}")
+        print(f"passages_last_hidden_state.shape = {passages_last_hidden_state.shape}")
 
         query_attn_mask = queries_batch.get('attention_mask')
         passage_attn_mask = passages_batch.get('attention_mask')
+        print(f"query_attn_mask.shape = {query_attn_mask.shape}")
+        print(f"passage_attn_mask.shape = {passage_attn_mask.shape}")
         assert isinstance(query_attn_mask, torch.Tensor)
         assert isinstance(passage_attn_mask, torch.Tensor)
         if self.vector_representation == 'eos':
@@ -345,6 +363,7 @@ class ContrastiveModel(HuggingFaceModel):
                 row_indices = torch.arange(mask.shape[0])
                 flipped_mask = ~mask.bool()
                 last_true_indices = flipped_mask.int().argmax(dim=1) - 1
+                print(f"pool_fn (eos): last_true_indices = {last_true_indices}")
                 pooled_outputs = x[row_indices, last_true_indices, :]
                 return pooled_outputs
         elif self.vector_representation == 'avg':
@@ -363,10 +382,13 @@ class ContrastiveModel(HuggingFaceModel):
             passages_last_hidden_state,
             passage_attn_mask,
         )
+        print(f"q_pooled_outputs.shape = {q_pooled_outputs.shape}")
+        print(f"p_pooled_outputs.shape = {p_pooled_outputs.shape}")
 
         if self.normalize_output:
             q_pooled_outputs = F.normalize(q_pooled_outputs, dim=-1)
             p_pooled_outputs = F.normalize(p_pooled_outputs, dim=-1)
+            print("Applied normalization to pooled outputs.")
 
         # Use all_gather to include negatives across mini batch
         if self.gather_in_batch_negatives:
@@ -378,6 +400,8 @@ class ContrastiveModel(HuggingFaceModel):
                 p_pooled_outputs,
                 group=self.infonce_process_group,
             )
+            print(f"all_q_pooled_outputs.shape after all_gather = {all_q_pooled_outputs.shape}")
+            print(f"all_p_pooled_outputs.shape after all_gather = {all_p_pooled_outputs.shape}")
         else:
             all_q_pooled_outputs = q_pooled_outputs
             all_p_pooled_outputs = p_pooled_outputs
@@ -389,6 +413,7 @@ class ContrastiveModel(HuggingFaceModel):
             queries=all_q_pooled_outputs,
             passages=all_p_pooled_outputs,
         )
+        print(f"all_scores.shape = {all_scores.shape}")
         all_scores = all_scores * (1 / self.temperature) + zero
 
         all_labels = torch.arange(
@@ -399,6 +424,8 @@ class ContrastiveModel(HuggingFaceModel):
         all_labels = all_labels * (
             p_pooled_outputs.size(0) // q_pooled_outputs.size(0)
         )
+        print(f"all_labels.shape = {all_labels.shape}")
+        print(f"all_labels = {all_labels}")
 
         return all_scores, all_labels
 
@@ -409,8 +436,10 @@ class ContrastiveModel(HuggingFaceModel):
     ) -> torch.Tensor:
 
         # this calculates the inner product between query and passage pairs
+        print(f"_full_contrastive_scores: queries.shape = {queries.shape}")
+        print(f"_full_contrastive_scores: passages.shape = {passages.shape}")
         qp = torch.mm(queries, passages.t())
-
+        print(f"_full_contrastive_scores: qp.shape = {qp.shape}")
         return qp
 
     def loss(
@@ -419,7 +448,9 @@ class ContrastiveModel(HuggingFaceModel):
         batch: MutableMapping,
     ) -> torch.Tensor:
         scores, labels = self._compute_scores(batch, outputs)
+        print(f"loss: scores.shape = {scores.shape}, labels.shape = {labels.shape}")
         loss = self.loss_fn(scores, labels)
+        print(f"loss: loss = {loss.item()}")
         return loss
 
     def eval_forward(
@@ -430,6 +461,7 @@ class ContrastiveModel(HuggingFaceModel):
         if outputs is None:
             outputs = self.forward(batch)
         val_loss = self.loss(outputs, batch)
+        print(f"eval_forward: val_loss = {val_loss.item()}")
         return {'loss': val_loss, 'outputs': outputs}
 
     def flops_per_batch(self, batch: Mapping) -> int:

--- a/llmfoundry/models/llm_embed/modeling_llm_embed.py
+++ b/llmfoundry/models/llm_embed/modeling_llm_embed.py
@@ -216,7 +216,7 @@ class ContrastiveModel(HuggingFaceModel):
         input_shape = batch['input_ids'].shape
         if len(input_shape) == 3 and input_shape[1] > 2:
             # We have hard negatives, update step size to match
-            self.step_size = input_shape[1] + 1
+            self.step_size = input_shape[1]
             log.info(
                 f'Detected hard negatives, updated step_size to {self.step_size}',
             )

--- a/llmfoundry/models/llm_embed/modeling_llm_embed.py
+++ b/llmfoundry/models/llm_embed/modeling_llm_embed.py
@@ -285,7 +285,7 @@ class ContrastiveModel(HuggingFaceModel):
             output_hidden_states=True,
             **batch,
         )
-        print(f"forward: outputs.logits.shape = {outputs.logits.shape}")
+        print(f"forward: outputs = {outputs}")
         return outputs
 
     def _cat_gather(self, t: torch.Tensor, group: Any = None) -> torch.Tensor:

--- a/llmfoundry/models/llm_embed/modeling_llm_embed.py
+++ b/llmfoundry/models/llm_embed/modeling_llm_embed.py
@@ -70,7 +70,7 @@ class ContrastiveConfig:
     vector_representation: str = 'avg'
     normalize_output: bool = True
     pos_step_size: int = -1  # keep for backwards compatibility
-    gather_in_batch_negatives: bool = False # keep for backwards compatibility
+    gather_in_batch_negatives: bool = False  # keep for backwards compatibility
     use_legacy_gradient_passthrough: bool = False
     infonce_process_group_size: Optional[int] = None
 
@@ -230,7 +230,9 @@ class ContrastiveModel(HuggingFaceModel):
         batch: MutableMapping,
         last_hidden_state: torch.Tensor,
     ) -> tuple[dict[str, torch.Tensor], torch.Tensor]:
-        assert self.step_size > 0 and (self.gather_in_batch_negatives is not None)
+        assert self.step_size > 0 and (
+            self.gather_in_batch_negatives is not None
+        )
         queries = {}
         for key in batch:
             indices = list(range(0, batch[key].size(0), self.step_size))

--- a/llmfoundry/models/llm_embed/modeling_llm_embed.py
+++ b/llmfoundry/models/llm_embed/modeling_llm_embed.py
@@ -230,15 +230,14 @@ class ContrastiveModel(HuggingFaceModel):
         batch: MutableMapping,
         last_hidden_state: torch.Tensor,
     ) -> tuple[dict[str, torch.Tensor], torch.Tensor]:
-        assert self.step_size > 0 and (
-            self.gather_in_batch_negatives is not None
-        )
+        assert self.step_size and (self.gather_in_batch_negatives is not None)
+        indices = []
         queries = {}
         for key in batch:
             indices = list(range(0, batch[key].size(0), self.step_size))
             queries[key] = batch[key][indices, :]
 
-        assert isinstance(indices, list)
+        assert indices
         return queries, last_hidden_state[indices, :, :]
 
     def format_passages_batch(

--- a/llmfoundry/models/llm_embed/modeling_llm_embed.py
+++ b/llmfoundry/models/llm_embed/modeling_llm_embed.py
@@ -233,9 +233,13 @@ class ContrastiveModel(HuggingFaceModel):
         negatives per passage.
         """
         queries = {}
+        print("Q1:", batch['input_ids'][0][0])
+        print("Q2:", batch['input_ids'][1][0])
+        print("Q3:", batch['input_ids'][2][0])
         for key in batch:
             # Select every `step_size`-th entry from the batch for the given key
             queries[key] = batch[key][0::self.step_size, :]
+            print(f'QUERY', queries['input_ids'][0:3])
 
         # Select every `step_size`-th entry from `last_hidden_state` along the batch dimension
         return queries, last_hidden_state[0::self.step_size, :, :]

--- a/llmfoundry/models/llm_embed/modeling_llm_embed.py
+++ b/llmfoundry/models/llm_embed/modeling_llm_embed.py
@@ -207,9 +207,9 @@ class ContrastiveModel(HuggingFaceModel):
             model = MPTForCausalLM(MPTConfig(**self.kwargs))
             self.is_mpt = True
         return model
-    
+
     def _update_step_size_if_needed(self, batch: MutableMapping) -> None:
-        """Update step size on first batch if we detect hard negatives"""
+        """Update step size on first batch if we detect hard negatives."""
         if self._first_batch_seen:
             return
 
@@ -217,8 +217,10 @@ class ContrastiveModel(HuggingFaceModel):
         if len(input_shape) == 3 and input_shape[1] > 2:
             # We have hard negatives, update step size to match
             self.step_size = input_shape[1] + 1
-            log.info(f"Detected hard negatives, updated step_size to {self.step_size}")
-            
+            log.info(
+                f'Detected hard negatives, updated step_size to {self.step_size}',
+            )
+
         self._first_batch_seen = True
 
     def format_queries_batch(

--- a/llmfoundry/models/llm_embed/modeling_llm_embed.py
+++ b/llmfoundry/models/llm_embed/modeling_llm_embed.py
@@ -69,7 +69,7 @@ class ContrastiveConfig:
     temperature: Union[int, float] = 1
     vector_representation: str = 'avg'
     normalize_output: bool = True
-    pos_step_size: int = -1 #keep for backwards compatibility
+    pos_step_size: int = -1  #keep for backwards compatibility
     gather_in_batch_negatives: bool = False
     use_legacy_gradient_passthrough: bool = False
     infonce_process_group_size: Optional[int] = None
@@ -233,6 +233,7 @@ class ContrastiveModel(HuggingFaceModel):
         Here ``n`` is the step size, which represents the number of hard
         negatives per passage.
         """
+        assert self.step_size
         queries = {}
         indices = []
         for key in batch:
@@ -250,6 +251,7 @@ class ContrastiveModel(HuggingFaceModel):
         Here ``n`` is the step size, which represents the number of hard
         negatives per passage.
         """
+        assert self.step_size
         passages = {}
         num_blocks = batch['input_ids'].size(0) // self.step_size
         index = torch.arange(

--- a/llmfoundry/models/llm_embed/modeling_llm_embed.py
+++ b/llmfoundry/models/llm_embed/modeling_llm_embed.py
@@ -212,6 +212,8 @@ class ContrastiveModel(HuggingFaceModel):
         """Update step size on first batch if we detect hard negatives."""
         if self._first_batch_seen:
             return
+        
+        print('UPDATE BATCH:', batch)
 
         input_shape = batch['input_ids'].shape
         if len(input_shape) == 3 and input_shape[1] > 2:

--- a/llmfoundry/models/llm_embed/modeling_llm_embed.py
+++ b/llmfoundry/models/llm_embed/modeling_llm_embed.py
@@ -230,16 +230,13 @@ class ContrastiveModel(HuggingFaceModel):
         batch: MutableMapping,
         last_hidden_state: torch.Tensor,
     ) -> tuple[dict[str, torch.Tensor], torch.Tensor]:
-        """Format `queries` by selecting every ``n``th entry from the batch.
-
-        Here ``n`` is the step size, which represents the number of hard
-        negatives per passage.
-        """
-        assert self.step_size and (self.gather_in_batch_negatives is not None)
+        assert self.step_size > 0 and (self.gather_in_batch_negatives is not None)
         queries = {}
         for key in batch:
             indices = list(range(0, batch[key].size(0), self.step_size))
             queries[key] = batch[key][indices, :]
+
+        assert isinstance(indices, list)
         return queries, last_hidden_state[indices, :, :]
 
     def format_passages_batch(

--- a/llmfoundry/models/llm_embed/modeling_llm_embed.py
+++ b/llmfoundry/models/llm_embed/modeling_llm_embed.py
@@ -233,13 +233,13 @@ class ContrastiveModel(HuggingFaceModel):
         negatives per passage.
         """
         queries = {}
-        print("Q1:", batch['input_ids'][0][0])
-        print("Q2:", batch['input_ids'][1][0])
-        print("Q3:", batch['input_ids'][2][0])
+        print("Q1:", batch['input_ids'][0])
+        print("Q2:", batch['input_ids'][1])
+        print("Q3:", batch['input_ids'][2])
         for key in batch:
             # Select every `step_size`-th entry from the batch for the given key
             queries[key] = batch[key][0::self.step_size, :]
-            print(f'QUERY', queries['input_ids'][0:3])
+            print(f'QUERY', queries[key])
 
         # Select every `step_size`-th entry from `last_hidden_state` along the batch dimension
         return queries, last_hidden_state[0::self.step_size, :, :]

--- a/llmfoundry/models/llm_embed/modeling_llm_embed.py
+++ b/llmfoundry/models/llm_embed/modeling_llm_embed.py
@@ -209,7 +209,6 @@ class ContrastiveModel(HuggingFaceModel):
 
     def _update_step_size_if_needed(self, batch: MutableMapping) -> None:
         """Update step size on first batch if we detect hard negatives."""
-
         input_shape = batch['input_ids'].shape
         if input_shape[1] > 2:
             # We have hard negatives, batch shape is [batch, sample of query+positive passage+negative passages, tokens].

--- a/llmfoundry/models/llm_embed/modeling_llm_embed.py
+++ b/llmfoundry/models/llm_embed/modeling_llm_embed.py
@@ -216,7 +216,7 @@ class ContrastiveModel(HuggingFaceModel):
         input_shape = batch['input_ids'].shape
         if len(input_shape) == 3 and input_shape[1] > 2:
             # We have hard negatives, update step size to match
-            self.step_size = input_shape[1]
+            self.step_size = input_shape[1] + 1
             log.info(f"Detected hard negatives, updated step_size to {self.step_size}")
             
         self._first_batch_seen = True

--- a/llmfoundry/models/llm_embed/modeling_llm_embed.py
+++ b/llmfoundry/models/llm_embed/modeling_llm_embed.py
@@ -69,8 +69,8 @@ class ContrastiveConfig:
     temperature: Union[int, float] = 1
     vector_representation: str = 'avg'
     normalize_output: bool = True
-    pos_step_size: int = -1  # keep for backwards compatibility
-    gather_in_batch_negatives: bool = False  # keep for backwards compatibility
+    pos_step_size: int = -1 #keep for backwards compatibility
+    gather_in_batch_negatives: bool = False
     use_legacy_gradient_passthrough: bool = False
     infonce_process_group_size: Optional[int] = None
 
@@ -157,7 +157,7 @@ class ContrastiveModel(HuggingFaceModel):
         self.normalize_output = contrastive_config_obj.normalize_output
 
         self.step_size = None
-        self.gather_in_batch_negatives = None
+        self.gather_in_batch_negatives = contrastive_config_obj.gather_in_batch_negatives
         self.use_legacy_gradient_passthrough = contrastive_config_obj.use_legacy_gradient_passthrough
         self.n_active_params = sum(p.numel() for p in self.parameters())
         if loss_fn == 'fused_crossentropy':
@@ -220,24 +220,24 @@ class ContrastiveModel(HuggingFaceModel):
             log.info(
                 f'Detected hard negatives, updated step_size to {self.step_size}',
             )
-            self.gather_in_batch_negatives = False
         else:
             self.step_size = 2
-            self.gather_in_batch_negatives = True
 
     def format_queries_batch(
         self,
         batch: MutableMapping,
         last_hidden_state: torch.Tensor,
     ) -> tuple[dict[str, torch.Tensor], torch.Tensor]:
-        assert self.step_size and (self.gather_in_batch_negatives is not None)
-        indices = []
+        """Format `queries` by selecting every ``n``th entry from the batch.
+
+        Here ``n`` is the step size, which represents the number of hard
+        negatives per passage.
+        """
         queries = {}
+        indices = []
         for key in batch:
             indices = list(range(0, batch[key].size(0), self.step_size))
             queries[key] = batch[key][indices, :]
-
-        assert indices
         return queries, last_hidden_state[indices, :, :]
 
     def format_passages_batch(
@@ -250,7 +250,6 @@ class ContrastiveModel(HuggingFaceModel):
         Here ``n`` is the step size, which represents the number of hard
         negatives per passage.
         """
-        assert self.step_size and (self.gather_in_batch_negatives is not None)
         passages = {}
         num_blocks = batch['input_ids'].size(0) // self.step_size
         index = torch.arange(

--- a/llmfoundry/models/llm_embed/modeling_llm_embed.py
+++ b/llmfoundry/models/llm_embed/modeling_llm_embed.py
@@ -62,9 +62,6 @@ class ContrastiveConfig:
         temperature (Union[int, float], optional): Temperature for InfoNCE Loss. Defaults to 1.
         vector_representation (str, optional): The vector representation to use. Defaults to 'avg'.
         normalize_output (bool, optional): Whether to normalize the output. Defaults to True.
-        pos_step_size (Optional[int], optional): The step size for positive samples. If None, will be inferred:
-            - For gather_in_batch_negatives=True, defaults to 2
-            - For hard negatives, inferred from batch structure (1 positive + N negatives)
         gather_in_batch_negatives (bool, optional): Whether to call all_gather on all samples in global batch
         use_legacy_gradient_passthrough (bool, optional): Whether to use the legacy gradient passthrough. Defaults to False.
         infonce_process_group_size (int, optional): The size of the process group for InfoNCE loss. Defaults to None.
@@ -72,7 +69,6 @@ class ContrastiveConfig:
     temperature: Union[int, float] = 1
     vector_representation: str = 'avg'
     normalize_output: bool = True
-    pos_step_size: Optional[int] = None
     gather_in_batch_negatives: bool = False
     use_legacy_gradient_passthrough: bool = False
     infonce_process_group_size: Optional[int] = None
@@ -159,20 +155,11 @@ class ContrastiveModel(HuggingFaceModel):
         self.vector_representation = contrastive_config_obj.vector_representation
         self.normalize_output = contrastive_config_obj.normalize_output
 
+        self.step_size = 2
+        self._first_batch_seen = False
         self.gather_in_batch_negatives = contrastive_config_obj.gather_in_batch_negatives
         self.use_legacy_gradient_passthrough = contrastive_config_obj.use_legacy_gradient_passthrough
-        
-        # Handle step size based on config
-        if contrastive_config_obj.pos_step_size is not None:
-            self.step_size = contrastive_config_obj.pos_step_size
-        else:
-            if self.gather_in_batch_negatives:
-                self.step_size = 2  # Default for in-batch negatives
-            else:
-                self.step_size = None  # Will be inferred from first batch
-                
         self.n_active_params = sum(p.numel() for p in self.parameters())
-
         if loss_fn == 'fused_crossentropy':
             try:
                 from flash_attn.losses.cross_entropy import \
@@ -221,15 +208,18 @@ class ContrastiveModel(HuggingFaceModel):
             self.is_mpt = True
         return model
     
-    def _infer_step_size(self, batch: MutableMapping) -> int:
-        """Infers the step size from batch structure.
-        
-        We expect input shape to be [batch_size, num_samples, seq_len]
-        where num_samples is (1 positive + N negatives).
-        """
+    def _update_step_size_if_needed(self, batch: MutableMapping) -> None:
+        """Update step size on first batch if we detect hard negatives"""
+        if self._first_batch_seen:
+            return
+
         input_shape = batch['input_ids'].shape
-        assert len(input_shape) == 3
-        return input_shape[1]
+        if len(input_shape) == 3 and input_shape[1] > 2:
+            # We have hard negatives, update step size to match
+            self.step_size = input_shape[1]
+            log.info(f"Detected hard negatives, updated step_size to {self.step_size}")
+            
+        self._first_batch_seen = True
 
     def format_queries_batch(
         self,
@@ -241,8 +231,6 @@ class ContrastiveModel(HuggingFaceModel):
         Here ``n`` is the step size, which represents the number of hard
         negatives per passage.
         """
-        if self.step_size is None:
-            self.step_size = self._infer_step_size(batch)
         queries = {}
         for key in batch:
             # Select every `step_size`-th entry from the batch for the given key
@@ -261,8 +249,6 @@ class ContrastiveModel(HuggingFaceModel):
         Here ``n`` is the step size, which represents the number of hard
         negatives per passage.
         """
-        if self.step_size is None:
-            self.step_size = self._infer_step_size(batch)
         passages = {}
 
         # Index on a variable step size
@@ -281,6 +267,7 @@ class ContrastiveModel(HuggingFaceModel):
 
     def forward(self, batch: MutableMapping) -> CausalLMOutputWithPast:
         # Collapse pairs into the batch dimension
+        self._update_step_size_if_needed(batch)
         collapse_dims = lambda x: rearrange(x, 'b p d -> (b p) d') if \
             len(x.shape) > 2 else x
 

--- a/llmfoundry/models/llm_embed/modeling_llm_embed.py
+++ b/llmfoundry/models/llm_embed/modeling_llm_embed.py
@@ -156,7 +156,6 @@ class ContrastiveModel(HuggingFaceModel):
         self.normalize_output = contrastive_config_obj.normalize_output
 
         self.step_size = 2
-        self._first_batch_seen = False
         self.gather_in_batch_negatives = contrastive_config_obj.gather_in_batch_negatives
         self.use_legacy_gradient_passthrough = contrastive_config_obj.use_legacy_gradient_passthrough
         self.n_active_params = sum(p.numel() for p in self.parameters())
@@ -210,8 +209,6 @@ class ContrastiveModel(HuggingFaceModel):
 
     def _update_step_size_if_needed(self, batch: MutableMapping) -> None:
         """Update step size on first batch if we detect hard negatives."""
-        if self._first_batch_seen:
-            return
 
         input_shape = batch['input_ids'].shape
         if input_shape[1] > 2:
@@ -220,8 +217,6 @@ class ContrastiveModel(HuggingFaceModel):
             log.info(
                 f'Detected hard negatives, updated step_size to {self.step_size}',
             )
-
-        self._first_batch_seen = True
 
     def format_queries_batch(
         self,

--- a/llmfoundry/models/llm_embed/modeling_llm_embed.py
+++ b/llmfoundry/models/llm_embed/modeling_llm_embed.py
@@ -212,14 +212,11 @@ class ContrastiveModel(HuggingFaceModel):
         """Update step size on first batch if we detect hard negatives."""
         if self._first_batch_seen:
             return
-        
-        print('UPDATE BATCH:', batch)
 
         input_shape = batch['input_ids'].shape
-        print('UPDATE BATCH input_ids, shape:', batch['input_ids'], batch['input_ids'].shape)
-        if len(input_shape) == 3 and input_shape[1] > 2:
-            # We have hard negatives, update step size to match
-            self.step_size = input_shape[1]
+        if input_shape[1] > 2:
+            # We have hard negatives, batch shape is [batch, sample of query+positive passage+negative passages, tokens].
+            self.step_size = input_shape[1] - 1
             log.info(
                 f'Detected hard negatives, updated step_size to {self.step_size}',
             )

--- a/llmfoundry/models/llm_embed/modeling_llm_embed.py
+++ b/llmfoundry/models/llm_embed/modeling_llm_embed.py
@@ -235,9 +235,8 @@ class ContrastiveModel(HuggingFaceModel):
         """
         assert self.step_size
         queries = {}
-        indices = []
+        indices = list(range(0, batch['input_ids'].size(0), self.step_size))
         for key in batch:
-            indices = list(range(0, batch[key].size(0), self.step_size))
             queries[key] = batch[key][indices, :]
         return queries, last_hidden_state[indices, :, :]
 

--- a/llmfoundry/models/llm_embed/modeling_llm_embed.py
+++ b/llmfoundry/models/llm_embed/modeling_llm_embed.py
@@ -216,6 +216,7 @@ class ContrastiveModel(HuggingFaceModel):
         print('UPDATE BATCH:', batch)
 
         input_shape = batch['input_ids'].shape
+        print('UPDATE BATCH input_ids, shape:', batch['input_ids'], batch['input_ids'].shape)
         if len(input_shape) == 3 and input_shape[1] > 2:
             # We have hard negatives, update step size to match
             self.step_size = input_shape[1]

--- a/llmfoundry/models/llm_embed/modeling_llm_embed.py
+++ b/llmfoundry/models/llm_embed/modeling_llm_embed.py
@@ -155,8 +155,7 @@ class ContrastiveModel(HuggingFaceModel):
         self.vector_representation = contrastive_config_obj.vector_representation
         self.normalize_output = contrastive_config_obj.normalize_output
 
-        self.step_size = 2
-        self._first_batch_seen = False
+        self.step_size = None
         self.gather_in_batch_negatives = contrastive_config_obj.gather_in_batch_negatives
         self.use_legacy_gradient_passthrough = contrastive_config_obj.use_legacy_gradient_passthrough
         self.n_active_params = sum(p.numel() for p in self.parameters())
@@ -210,7 +209,7 @@ class ContrastiveModel(HuggingFaceModel):
 
     def _update_step_size_if_needed(self, batch: MutableMapping) -> None:
         """Update step size on first batch if we detect hard negatives."""
-        if self._first_batch_seen:
+        if self.step_size:
             return
 
         input_shape = batch['input_ids'].shape
@@ -220,8 +219,8 @@ class ContrastiveModel(HuggingFaceModel):
             log.info(
                 f'Detected hard negatives, updated step_size to {self.step_size}',
             )
-
-        self._first_batch_seen = True
+        else:
+            self.step_size = 2
 
     def format_queries_batch(
         self,

--- a/llmfoundry/models/llm_embed/modeling_llm_embed.py
+++ b/llmfoundry/models/llm_embed/modeling_llm_embed.py
@@ -215,7 +215,7 @@ class ContrastiveModel(HuggingFaceModel):
         input_shape = batch['input_ids'].shape
         if input_shape[1] > 2:
             # We have hard negatives, batch shape is [batch, sample of query+positive passage+negative passages, tokens].
-            self.step_size = input_shape[1] - 1
+            self.step_size = input_shape[1]
             log.info(
                 f'Detected hard negatives, updated step_size to {self.step_size}',
             )

--- a/llmfoundry/models/llm_embed/modeling_llm_embed.py
+++ b/llmfoundry/models/llm_embed/modeling_llm_embed.py
@@ -69,6 +69,7 @@ class ContrastiveConfig:
     temperature: Union[int, float] = 1
     vector_representation: str = 'avg'
     normalize_output: bool = True
+    pos_step_size: int = -1 # keep for backwards compatibility
     gather_in_batch_negatives: bool = False
     use_legacy_gradient_passthrough: bool = False
     infonce_process_group_size: Optional[int] = None


### PR DESCRIPTION
Theres two cases: 

1. For in batch negatives, total number of negatives is batch size - 1. And pos_step_size is 2. 
2. For hard negatives, each sample has a list of negatives that can be as long as you like. In this case you have to change the pos_step_size.

We can remove setting step_size and autoinfer without needing the pos_step_size. We will need to look at the first batch to determine how many hard negatives. If there are hard negatives, we will use that - 1 as the step size. Otherwise, we will defer to batch negatives, setting step_size = 2

Testing:

embedding-ft-no-pos-zXOtvz (off of this branch, removed pos_step_size keyword):
<img width="525" alt="image" src="https://github.com/user-attachments/assets/3b4ac261-de9f-4719-8980-57d8cb8e8888">

embedding-ft-pos-kl2fPy (off foundry main pos_step_size = 2):
<img width="523" alt="image" src="https://github.com/user-attachments/assets/99878fdb-8875-44a7-ac9d-462403094ab0">

embedding-ft-pos-neg-gMJSGx (off foundry main pos_step_size = 21)
<img width="524" alt="image" src="https://github.com/user-attachments/assets/14a14663-c9bb-4250-a24b-4cde0dcb9912">


embedding-ft-no-pos-neg-3GoEms (off of this branch, removed pos_step_size keyword):
<img width="540" alt="image" src="https://github.com/user-attachments/assets/a8421068-1855-4423-8d21-9691566412d0">
