### PR TITLE
Catch bad split regex

### DIFF
--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -71,6 +71,7 @@ from llmfoundry.utils.exceptions import (
     ALLOWED_MESSAGES_KEYS,
     ALLOWED_PROMPT_KEYS,
     ALLOWED_RESPONSE_KEYS,
+    BadDatasetSplitError,
     ChatTemplateError,
     ConsecutiveRepeatedChatRolesError,
     DatasetTooSmallError,
@@ -1044,6 +1045,14 @@ class DatasetConstructor:
         if isinstance(error, hf_exceptions.DatasetGenerationError):
             log.error('Huggingface DatasetGenerationError during data prep.')
             raise MisconfiguredHfDatasetError(
+                dataset_name=dataset_name,
+                split=split,
+            ) from error
+        elif isinstance(error, ValueError) and 'Split name should match' in str(
+            error,
+        ):
+            log.error('Huggingface split ValueError during data prep.')
+            raise BadDatasetSplitError(
                 dataset_name=dataset_name,
                 split=split,
             ) from error

--- a/llmfoundry/utils/exceptions.py
+++ b/llmfoundry/utils/exceptions.py
@@ -417,6 +417,18 @@ class MisconfiguredHfDatasetError(UserError):
         super().__init__(message, dataset_name=dataset_name, split=split)
 
 
+class BadDatasetSplitError(UserError):
+    """Error thrown when a HuggingFace dataset is misconfigured."""
+
+    def __init__(self, dataset_name: str, split: Optional[str] = None) -> None:
+        reg = r"^\\w+(\\.\\w+)*$"
+        message = f'Your dataset (name={dataset_name}, split={split}) has an invalid split. ' + \
+            f'Please check your split name to make sure it matches the pattern "{reg}"' \
+            if split is not None else f'Your dataset (name={dataset_name}) is misconfigured. ' + \
+            f'Please check your split name to make sure it matches the pattern "{reg}"'
+        super().__init__(message, dataset_name=dataset_name, split=split)
+
+
 class InvalidDatasetError(UserError):
     """Error thrown when a dataset contains no valid samples for training."""
 


### PR DESCRIPTION
Datasets throws this error:

https://github.com/huggingface/datasets/blob/661d7bac29689e2d9eb74fba3d243939d6e9f25b/src/datasets/splits.py#L362

when a split doesn't match the regex. This we catch and throw to the user.