### PR TITLE
Add permission error

### DIFF
--- a/llmfoundry/command_utils/data_prep/convert_delta_to_json.py
+++ b/llmfoundry/command_utils/data_prep/convert_delta_to_json.py
@@ -730,6 +730,14 @@ def fetch_DT(
                 message=
                 f'The data preparation cluster you provided is not usable. Please retry with a cluster that is healthy and alive. {e}',
             ) from e
+        if isinstance(
+            e,
+            spark_errors.SparkConnectGrpcException,
+        ) and 'do not have permission to attach to cluster' in str(e):
+            raise FaultyDataPrepCluster(
+                message=
+                f'You do not have permission to attach to the data preparation cluster you provided. {e}',
+            ) from e
         if isinstance(e, grpc.RpcError) and e.code(
         ) == grpc.StatusCode.INTERNAL and 'Job aborted due to stage failure' in e.details(
         ):

--- a/tests/a_scripts/data_prep/test_convert_delta_to_json.py
+++ b/tests/a_scripts/data_prep/test_convert_delta_to_json.py
@@ -626,7 +626,9 @@ class TestConvertDeltaToJsonl(unittest.TestCase):
                 ],
             ),
             (
-                SparkConnectGrpcException('do not have permission to attach to cluster etc...'),
+                SparkConnectGrpcException(
+                    'do not have permission to attach to cluster etc...',
+                ),
                 FaultyDataPrepCluster,
                 [
                     'You do not have permission to attach to the data preparation cluster you provided.',

--- a/tests/a_scripts/data_prep/test_convert_delta_to_json.py
+++ b/tests/a_scripts/data_prep/test_convert_delta_to_json.py
@@ -626,6 +626,13 @@ class TestConvertDeltaToJsonl(unittest.TestCase):
                 ],
             ),
             (
+                SparkConnectGrpcException('do not have permission to attach to cluster etc...'),
+                FaultyDataPrepCluster,
+                [
+                    'You do not have permission to attach to the data preparation cluster you provided.',
+                ],
+            ),
+            (
                 grpc_lib_error,
                 FaultyDataPrepCluster,
                 [


### PR DESCRIPTION
When accessing the cluster, a permission error can be thrown. This wraps the permission error. The error is in the format `SparkConnectGrpcException: PERMISSION_DENIED: You do not have permission to attach to cluster 0103-084159-k6zx2i2q-v2n`. Structured the same as #1628 