### PR TITLE
Fix bugs in `llmfoundry/data/text_data.py`

### DIFF
--- a/llmfoundry/data/text_data.py
+++ b/llmfoundry/data/text_data.py
@@ -476,7 +476,10 @@ if __name__ == '__main__':
         print('\n')
         print('#' * 20, f'Batch {batch_ix}', '#' * 20)
         for k, v in batch.items():
-            print(k, v.shape, v.dtype)
+            if isinstance(v, torch.Tensor):
+                print(k, v.shape, v.dtype)
+            else:
+                print(k, v)
         for sample_ix, token_sample in enumerate(batch['input_ids']):
             print('-' * 20, f' Sample {sample_ix} ', '-' * 20)
             print(tokenizer.decode(token_sample))

--- a/llmfoundry/data/text_data.py
+++ b/llmfoundry/data/text_data.py
@@ -446,7 +446,6 @@ if __name__ == '__main__':
         print(f'Reading {args.split} split from {args.local_path}')
 
     cfg = {
-        'name': 'text',
         'dataset': {
             'local': args.local_path,
             'remote': args.remote_path,


### PR DESCRIPTION
When following `scripts/train/README.md` I encountered two apparent bugs in `llmfoundry/data/text_data.py`. This PR fixes them.

# Steps

## Issue 1

```bash
python ../data_prep/convert_dataset_hf.py --dataset allenai/c4 --data_subset en --out_root ./my-copy-c4 --splits train val --concat_tokens 2048 --tokenizer EleutherAI/gpt-neox-20b --eos_text '<|endoftext|>'
```

```bash
python ../../llmfoundry/data/text_data.py --local_path ./my-copy-c4 --split val_small
```

This is the first error:

```
Reading val_small split from ./my-copy-c4
Traceback (most recent call last):
  File "/workspaces/llm-foundry/scripts/train/../../llmfoundry/data/text_data.py", line 467, in <module>
    loader = build_text_dataloader(
             ^^^^^^^^^^^^^^^^^^^^^^
TypeError: build_text_dataloader() got an unexpected keyword argument 'name'
```

https://github.com/mosaicml/llm-foundry/blob/2c5068eb996867e6ca9d122431f61af3fb1bada6/llmfoundry/data/text_data.py#L467 is calling `build_text_dataloader` with a `name` keyword argument that does not exist. I address this problem by deleting the `"name"` key from `cfg`, which does not appear to be used anywhere else.

## Issue 2

```bash
python ../../llmfoundry/data/text_data.py --local_path ./my-copy-c4 --split val_small
```

Result:

```
Traceback (most recent call last):
  File "/workspaces/llm-foundry/scripts/train/../../llmfoundry/data/text_data.py", line 479, in <module>
    print(k, v.shape, v.dtype)
             ^^^^^^^
AttributeError: 'list' object has no attribute 'shape'
```

The problem here is that each element of `loader` looks like this:

```
{
    "input_ids": tensor([[13698, ...], [323, ...], [323, ...]]),
    "total_tokens": [32, 32],
    "loss_generating_tokens": [tensor(31), tensor(31)],
}
```

The value for `"total_tokens"` is a `list` of `int`s, not a `torch.Tensor`, so it does not have a shape.

I fixed this problem by running `print(k, v.shape, v.dtype)` only if `v` is a `torch.Tensor`, and running `print(k, v)` otherwise.