### PR TITLE
Catch Delta Table Not Found

### DIFF
--- a/llmfoundry/command_utils/data_prep/convert_delta_to_json.py
+++ b/llmfoundry/command_utils/data_prep/convert_delta_to_json.py
@@ -504,13 +504,16 @@ def fetch(
                 raise InsufficientPermissionsError(str(e)) from e
             elif 'UC_NOT_ENABLED' in str(e):
                 raise UCNotEnabledError() from e
-            elif 'DELTA_TABLE_NOT_FOUND' in str(e):
+            elif 'Delta table' in str(e) and "doesn't exist" in str(e):
                 err_str = str(e)
                 # Error string should be in this format:
                 # ---
                 # Error processing `catalog`.`volume_name`.`table_name`:
                 # [DELTA_TABLE_NOT_FOUND] Delta table `volume_name`.`table_name`
                 # doesn't exist.
+                # ---
+                # Error processing `catalog`.`volume_name`.`table_name`:
+                # Delta table `volume_name`.`table_name` doesn't exist.
                 # ---
                 parts = err_str.split('`')
                 if len(parts) < 7:

--- a/tests/a_scripts/data_prep/test_convert_delta_to_json.py
+++ b/tests/a_scripts/data_prep/test_convert_delta_to_json.py
@@ -617,7 +617,8 @@ class TestConvertDeltaToJsonl(unittest.TestCase):
     ):
         # Create a spark.AnalysisException with specific details
         analysis_exception = AnalysisException(
-            message='[DELTA_TABLE_NOT_FOUND] yada yada',
+            message=
+            "[DELTA_TABLE_NOT_FOUND] Delta table `volume_name`.`table_name` doesn't exist",
         )
 
         # Configure the fetch function to raise the AnalysisException


### PR DESCRIPTION
In this [PR](https://github.com/mosaicml/llm-foundry/pull/1625/files), we attempt to catch the error of when delta table is not found. However, the [DELTA_TABLE_NOT_FOUND] is not guaranteed. Instead, we will catch for the rest of the error message.