### PR TITLE
Bugfix auto packing with streams + no remote path

### DIFF
--- a/llmfoundry/data/packing.py
+++ b/llmfoundry/data/packing.py
@@ -485,6 +485,8 @@ def profile_packing(
             tmp_path_to_broadcast = tempfile.TemporaryDirectory().name
             gathered_paths = dist.all_gather_object(tmp_path_to_broadcast)
             tmp_path = gathered_paths[local_rank_zero]
+            if stream_config.get('remote') is None:
+                stream_config['remote'] = stream_config['local']
             stream_config['local'] = tmp_path
 
     # Determine the packing_ratio values we'll try

--- a/llmfoundry/data/packing.py
+++ b/llmfoundry/data/packing.py
@@ -474,7 +474,8 @@ def profile_packing(
 
     # If streaming dataset, use a temporary local folder for profiling
     local_rank_zero = dist.get_global_rank() - dist.get_local_rank()
-    if dataset_cfg.get('remote') is not None:
+    if dataset_cfg.get('remote'
+                      ) is not None and dataset_cfg.get('local') is None:
         tmp_path_to_broadcast = tempfile.TemporaryDirectory().name
         gathered_paths = dist.all_gather_object(tmp_path_to_broadcast)
         tmp_path = gathered_paths[local_rank_zero]
@@ -485,9 +486,8 @@ def profile_packing(
             tmp_path_to_broadcast = tempfile.TemporaryDirectory().name
             gathered_paths = dist.all_gather_object(tmp_path_to_broadcast)
             tmp_path = gathered_paths[local_rank_zero]
-            if stream_config.get('remote') is None:
-                stream_config['remote'] = stream_config['local']
-            stream_config['local'] = tmp_path
+            if stream_config.get('local') is None:
+                stream_config['local'] = tmp_path
 
     # Determine the packing_ratio values we'll try
     packing_ratios, raw_batch_sizes = [], []

--- a/llmfoundry/data/packing.py
+++ b/llmfoundry/data/packing.py
@@ -474,8 +474,9 @@ def profile_packing(
 
     # If streaming dataset, use a temporary local folder for profiling
     local_rank_zero = dist.get_global_rank() - dist.get_local_rank()
-    if dataset_cfg.get('remote'
-                      ) is not None and dataset_cfg.get('local') is None:
+    if dataset_cfg.get(
+        'remote',
+    ) is not None and dataset_cfg.get('local') is None:
         tmp_path_to_broadcast = tempfile.TemporaryDirectory().name
         gathered_paths = dist.all_gather_object(tmp_path_to_broadcast)
         tmp_path = gathered_paths[local_rank_zero]

--- a/tests/data/test_packing.py
+++ b/tests/data/test_packing.py
@@ -162,7 +162,9 @@ def test_dist_auto_packing(profile_packing: Mock):
 
 
 def get_remote_config(
-    base_cfg: dict, remote_dir: str, local_dir: str
+    base_cfg: dict,
+    remote_dir: str,
+    local_dir: str,
 ) -> DictConfig:
     return DictConfig({
         **base_cfg,
@@ -175,7 +177,9 @@ def get_remote_config(
 
 
 def get_streams_config(
-    base_cfg: dict, remote_dir: str, local_dir: str
+    base_cfg: dict,
+    remote_dir: str,
+    local_dir: str,
 ) -> DictConfig:
     return DictConfig({
         **base_cfg,
@@ -201,17 +205,19 @@ def patched_packing_ratio(*args: Any, **kwargs: Any):
 
 
 @pytest.mark.parametrize(
-    'get_config', [
+    'get_config',
+    [
         get_remote_config,
         get_streams_config,
-    ]
+    ],
 )
 @patch(
     'llmfoundry.data.finetuning.dataloader.auto_packing_ratio',
     patched_packing_ratio,
 )
 def test_auto_packing_with_streaming_dataloader(
-    get_config: Callable[[dict, str, str], DictConfig], tmp_path: Path
+    get_config: Callable[[dict, str, str], DictConfig],
+    tmp_path: Path,
 ):
     columns = {'prompt': 'str', 'response': 'str'}
     tokenizer = build_tokenizer('gpt2', {})

--- a/tests/data/test_packing.py
+++ b/tests/data/test_packing.py
@@ -208,15 +208,15 @@ def test_auto_packing_with_streaming_dataloader(tmp_path: Path):
         **base_cfg,
         'dataset': {
             **base_cfg['dataset'],
-            'streams': [
-                {
+            'streams': {
+                'stream_with_remote': {
                     'remote': remote_dir,
                     'local': local_dir,
                 },
-                {
+                'stream_without_remote': {
                     'local': remote_dir,
                 },
-            ],
+            },
         },
     })
 


### PR DESCRIPTION
## This PR

Edge case where auto packing fails for a streaming dataset specified through `streams` field if only a local path and no remote path is provided. This configuration is more broadly supported for Foundry.
```
  train_loader:
    name: finetuning
    dataset:
      streams:
        finetuning:
          local: /foo/bar/train/mds/
```
An error is thrown in StreamingDataset init because there is a [check](https://github.com/mosaicml/streaming/blob/f4832d41823c99fe9f80d6f0101fbc62041599e3/streaming/base/stream.py#L451-L454) that `local` contains an index file. The current auto packing script overwrites `local` with an empty tempdir. This fix temporarily has `remote` point to the user-provided `local`, which should contain an index file. 

## Testing
- MCLI run with streams + no remote path
- Added unit test
