### PR TITLE
Move transform_model_pre_registration in hf_checkpointer

### DIFF
--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -784,6 +784,10 @@ class HuggingFaceCheckpointer(Callback):
 
         if dist.get_global_rank() == 0:
             if register_to_mlflow:
+                assert new_model_instance is not None
+                new_model_instance = self.transform_model_pre_registration(
+                    new_model_instance,
+                )
                 if self.using_peft:
 
                     # Save and register peft model to mlflow, this code path uses our older two step logic
@@ -797,10 +801,6 @@ class HuggingFaceCheckpointer(Callback):
                     register_save_dir = os.path.join(
                         temp_save_dir,
                         'register_save',
-                    )
-                    assert new_model_instance is not None
-                    new_model_instance = self.transform_model_pre_registration(
-                        new_model_instance,
                     )
                     new_model_instance.save_pretrained(
                         register_save_dir,
@@ -860,9 +860,6 @@ class HuggingFaceCheckpointer(Callback):
         original_tokenizer: Optional[Any],
         save_dir: str,
     ):
-        new_model_instance = self.transform_model_pre_registration(
-            new_model_instance,
-        )
         components = {'model': new_model_instance}
         if original_tokenizer is not None:
             components['tokenizer'] = original_tokenizer

--- a/tests/a_scripts/inference/test_convert_composer_to_hf.py
+++ b/tests/a_scripts/inference/test_convert_composer_to_hf.py
@@ -1166,7 +1166,7 @@ def test_transform_model_pre_registration():
     assert tokenizer_name is not None
 
     checkpointer._save_and_register_peft_model = MagicMock()
-checkpointer.using_peft = True
+    checkpointer.using_peft = True
     checkpointer._save_checkpoint(
         state=state,
         logger=logger,

--- a/tests/a_scripts/inference/test_convert_composer_to_hf.py
+++ b/tests/a_scripts/inference/test_convert_composer_to_hf.py
@@ -1129,7 +1129,14 @@ def test_transform_model_pre_registration():
         tie_word_embeddings=None,
         precision='bfloat16',
     )
-
+    model_cfg['peft_config'] = {
+        'peft_type': 'LORA',
+        'task_type': 'CAUSAL_LM',
+        'lora_alpha': 32,
+        'lora_dropout': 0.05,
+        'r': 16,
+        'target_modules': 'all-linear',
+    }
     tokenizer = build_tokenizer(
         tokenizer_name=tokenizer_name,
         tokenizer_kwargs={},

--- a/tests/a_scripts/inference/test_convert_composer_to_hf.py
+++ b/tests/a_scripts/inference/test_convert_composer_to_hf.py
@@ -1124,7 +1124,7 @@ def test_transform_model_pre_registration():
             return super().transform_model_pre_registration(model)
 
     model_cfg, tokenizer_name = _get_model_and_tokenizer(
-        model='llama2',
+        model='neo',
         max_seq_len=10,
         tie_word_embeddings=None,
         precision='bfloat16',

--- a/tests/a_scripts/inference/test_convert_composer_to_hf.py
+++ b/tests/a_scripts/inference/test_convert_composer_to_hf.py
@@ -10,7 +10,7 @@ import shutil
 from argparse import Namespace
 from typing import Any, Callable, Optional, Union, cast
 from unittest import mock
-from unittest.mock import ANY, MagicMock, Mock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import catalogue
 import numpy as np

--- a/tests/a_scripts/inference/test_convert_composer_to_hf.py
+++ b/tests/a_scripts/inference/test_convert_composer_to_hf.py
@@ -1116,7 +1116,7 @@ def test_huggingface_conversion_callback(
     new=MockSpawnProcess,
 )
 def test_transform_model_pre_registration():
-    """Test that the `transform_model_pre_registration` method is called
+    """Test `transform_model_pre_registration` method is called."""
     correctly."""
 
     class ExtendedHuggingFaceCheckpointer(HuggingFaceCheckpointer):

--- a/tests/a_scripts/inference/test_convert_composer_to_hf.py
+++ b/tests/a_scripts/inference/test_convert_composer_to_hf.py
@@ -1116,7 +1116,6 @@ def test_huggingface_conversion_callback(
     new=MockSpawnProcess,
 )
 def test_transform_model_pre_registration():
-
     class ExtendedHuggingFaceCheckpointer(HuggingFaceCheckpointer):
 
         def transform_model_pre_registration(self, model: PreTrainedModel):

--- a/tests/a_scripts/inference/test_convert_composer_to_hf.py
+++ b/tests/a_scripts/inference/test_convert_composer_to_hf.py
@@ -1116,7 +1116,12 @@ def test_huggingface_conversion_callback(
     new=MockSpawnProcess,
 )
 def test_transform_model_pre_registration():
+        """Test that the `transform_model_pre_registration` method is called
+    correctly."""
+
     class ExtendedHuggingFaceCheckpointer(HuggingFaceCheckpointer):
+        """Set PEFT to false before registering for testing."""
+
 
         def transform_model_pre_registration(self, model: PreTrainedModel):
             self.using_peft = False

--- a/tests/a_scripts/inference/test_convert_composer_to_hf.py
+++ b/tests/a_scripts/inference/test_convert_composer_to_hf.py
@@ -10,7 +10,7 @@ import shutil
 from argparse import Namespace
 from typing import Any, Callable, Optional, Union, cast
 from unittest import mock
-from unittest.mock import ANY, MagicMock, patch
+from unittest.mock import ANY, MagicMock, Mock, patch
 
 import catalogue
 import numpy as np
@@ -624,7 +624,7 @@ def test_huggingface_conversion_callback_interval(
 def _get_model_and_tokenizer(
     model: str,
     max_seq_len: int,
-    tie_word_embeddings: bool,
+    tie_word_embeddings: Optional[bool],
     precision: str,
 ):
     if model == 'mpt':
@@ -1108,6 +1108,79 @@ def test_huggingface_conversion_callback(
 
     dist.barrier()
     delete_transformers_cache()
+
+
+@patch('os.cpu_count', MagicMock(return_value=1))
+@patch(
+    'llmfoundry.callbacks.hf_checkpointer.SpawnProcess',
+    new=MockSpawnProcess,
+)
+def test_transform_model_pre_registration():
+
+    class ExtendedHuggingFaceCheckpointer(HuggingFaceCheckpointer):
+
+        def transform_model_pre_registration(self, model: PreTrainedModel):
+            self.using_peft = False
+            return super().transform_model_pre_registration(model)
+
+    model_cfg, tokenizer_name = _get_model_and_tokenizer(
+        model='llama2',
+        max_seq_len=10,
+        tie_word_embeddings=None,
+        precision='bfloat16',
+    )
+
+    tokenizer = build_tokenizer(
+        tokenizer_name=tokenizer_name,
+        tokenizer_kwargs={},
+    )
+
+    original_model = build_composer_model(
+        model_cfg.pop('name'),
+        tokenizer=tokenizer,
+        cfg=model_cfg,
+    )
+
+    logger = MagicMock()
+    state = MagicMock()
+    state.timestamp.batch = 1
+    state.is_model_ddp = False
+    state.model = original_model
+    state.model.tokenizer = tokenizer
+
+    checkpointer = ExtendedHuggingFaceCheckpointer(
+        save_folder='test',
+        save_interval='1ba',
+    )
+    mlflow_logger_mock = _create_mlflow_logger_mock()
+    checkpointer.mlflow_loggers = [mlflow_logger_mock]  # type: ignore
+
+    assert model_cfg is not None
+    assert tokenizer_name is not None
+    model_cfg['peft_config'] = {
+        'peft_type': 'LORA',
+        'task_type': 'CAUSAL_LM',
+        'lora_alpha': 32,
+        'lora_dropout': 0.05,
+        'r': 16,
+        'target_modules': [
+            'q_proj',
+            'k_proj',
+            'v_proj',
+        ],
+    }
+
+    checkpointer._save_and_register_peft_model = MagicMock()
+
+    checkpointer._save_checkpoint(
+        state=state,
+        logger=logger,
+        upload_to_save_folder=True,
+        register_to_mlflow=True,
+    )
+
+    checkpointer._save_and_register_peft_model.assert_not_called()
+    assert mlflow_logger_mock.log_model.call_count == 1
 
 
 # TODO(GRT-2431): Refactor as enums

--- a/tests/a_scripts/inference/test_convert_composer_to_hf.py
+++ b/tests/a_scripts/inference/test_convert_composer_to_hf.py
@@ -1116,7 +1116,7 @@ def test_huggingface_conversion_callback(
     new=MockSpawnProcess,
 )
 def test_transform_model_pre_registration():
-        """Test that the `transform_model_pre_registration` method is called
+    """Test that the `transform_model_pre_registration` method is called
     correctly."""
 
     class ExtendedHuggingFaceCheckpointer(HuggingFaceCheckpointer):

--- a/tests/a_scripts/inference/test_convert_composer_to_hf.py
+++ b/tests/a_scripts/inference/test_convert_composer_to_hf.py
@@ -1166,7 +1166,7 @@ def test_transform_model_pre_registration():
     assert tokenizer_name is not None
 
     checkpointer._save_and_register_peft_model = MagicMock()
-
+checkpointer.using_peft = True
     checkpointer._save_checkpoint(
         state=state,
         logger=logger,

--- a/tests/a_scripts/inference/test_convert_composer_to_hf.py
+++ b/tests/a_scripts/inference/test_convert_composer_to_hf.py
@@ -1117,7 +1117,6 @@ def test_huggingface_conversion_callback(
 )
 def test_transform_model_pre_registration():
     """Test `transform_model_pre_registration` method is called."""
-    correctly."""
 
     class ExtendedHuggingFaceCheckpointer(HuggingFaceCheckpointer):
         """Set PEFT to false before registering for testing."""

--- a/tests/a_scripts/inference/test_convert_composer_to_hf.py
+++ b/tests/a_scripts/inference/test_convert_composer_to_hf.py
@@ -1121,7 +1121,6 @@ def test_transform_model_pre_registration():
     class ExtendedHuggingFaceCheckpointer(HuggingFaceCheckpointer):
         """Set PEFT to false before registering for testing."""
 
-
         def transform_model_pre_registration(self, model: PreTrainedModel):
             self.using_peft = False
             return super().transform_model_pre_registration(model)

--- a/tests/a_scripts/inference/test_convert_composer_to_hf.py
+++ b/tests/a_scripts/inference/test_convert_composer_to_hf.py
@@ -1164,18 +1164,6 @@ def test_transform_model_pre_registration():
 
     assert model_cfg is not None
     assert tokenizer_name is not None
-    model_cfg['peft_config'] = {
-        'peft_type': 'LORA',
-        'task_type': 'CAUSAL_LM',
-        'lora_alpha': 32,
-        'lora_dropout': 0.05,
-        'r': 16,
-        'target_modules': [
-            'q_proj',
-            'k_proj',
-            'v_proj',
-        ],
-    }
 
     checkpointer._save_and_register_peft_model = MagicMock()
 


### PR DESCRIPTION
Moves it before the peft branch so that it's closer to the original logic. 

run: `405b-reg-test-4-3lhrhp`