### PR TITLE
Catch multiple slashes in source dataset into one slash

### DIFF
--- a/llmfoundry/utils/config_utils.py
+++ b/llmfoundry/utils/config_utils.py
@@ -6,9 +6,9 @@ import copy
 import logging
 import math
 import os
-import re
 import warnings
 from dataclasses import dataclass, fields
+from pathlib import Path
 from typing import (
     Any,
     Callable,
@@ -705,7 +705,7 @@ def _process_data_source(
         data_paths (List[Tuple[str, str, str]]): A list of tuples formatted as (data type, path, split)
     """
     if source_dataset_path:
-        source_dataset_path = re.sub(r'/+', '/', source_dataset_path)
+        source_dataset_path = str(Path(source_dataset_path))
     # Check for Delta table
     if source_dataset_path and len(source_dataset_path.split('.')) == 3:
         data_paths.append(('delta_table', source_dataset_path, true_split))

--- a/llmfoundry/utils/config_utils.py
+++ b/llmfoundry/utils/config_utils.py
@@ -22,7 +22,6 @@ from typing import (
 import mlflow
 from composer.loggers import Logger
 from composer.utils import dist, parse_uri
-from exceptions import UCNotFoundError
 from mlflow.data import (
     delta_dataset_source,
     http_dataset_source,
@@ -37,6 +36,7 @@ from transformers import PretrainedConfig
 from llmfoundry.layers_registry import ffns_with_megablocks
 from llmfoundry.models.utils import init_empty_weights
 from llmfoundry.registry import config_transforms
+from llmfoundry.utils.exceptions import UCNotFoundError
 
 log = logging.getLogger(__name__)
 
@@ -706,6 +706,8 @@ def _process_data_source(
         true_split (str): The split of the dataset to be added (i.e. train or eval)
         data_paths (List[Tuple[str, str, str]]): A list of tuples formatted as (data type, path, split)
     """
+    if source_dataset_path:
+        source_dataset_path = re.sub(r'/+', '/', source_dataset_path)
     # Check for Delta table
     if source_dataset_path and len(source_dataset_path.split('.')) == 3:
         data_paths.append(('delta_table', source_dataset_path, true_split))

--- a/llmfoundry/utils/config_utils.py
+++ b/llmfoundry/utils/config_utils.py
@@ -28,7 +28,6 @@ from mlflow.data import (
     huggingface_dataset_source,
     uc_volume_dataset_source,
 )
-from mlflow.exceptions import MlflowException
 from omegaconf import MISSING, DictConfig, ListConfig, MissingMandatoryValue
 from omegaconf import OmegaConf as om
 from transformers import PretrainedConfig
@@ -36,7 +35,6 @@ from transformers import PretrainedConfig
 from llmfoundry.layers_registry import ffns_with_megablocks
 from llmfoundry.models.utils import init_empty_weights
 from llmfoundry.registry import config_transforms
-from llmfoundry.utils.exceptions import UCNotFoundError
 
 log = logging.getLogger(__name__)
 
@@ -798,18 +796,7 @@ def log_dataset_uri(cfg: dict[str, Any]) -> None:
             if dataset_type == 'delta_table':
                 source = source_class(delta_table_name=path)
             elif dataset_type == 'hf' or dataset_type == 'uc_volume':
-                try:
-                    source = source_class(path=path)
-                except MlflowException as e:
-                    error_str = str(e)
-                    match = re.search(
-                        r'MlflowException:\s+(.*?)\s+does not exist in Databricks Unified Catalog\.',
-                        error_str,
-                    )
-                    if match:
-                        uc_path = match.group(1)
-                        raise UCNotFoundError(uc_path)
-                    raise
+                source = source_class(path=path)
             else:
                 source = source_class(url=path)
         else:

--- a/llmfoundry/utils/exceptions.py
+++ b/llmfoundry/utils/exceptions.py
@@ -33,6 +33,7 @@ __all__ = [
     'StoragePermissionError',
     'UCNotEnabledError',
     'DeltaTableNotFoundError',
+    'UCNotFoundError',
 ]
 
 ALLOWED_RESPONSE_KEYS = {'response', 'completion'}
@@ -584,4 +585,18 @@ class DeltaTableNotFoundError(UserError):
             catalog_name=catalog_name,
             volume_name=volume_name,
             table_name=table_name,
+        )
+
+
+class UCNotFoundError(UserError):
+    """Error thrown when the UC passed in training doesn't exist."""
+
+    def __init__(
+        self,
+        path: str,
+    ) -> None:
+        message = f'Your data path {path} does not exist. Please double check your UC path'
+        super().__init__(
+            message=message,
+            path=path,
         )

--- a/llmfoundry/utils/exceptions.py
+++ b/llmfoundry/utils/exceptions.py
@@ -33,7 +33,6 @@ __all__ = [
     'StoragePermissionError',
     'UCNotEnabledError',
     'DeltaTableNotFoundError',
-    'UCNotFoundError',
 ]
 
 ALLOWED_RESPONSE_KEYS = {'response', 'completion'}
@@ -585,18 +584,4 @@ class DeltaTableNotFoundError(UserError):
             catalog_name=catalog_name,
             volume_name=volume_name,
             table_name=table_name,
-        )
-
-
-class UCNotFoundError(UserError):
-    """Error thrown when the UC passed in training doesn't exist."""
-
-    def __init__(
-        self,
-        path: str,
-    ) -> None:
-        message = f'Your data path {path} does not exist. Please double check your UC path'
-        super().__init__(
-            message=message,
-            path=path,
         )


### PR DESCRIPTION
As title suggests, trying to catch wrong input for UC where user accidentally adds multiple slashes

Test:
On main:
`test-uc-mlflow-IEv1zp`
<img width="664" alt="image" src="https://github.com/user-attachments/assets/3710fa26-e716-4b84-a13d-241043bc39e0" />

On branch:
`test-uc-mlflow-8yeqFa`
<img width="453" alt="image" src="https://github.com/user-attachments/assets/21fe19c2-1a57-45d0-a8d6-1e179175c625" />

Trains properly now with s broken dummy path: 
<img width="528" alt="image" src="https://github.com/user-attachments/assets/1fb73ff1-9cdc-42ef-90d6-dd71b7d39f07" />
