### PR TITLE
Speed up embedding tests

### DIFF
--- a/llmfoundry/models/llm_embed/modeling_llm_embed.py
+++ b/llmfoundry/models/llm_embed/modeling_llm_embed.py
@@ -132,9 +132,7 @@ class ContrastiveModel(HuggingFaceModel):
         if tokenizer.pad_token is None:  # type: ignore
             tokenizer.pad_token = tokenizer.eos_token
 
-        print('before construct')
         model = self.construct_model()
-        print('after construct')
 
         train_metrics: list[Metric] = [
         ]  # TODO: no train metrics for embedding models yet!

--- a/llmfoundry/models/llm_embed/modeling_llm_embed.py
+++ b/llmfoundry/models/llm_embed/modeling_llm_embed.py
@@ -129,7 +129,9 @@ class ContrastiveModel(HuggingFaceModel):
         if tokenizer.pad_token is None:  # type: ignore
             tokenizer.pad_token = tokenizer.eos_token
 
+        print('before construct')
         model = self.construct_model()
+        print('after construct')
 
         train_metrics: list[Metric] = [
         ]  # TODO: no train metrics for embedding models yet!
@@ -138,6 +140,7 @@ class ContrastiveModel(HuggingFaceModel):
             ContrastiveEvalLoss(),
         ]
 
+        print('before super')
         super().__init__(
             model=model,
             tokenizer=tokenizer,
@@ -147,6 +150,7 @@ class ContrastiveModel(HuggingFaceModel):
             shift_labels=False,
             allow_embedding_resizing=True,
         )
+        print('after super')
 
         # Temperature for InfoNCELoss
         self.temperature = contrastive_config_obj.temperature
@@ -185,6 +189,7 @@ class ContrastiveModel(HuggingFaceModel):
         if contrastive_config_obj.infonce_process_group_size is not None:
             pg_size = contrastive_config_obj.infonce_process_group_size
             self.infonce_process_group = create_set_process_group(pg_size)
+        print('end constructor')
 
     def construct_model(self):
         if self.pretrained_model_name_or_path:

--- a/tests/data_utils.py
+++ b/tests/data_utils.py
@@ -342,7 +342,7 @@ def build_temporary_contrastive_streaming_dataset(ds_format: str):
         out=os.path.join(tempdir.name, 'train'),
         compression=None,
     ) as output_writer:
-        for i in range(10):
+        for i in range(100):
             if ds_format == 'one_query_one_response':
                 output_writer.write({
                     'text_a': f'hello {i}',

--- a/tests/data_utils.py
+++ b/tests/data_utils.py
@@ -342,7 +342,7 @@ def build_temporary_contrastive_streaming_dataset(ds_format: str):
         out=os.path.join(tempdir.name, 'train'),
         compression=None,
     ) as output_writer:
-        for i in range(100):
+        for i in range(10):
             if ds_format == 'one_query_one_response':
                 output_writer.write({
                     'text_a': f'hello {i}',

--- a/tests/models/llm_embed/test_llm_embedding.py
+++ b/tests/models/llm_embed/test_llm_embedding.py
@@ -134,10 +134,10 @@ def test_mpt_embedding_lm(
                                         truncation=True,
                                         max_length=msl,
                                         return_tensors='pt')
-    if isinstance(model_inputs_batch, dict):
-        model_inputs_batch = {
-            k: v.to('cuda') for k, v in model_inputs_batch.items()
-        }
+
+    model_inputs_batch = {
+        k: v.to('cuda') for k, v in model_inputs_batch.items()
+    }
 
     with get_precision_context('amp_bf16'):
         outputs = model(model_inputs_batch)

--- a/tests/models/llm_embed/test_llm_embedding.py
+++ b/tests/models/llm_embed/test_llm_embedding.py
@@ -1,7 +1,6 @@
 # Copyright 2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
-from contextlib import nullcontext
 from typing import Any, Optional
 from unittest.mock import patch
 
@@ -103,7 +102,7 @@ def build_lm_config(is_hf: bool, attn_impl: Optional[str]) -> dict[str, Any]:
                 'hidden_size': 2,
                 'num_attention_heads': 2,
                 'num_hidden_layers': 2,
-            }
+            },
         }
     else:
         assert attn_impl is not None
@@ -198,7 +197,8 @@ def test_contrastive_loss(
 
     with temporary_contrastive_streaming_dataset(ds_format) as data_dir:
         lm_config = build_lm_config(is_hf, maybe_attn_impl)
-        model = ContrastiveModel(**lm_config, tokenizer=mock_tokenizer).to('cuda')
+        model = ContrastiveModel(**lm_config,
+                                 tokenizer=mock_tokenizer).to('cuda')
 
         train_dataloader = build_dataloader(
             dataloader_config(data_dir, 'local'),

--- a/tests/models/llm_embed/test_llm_embedding.py
+++ b/tests/models/llm_embed/test_llm_embedding.py
@@ -96,7 +96,16 @@ def model(
 def build_lm_config(is_hf: bool, attn_impl: Optional[str]) -> dict[str, Any]:
     if is_hf:
         assert attn_impl is None
-        return {'pretrained_model_name_or_path': 'facebook/opt-350m'}
+        return {
+            'pretrained_model_name_or_path': 'facebook/opt-350m',
+            'pretrained': False,
+            'config_overrides': {
+                'n_embd': 2,
+                'n_head': 2,
+                'n_layer': 2,
+                'vocab_size': 50272,
+            }
+        }
     else:
         assert attn_impl is not None
         return {

--- a/tests/models/llm_embed/test_llm_embedding.py
+++ b/tests/models/llm_embed/test_llm_embedding.py
@@ -100,10 +100,9 @@ def build_lm_config(is_hf: bool, attn_impl: Optional[str]) -> dict[str, Any]:
             'pretrained_model_name_or_path': 'facebook/opt-350m',
             'pretrained': False,
             'config_overrides': {
-                'n_embd': 2,
-                'n_head': 2,
-                'n_layer': 2,
-                'vocab_size': 50272,
+                'hidden_size': 2,
+                'num_attention_heads': 2,
+                'num_hidden_layers': 2,
             }
         }
     else:
@@ -121,7 +120,7 @@ def build_lm_config(is_hf: bool, attn_impl: Optional[str]) -> dict[str, Any]:
 
 
 def build_tokenizer_config(is_hf: bool) -> dict[str, Any]:
-    return {'vocab_size': 50257 if is_hf else 100352}
+    return {'vocab_size': 50257 if is_hf else 128}
 
 
 @pytest.mark.gpu

--- a/tests/models/llm_embed/test_llm_embedding.py
+++ b/tests/models/llm_embed/test_llm_embedding.py
@@ -101,9 +101,9 @@ def build_lm_config(is_hf: bool, attn_impl: Optional[str]) -> dict[str, Any]:
         assert attn_impl is not None
         return {
             'num_layers': 2,
-            'word_embed_proj_dim': 768,
-            'd_model': 768,
-            'n_heads': 12,
+            'word_embed_proj_dim': 128,
+            'd_model': 128,
+            'n_heads': 2,
             'vocab_size': 100352,
             'attn_config': {
                 'attn_impl': attn_impl,

--- a/tests/models/llm_embed/test_llm_embedding.py
+++ b/tests/models/llm_embed/test_llm_embedding.py
@@ -198,9 +198,7 @@ def test_contrastive_loss(
 
     with temporary_contrastive_streaming_dataset(ds_format) as data_dir:
         lm_config = build_lm_config(is_hf, maybe_attn_impl)
-        model = ContrastiveModel(**lm_config, tokenizer=mock_tokenizer).to(
-            torch.bfloat16,
-        ).to('cuda')
+        model = ContrastiveModel(**lm_config, tokenizer=mock_tokenizer).to('cuda')
 
         train_dataloader = build_dataloader(
             dataloader_config(data_dir, 'local'),
@@ -208,16 +206,12 @@ def test_contrastive_loss(
             2,
         )
 
-        precision = 'amp_bf16' if maybe_attn_impl == 'flash' else 'fp32'
-        ctx = get_precision_context(
-            'amp_bf16',
-        ) if attn_impl == 'flash' else nullcontext()
-        with ctx:
+        with get_precision_context('amp_bf16',):
             trainer = Trainer(
                 model=model,
                 train_dataloader=train_dataloader,
-                precision=precision,
-                max_duration='3ba',
+                precision='amp_bf16',
+                max_duration='1ba',
             )
             trainer.fit()
 

--- a/tests/models/llm_embed/test_llm_embedding.py
+++ b/tests/models/llm_embed/test_llm_embedding.py
@@ -104,7 +104,7 @@ def build_lm_config(is_hf: bool, attn_impl: Optional[str]) -> dict[str, Any]:
             'word_embed_proj_dim': 128,
             'd_model': 128,
             'n_heads': 2,
-            'vocab_size': 100352,
+            'vocab_size': 30000,
             'attn_config': {
                 'attn_impl': attn_impl,
             },
@@ -129,11 +129,12 @@ def test_mpt_embedding_lm(
     model = ContrastiveModel(**lm_config, tokenizer=mock_tokenizer).to(
         torch.bfloat16,
     ).to('cuda')
+    msl = 32
     model_inputs_batch = mock_tokenizer([['pair 1 a', 'pair 1 b'],
                                          ['pair 2 a', 'pair 2 b']],
                                         padding='max_length',
                                         truncation=True,
-                                        max_length=128,
+                                        max_length=msl,
                                         return_tensors='pt')
     if isinstance(model_inputs_batch, dict):
         model_inputs_batch = {
@@ -156,7 +157,7 @@ def test_mpt_embedding_lm(
         proj_dim = model.model.config.word_embed_proj_dim
         assert last_hidden_state.shape == (
             4,
-            128,
+            msl,
             proj_dim,
         )  # 2 pairs * 2 texts per pair, 128 sequence length, word_embed_proj_dim dim
         assert last_hidden_state.dtype == torch.bfloat16

--- a/tests/models/llm_embed/test_llm_embedding.py
+++ b/tests/models/llm_embed/test_llm_embedding.py
@@ -112,7 +112,7 @@ def build_lm_config(is_hf: bool, attn_impl: Optional[str]) -> dict[str, Any]:
             'word_embed_proj_dim': 128,
             'd_model': 128,
             'n_heads': 2,
-            'vocab_size': 128,
+            'vocab_size': 100352,
             'attn_config': {
                 'attn_impl': attn_impl,
             },
@@ -120,7 +120,7 @@ def build_lm_config(is_hf: bool, attn_impl: Optional[str]) -> dict[str, Any]:
 
 
 def build_tokenizer_config(is_hf: bool) -> dict[str, Any]:
-    return {'vocab_size': 50257 if is_hf else 128}
+    return {'vocab_size': 50257 if is_hf else 100352}
 
 
 @pytest.mark.gpu

--- a/tests/models/llm_embed/test_llm_embedding.py
+++ b/tests/models/llm_embed/test_llm_embedding.py
@@ -135,36 +135,36 @@ def test_mpt_embedding_lm(
     lm_config = build_lm_config(is_hf, maybe_attn_impl)
 
     model = ContrastiveModel(**lm_config, tokenizer=mock_tokenizer).to('cuda')
-    # msl = 32
-    # model_inputs_batch = mock_tokenizer([['pair 1 a', 'pair 1 b'],
-    #                                      ['pair 2 a', 'pair 2 b']],
-    #                                     padding='max_length',
-    #                                     truncation=True,
-    #                                     max_length=msl,
-    #                                     return_tensors='pt')
-    # if isinstance(model_inputs_batch, dict):
-    #     model_inputs_batch = {
-    #         k: v.to('cuda') for k, v in model_inputs_batch.items()
-    #     }
+    msl = 32
+    model_inputs_batch = mock_tokenizer([['pair 1 a', 'pair 1 b'],
+                                         ['pair 2 a', 'pair 2 b']],
+                                        padding='max_length',
+                                        truncation=True,
+                                        max_length=msl,
+                                        return_tensors='pt')
+    if isinstance(model_inputs_batch, dict):
+        model_inputs_batch = {
+            k: v.to('cuda') for k, v in model_inputs_batch.items()
+        }
 
-    # with get_precision_context('amp_bf16'):
-    #     outputs = model(model_inputs_batch)
+    with get_precision_context('amp_bf16'):
+        outputs = model(model_inputs_batch)
 
-    #     assert isinstance(outputs, dict)
-    #     assert 'hidden_states' in outputs
+        assert isinstance(outputs, dict)
+        assert 'hidden_states' in outputs
 
-    #     hidden_states = outputs['hidden_states']
-    #     assert isinstance(hidden_states, tuple)
+        hidden_states = outputs['hidden_states']
+        assert isinstance(hidden_states, tuple)
 
-    #     last_hidden_state = hidden_states[-1]
-    #     proj_dim = model.model.config.word_embed_proj_dim
-    #     assert last_hidden_state.shape == (
-    #         4,
-    #         msl,
-    #         proj_dim,
-    #     )  # 2 pairs * 2 texts per pair, 128 sequence length, word_embed_proj_dim dim
-    #     assert last_hidden_state.dtype == torch.bfloat16
-    #     assert last_hidden_state.device.type == 'cuda'
+        last_hidden_state = hidden_states[-1]
+        proj_dim = model.model.config.word_embed_proj_dim
+        assert last_hidden_state.shape == (
+            4,
+            msl,
+            proj_dim,
+        )  # 2 pairs * 2 texts per pair, 128 sequence length, word_embed_proj_dim dim
+        assert last_hidden_state.dtype == torch.bfloat16
+        assert last_hidden_state.device.type == 'cuda'
 
 
 dataloader_config = lambda remote, local_ext: {

--- a/tests/models/llm_embed/test_llm_embedding.py
+++ b/tests/models/llm_embed/test_llm_embedding.py
@@ -104,7 +104,7 @@ def build_lm_config(is_hf: bool, attn_impl: Optional[str]) -> dict[str, Any]:
             'word_embed_proj_dim': 128,
             'd_model': 128,
             'n_heads': 2,
-            'vocab_size': 30000,
+            'vocab_size': 128,
             'attn_config': {
                 'attn_impl': attn_impl,
             },

--- a/tests/models/llm_embed/test_llm_embedding.py
+++ b/tests/models/llm_embed/test_llm_embedding.py
@@ -112,7 +112,7 @@ def build_lm_config(is_hf: bool, attn_impl: Optional[str]) -> dict[str, Any]:
             'word_embed_proj_dim': 128,
             'd_model': 128,
             'n_heads': 2,
-            'vocab_size': 100352,
+            'vocab_size': 4096,
             'attn_config': {
                 'attn_impl': attn_impl,
             },
@@ -120,7 +120,7 @@ def build_lm_config(is_hf: bool, attn_impl: Optional[str]) -> dict[str, Any]:
 
 
 def build_tokenizer_config(is_hf: bool) -> dict[str, Any]:
-    return {'vocab_size': 50257 if is_hf else 100352}
+    return {'vocab_size': 50257 if is_hf else 4096}
 
 
 @pytest.mark.gpu

--- a/tests/models/llm_embed/test_llm_embedding.py
+++ b/tests/models/llm_embed/test_llm_embedding.py
@@ -10,7 +10,7 @@ import torch
 from composer import Trainer
 from composer.core import get_precision_context
 from torch.nn.parallel import DistributedDataParallel as DDP
-from transformers import AutoConfig
+from transformers import AutoConfig, PreTrainedTokenizerBase
 from transformers.modeling_outputs import \
     BaseModelOutputWithPastAndCrossAttentions
 
@@ -121,14 +121,14 @@ def build_tokenizer_config(is_hf: bool) -> dict[str, Any]:
 def test_mpt_embedding_lm(
     is_hf: bool,
     attn_impl: str,
-    mock_tokenizer: MockTokenizer,
+    tiny_gpt2_tokenizer: PreTrainedTokenizerBase,
 ):
     maybe_attn_impl = None if is_hf else attn_impl
     lm_config = build_lm_config(is_hf, maybe_attn_impl)
 
-    model = ContrastiveModel(**lm_config, tokenizer=mock_tokenizer).to('cuda')
+    model = ContrastiveModel(**lm_config, tokenizer=tiny_gpt2_tokenizer).to('cuda')
     msl = 32
-    model_inputs_batch = mock_tokenizer([['pair 1 a', 'pair 1 b'],
+    model_inputs_batch = tiny_gpt2_tokenizer([['pair 1 a', 'pair 1 b'],
                                          ['pair 2 a', 'pair 2 b']],
                                         padding='max_length',
                                         truncation=True,

--- a/tests/models/llm_embed/test_llm_embedding.py
+++ b/tests/models/llm_embed/test_llm_embedding.py
@@ -139,10 +139,7 @@ def test_mpt_embedding_lm(
             k: v.to('cuda') for k, v in model_inputs_batch.items()
         }
 
-    ctx = get_precision_context(
-        'amp_bf16',
-    ) if maybe_attn_impl == 'flash' else nullcontext()
-    with ctx:
+    with get_precision_context('amp_bf16'):
         outputs = model(model_inputs_batch)
 
         assert isinstance(outputs, dict)

--- a/tests/models/llm_embed/test_llm_embedding.py
+++ b/tests/models/llm_embed/test_llm_embedding.py
@@ -126,9 +126,7 @@ def test_mpt_embedding_lm(
     maybe_attn_impl = None if is_hf else attn_impl
     lm_config = build_lm_config(is_hf, maybe_attn_impl)
 
-    model = ContrastiveModel(**lm_config, tokenizer=mock_tokenizer).to(
-        torch.bfloat16,
-    ).to('cuda')
+    model = ContrastiveModel(**lm_config, tokenizer=mock_tokenizer).to('cuda')
     msl = 32
     model_inputs_batch = mock_tokenizer([['pair 1 a', 'pair 1 b'],
                                          ['pair 2 a', 'pair 2 b']],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -142,9 +142,8 @@ class MockTokenizer(PreTrainedTokenizerBase):
         else:
             texts = batch_texts
 
-        max_int = self._vocab_size - max_length
         token_ids = torch.tensor([
-            [hash(text) % max_int + j for j in range(max_length)] for text in texts
+            [hash(text) % 1000 + j for j in range(max_length)] for text in texts
         ])
 
         return {

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -142,8 +142,9 @@ class MockTokenizer(PreTrainedTokenizerBase):
         else:
             texts = batch_texts
 
+        max_int = self._vocab_size - max_length
         token_ids = torch.tensor([
-            [hash(text) % 1000 + j for j in range(max_length)] for text in texts
+            [hash(text) % max_int + j for j in range(max_length)] for text in texts
         ])
 
         return {

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -114,7 +114,7 @@ class MockTokenizer(PreTrainedTokenizerBase):
         self.eos_token: str = '</s>'
         self.bos_token: str = '<s>'
         self.unk_token: str = '<unk>'
-        self._vocab_size: int = 30000
+        self._vocab_size: int = 128
 
     def __len__(self) -> int:
         return self._vocab_size


### PR DESCRIPTION
Slowest tests before:
```
72.64s call     tests/models/llm_embed/test_llm_embedding.py::test_mpt_embedding_lm[flash-True]
67.93s call     tests/models/llm_embed/test_llm_embedding.py::test_mpt_embedding_lm[torch-True]
67.84s call     tests/models/llm_embed/test_llm_embedding.py::test_contrastive_loss[one_query_multiple_responses-torch-True]
67.66s call     tests/models/llm_embed/test_llm_embedding.py::test_contrastive_loss[one_query_multiple_responses-flash-True]
67.52s call     tests/models/llm_embed/test_llm_embedding.py::test_contrastive_loss[one_query_one_response-torch-True]
67.48s call     tests/models/llm_embed/test_llm_embedding.py::test_contrastive_loss[one_query_one_response-flash-True]
40.42s setup    tests/tp/test_tp_strategies.py::test_tp_train_with_moes[ffn-2]
34.22s call     tests/models/llm_embed/test_llm_embedding.py::test_contrastive_loss[one_query_multiple_responses-torch-False]
33.72s call     tests/models/llm_embed/test_llm_embedding.py::test_contrastive_loss[one_query_multiple_responses-flash-False]
33.41s call     tests/models/llm_embed/test_llm_embedding.py::test_contrastive_loss[one_query_one_response-flash-False]
33.37s call     tests/models/llm_embed/test_llm_embedding.py::test_mpt_embedding_lm[flash-False]
32.93s call     tests/models/llm_embed/test_llm_embedding.py::test_contrastive_loss[one_query_one_response-torch-False]
32.73s call     tests/models/llm_embed/test_llm_embedding.py::test_mpt_embedding_lm[torch-False]
23.31s call     tests/tp/test_tp_strategies.py::test_tp_train_with_one_gpu
17.43s call     tests/a_scripts/inference/test_convert_composer_to_hf.py::test_convert_and_generate[mptmoe-None]
14.04s call     tests/a_scripts/inference/test_convert_composer_to_hf.py::test_convert_and_generate_meta[False-scripts/train/yamls/pretrain/testing-moe.yaml]
13.86s call     tests/a_scripts/inference/test_convert_composer_to_hf.py::test_convert_and_generate_meta[True-scripts/train/yamls/pretrain/testing-moe.yaml]
10.22s call     tests/models/layers/test_dmoe.py::test_fwd_equal_dmoe[bf16-glu-512]
8.52s call     tests/models/layers/test_dmoe.py::test_fwd_equal_dmoe[fp32-glu-512]
7.68s call     tests/a_scripts/inference/test_convert_composer_to_hf.py::test_huggingface_conversion_callback_interval[3ba-2ba-4ba-2-2-True]
```

Slowest tests after:
```
40.43s setup    tests/tp/test_tp_strategies.py::test_tp_train_with_moes[ffn-2]
22.27s call     tests/tp/test_tp_strategies.py::test_tp_train_with_one_gpu
17.86s call     tests/a_scripts/inference/test_convert_composer_to_hf.py::test_convert_and_generate[mptmoe-None]
14.43s call     tests/a_scripts/inference/test_convert_composer_to_hf.py::test_convert_and_generate_meta[True-scripts/train/yamls/pretrain/testing-moe.yaml]
14.27s call     tests/a_scripts/inference/test_convert_composer_to_hf.py::test_convert_and_generate_meta[False-scripts/train/yamls/pretrain/testing-moe.yaml]
10.26s call     tests/models/layers/test_dmoe.py::test_fwd_equal_dmoe[bf16-glu-512]
8.85s call     tests/models/llm_embed/test_llm_embedding.py::test_contrastive_loss[one_query_multiple_responses-flash-False]
8.82s call     tests/models/llm_embed/test_llm_embedding.py::test_contrastive_loss[one_query_multiple_responses-torch-False]
8.55s call     tests/models/layers/test_dmoe.py::test_fwd_equal_dmoe[fp32-glu-512]
8.15s call     tests/a_scripts/inference/test_convert_composer_to_hf.py::test_huggingface_conversion_callback_interval[3ba-2ba-4ba-2-2-False]
8.07s call     tests/models/llm_embed/test_llm_embedding.py::test_contrastive_loss[one_query_one_response-torch-False]
7.86s call     tests/models/llm_embed/test_llm_embedding.py::test_mpt_embedding_lm[torch-False]
7.71s call     tests/a_scripts/inference/test_convert_composer_to_hf.py::test_huggingface_conversion_callback_interval[3ba-2ba-4ba-2-2-True]
7.56s call     tests/models/llm_embed/test_llm_embedding.py::test_contrastive_loss[one_query_one_response-flash-False]
7.47s call     tests/models/llm_embed/test_llm_embedding.py::test_mpt_embedding_lm[flash-False]
6.93s call     tests/a_scripts/inference/test_convert_composer_to_hf.py::test_huggingface_conversion_callback_interval[1dur-2ba-1ep-1-2-False]
6.72s call     tests/a_scripts/inference/test_convert_composer_to_hf.py::test_huggingface_conversion_callback_interval[1dur-2ba-1ep-1-2-True]
6.67s call     tests/models/layers/test_dmoe.py::test_fwd_equal_dmoe[bf16-mlp-512]
5.29s call     tests/a_scripts/inference/test_convert_composer_to_hf.py::test_final_register_only[None-False]
5.02s call     tests/models/hf/test_hf_mpt_gen.py::test_init_hfhub_mpt[flash-gpu]
```