### PR TITLE
Use llmfoundry image instead of pytorch image for gpu tests

### DIFF
--- a/.github/workflows/pr-gpu.yaml
+++ b/.github/workflows/pr-gpu.yaml
@@ -4,7 +4,7 @@ on:
     branches:
     - main
     - release/*
-  pull_request:
+  pull_request_target:
     branches:
     - main
     - release/**

--- a/.github/workflows/pr-gpu.yaml
+++ b/.github/workflows/pr-gpu.yaml
@@ -4,7 +4,7 @@ on:
     branches:
     - main
     - release/*
-  pull_request_target:
+  pull_request:
     branches:
     - main
     - release/**
@@ -23,7 +23,7 @@ jobs:
       matrix:
         include:
         - name: "gpu-2.6.0-1"
-          container: mosaicml/pytorch:2.6.0_cu124-python3.11-ubuntu22.04
+          container: mosaicml/llm-foundry:2.6.0_cu124-latest
           markers: "gpu"
           pip_deps: "[all]"
           pytest_command: "coverage run -m pytest"
@@ -52,7 +52,7 @@ jobs:
       matrix:
         include:
         - name: "gpu-2.6.0-2"
-          container: mosaicml/pytorch:2.6.0_cu124-python3.11-ubuntu22.04
+          container: mosaicml/llm-foundry:2.6.0_cu124-latest
           markers: "gpu"
           pip_deps: "[all]"
           pytest_command: "coverage run -m pytest"
@@ -81,7 +81,7 @@ jobs:
       matrix:
         include:
         - name: "gpu-2.6.0-4"
-          container: mosaicml/pytorch:2.6.0_cu124-python3.11-ubuntu22.04
+          container: mosaicml/llm-foundry:2.6.0_cu124-latest
           markers: "gpu"
           pip_deps: "[all]"
           pytest_command: "coverage run -m pytest"


### PR DESCRIPTION
We replaced the original llmfoundry images with the pytorch images since the original llmfoundry images weren't built yet; so I am replacing this just before we start working on the llmfoundry release