### PR TITLE
Retry catching BlockingIOError

### DIFF
--- a/llmfoundry/data/contrastive_pairs/dataloader.py
+++ b/llmfoundry/data/contrastive_pairs/dataloader.py
@@ -13,6 +13,7 @@ from typing import Any, Literal, Mapping, Optional, Union
 import numpy as np
 import torch
 from composer.core import DataSpec
+from composer.utils import retry
 from streaming import Stream, StreamingDataset
 from torch.utils.data import DataLoader
 from transformers import PreTrainedTokenizerBase
@@ -136,6 +137,7 @@ class StreamingPairsDataset(StreamingTextDataset):
             'negative': negative_responses,
         }
 
+    @retry(BlockingIOError, num_attempts=5, initial_backoff=1.0, max_jitter=0.5)
     def __getitem__(self, idx: int) -> dict[str, list[int]]:
         sample = StreamingDataset.__getitem__(self, idx)
         text_samples = []


### PR DESCRIPTION
Transiently hitting this error (pretty rare):
`BlockingIOError: [Errno 11] Resource temporarily unavailable: '*****/embedding_data/train/shard.00000.mds'`

Adding a retry mechanism here because BlockingIOError means either a running out of resources issue or a linux I/O issue, so no risks for retrying