### PR TITLE
Making tokenizers optional in the building of LLMs

### DIFF
--- a/llmfoundry/command_utils/train.py
+++ b/llmfoundry/command_utils/train.py
@@ -361,6 +361,7 @@ def train(cfg: DictConfig) -> Trainer:
 
     # Build tokenizer
     tokenizer = None
+    tokenizer_name - None
     if train_cfg.tokenizer:
         log.info('Building tokenizer...')
         tokenizer_name = train_cfg.tokenizer['name']

--- a/llmfoundry/command_utils/train.py
+++ b/llmfoundry/command_utils/train.py
@@ -361,7 +361,7 @@ def train(cfg: DictConfig) -> Trainer:
 
     # Build tokenizer
     tokenizer = None
-    tokenizer_name - None
+    tokenizer_name = None
     if train_cfg.tokenizer:
         log.info('Building tokenizer...')
         tokenizer_name = train_cfg.tokenizer['name']

--- a/llmfoundry/command_utils/train.py
+++ b/llmfoundry/command_utils/train.py
@@ -360,10 +360,12 @@ def train(cfg: DictConfig) -> Trainer:
     logged_cfg.update({'tp_config': tp_config}, merge=True)
 
     # Build tokenizer
-    log.info('Building tokenizer...')
-    tokenizer_name = train_cfg.tokenizer['name']
-    tokenizer_kwargs = train_cfg.tokenizer.get('kwargs', {})
-    tokenizer = build_tokenizer(tokenizer_name, tokenizer_kwargs)
+    tokenizer = None
+    if train_cfg.tokenizer:
+        log.info('Building tokenizer...')
+        tokenizer_name = train_cfg.tokenizer['name']
+        tokenizer_kwargs = train_cfg.tokenizer.get('kwargs', {})
+        tokenizer = build_tokenizer(tokenizer_name, tokenizer_kwargs)
 
     # Scheduler
     scheduler_name: str = train_cfg.scheduler.pop('name')

--- a/llmfoundry/data/contrastive_pairs/dataloader.py
+++ b/llmfoundry/data/contrastive_pairs/dataloader.py
@@ -197,7 +197,7 @@ def build_pairs_dataloader(
 ) -> DataSpec:
     if tokenizer is None:
         raise ValueError(
-            'Tokenizer is required for contrastive pairs dataloader'
+            'Tokenizer is required for contrastive pairs dataloader',
         )
 
     dataset_cfg = dataset

--- a/llmfoundry/data/contrastive_pairs/dataloader.py
+++ b/llmfoundry/data/contrastive_pairs/dataloader.py
@@ -185,7 +185,7 @@ class StreamingPairsDataset(StreamingTextDataset):
 
 def build_pairs_dataloader(
     dataset: dict[str, Any],
-    tokenizer: PreTrainedTokenizerBase,
+    tokenizer: Optional[PreTrainedTokenizerBase],
     device_batch_size: int,
     drop_last: bool,
     num_workers: int,
@@ -195,6 +195,9 @@ def build_pairs_dataloader(
     timeout: int = 0,
     max_hard_negatives: Optional[int] = None,
 ) -> DataSpec:
+    if tokenizer is None:
+        raise ValueError('Tokenizer is required for contrastive pairs dataloader')
+
     dataset_cfg = dataset
     streams_dict = dataset.pop('streams', None)
     eos_token_id = dataset.pop('eos_token_id', None)

--- a/llmfoundry/data/contrastive_pairs/dataloader.py
+++ b/llmfoundry/data/contrastive_pairs/dataloader.py
@@ -196,7 +196,9 @@ def build_pairs_dataloader(
     max_hard_negatives: Optional[int] = None,
 ) -> DataSpec:
     if tokenizer is None:
-        raise ValueError('Tokenizer is required for contrastive pairs dataloader')
+        raise ValueError(
+            'Tokenizer is required for contrastive pairs dataloader'
+        )
 
     dataset_cfg = dataset
     streams_dict = dataset.pop('streams', None)

--- a/llmfoundry/data/dataloader.py
+++ b/llmfoundry/data/dataloader.py
@@ -3,7 +3,7 @@
 
 """Dataloader builder utilities."""
 
-from typing import Any, Union
+from typing import Any, Optional, Union
 
 from composer import DataSpec
 from transformers import PreTrainedTokenizerBase
@@ -18,14 +18,14 @@ __all__ = [
 
 def build_dataloader(
     cfg: dict[str, Any],
-    tokenizer: PreTrainedTokenizerBase,
+    tokenizer: Optional[PreTrainedTokenizerBase],
     device_batch_size: Union[int, float],
 ) -> DataSpec:
     """Builds a dataloader from a config.
 
     Args:
         cfg (DictConfig): An omegaconf dictionary used to configure the loader.
-        tokenizer (PreTrainedTokenizerBase): The tokenizer that the model will use.
+        tokenizer (Optional[PreTrainedTokenizerBase]): The tokenizer that the model will use.
         device_batch_size (int): The size of the batches (number of examples)
             that the dataloader will produce.
     """

--- a/llmfoundry/data/finetuning/collator.py
+++ b/llmfoundry/data/finetuning/collator.py
@@ -311,7 +311,6 @@ class Seq2SeqFinetuningCollator:
         else:
             batch = self._process_and_batch_encoder_decoder(examples)
 
-        
         batch_size = batch['input_ids'].shape[0]
         batch.update({
             k: torch.tensor([v] * batch_size)

--- a/llmfoundry/data/finetuning/collator.py
+++ b/llmfoundry/data/finetuning/collator.py
@@ -311,7 +311,7 @@ class Seq2SeqFinetuningCollator:
         else:
             batch = self._process_and_batch_encoder_decoder(examples)
 
-        # Add any batch_metadata
+        
         batch_size = batch['input_ids'].shape[0]
         batch.update({
             k: torch.tensor([v] * batch_size)

--- a/llmfoundry/data/finetuning/dataloader.py
+++ b/llmfoundry/data/finetuning/dataloader.py
@@ -54,7 +54,7 @@ _ALLOWED_DATASET_KEYS = {
 
 
 def build_finetuning_dataloader(
-    tokenizer: PreTrainedTokenizerBase,
+    tokenizer: Optional[PreTrainedTokenizerBase],
     device_batch_size: Union[int, float],
     dataset: dict[str, Any],
     num_workers: int,
@@ -179,6 +179,9 @@ def build_finetuning_dataloader(
         padding/waste rates for different `cfg.dataset.packing_ratio` choices,
         given a starting workload YAML.
     """
+    if tokenizer is None:
+        raise ValueError('Tokenizer is required for finetuning dataloader')
+
     dataset_cfg = dataset
     is_streaming = (
         dataset_cfg.get('remote') is not None or

--- a/llmfoundry/data/text_data.py
+++ b/llmfoundry/data/text_data.py
@@ -301,7 +301,7 @@ def build_streams(streams: Optional[dict[str, Any]] = None,):
 
 
 def build_text_dataloader(
-    tokenizer: PreTrainedTokenizerBase,
+    tokenizer: Optional[PreTrainedTokenizerBase],
     device_batch_size: Union[int, float],
     dataset: dict[str, Any],
     drop_last: bool,
@@ -311,6 +311,8 @@ def build_text_dataloader(
     persistent_workers: bool = True,
     timeout: int = 0,
 ) -> DataSpec:
+    if tokenizer is None:
+        raise ValueError('Tokenizer is required for text dataloader')
 
     dataset_cfg = dataset
 

--- a/llmfoundry/utils/builders.py
+++ b/llmfoundry/utils/builders.py
@@ -58,7 +58,7 @@ def build_evaluators(
     icl_tasks_config: Optional[Union[str, list[dict[str, Any]]]],
     eval_gauntlet_config: Optional[Union[str, dict[str, Any]]],
     *,
-    tokenizer: PreTrainedTokenizerBase,
+    tokenizer: Optional[PreTrainedTokenizerBase],
     device_eval_batch_size: Union[int, float],
     icl_seq_len: int,
     icl_subset_num_batches: Optional[int],
@@ -75,10 +75,13 @@ def build_evaluators(
     logger_keys = []
     eval_gauntlet_callback = None
     if icl_tasks_config is not None:
+        if tokenizer is None:
+            raise ValueError('Tokenizer is required for icl tasks')
         if not isinstance(device_eval_batch_size, int):
             raise ValueError(
                 'device_eval_batch_size should be an int for icl tasks.',
             )
+
         icl_evaluators, logger_keys, eval_gauntlet_callback = build_icl_data_and_gauntlet(
             icl_tasks_config,
             eval_gauntlet_config,
@@ -94,7 +97,7 @@ def build_evaluators(
 
 def build_eval_loaders(
     eval_loader_config: Union[dict[str, Any], list[dict[str, Any]]],
-    tokenizer: PreTrainedTokenizerBase,
+    tokenizer: Optional[PreTrainedTokenizerBase],
     device_eval_batch_size: Union[int, float],
 ) -> list[Evaluator]:
     evaluators: list[Evaluator] = []
@@ -225,7 +228,7 @@ def build_save_planner(name: str, **kwargs: Any) -> SavePlanner:
 def build_composer_model(
     name: str,
     cfg: dict[str, Any],
-    tokenizer: PreTrainedTokenizerBase,
+    tokenizer: Optional[PreTrainedTokenizerBase],
     init_context: Optional[ContextManager] = None,
     master_weights_dtype: Optional[str] = None,
 ) -> ComposerModel:
@@ -234,7 +237,7 @@ def build_composer_model(
     Args:
         name (str): Name of the model to build.
         cfg (DictConfig): Configuration for the model.
-        tokenizer (PreTrainedTokenizerBase): Tokenizer to use.
+        tokenizer (Optional[PreTrainedTokenizerBase]): Tokenizer to use.
         init_context (Optional[ContextManager], optional): Context manager to use for initialization. Defaults to None.
         master_weights_dtype (Optional[str], optional): Master weights dtype. Defaults to None.
 

--- a/llmfoundry/utils/mosaicml_logger_utils.py
+++ b/llmfoundry/utils/mosaicml_logger_utils.py
@@ -87,7 +87,7 @@ def log_train_analytics(
     train_loader_config: dict[str, Any],
     eval_loader_config: Optional[Union[dict[str, Any], list[dict[str, Any]]]],
     callback_configs: Optional[dict[str, Any]],
-    tokenizer_name: str,
+    tokenizer_name: Optional[str],
     load_path: Optional[str],
     icl_tasks_config: Optional[Union[list[dict[str, Any]], str]],
     eval_gauntlet: Optional[Union[dict[str, Any], str]],
@@ -95,10 +95,12 @@ def log_train_analytics(
     """Logs analytics for runs using the `train.py` script."""
     train_loader_dataset = train_loader_config.get('dataset', {})
     metrics: dict[str, Any] = {
-        'llmfoundry/tokenizer_name': tokenizer_name,
         'llmfoundry/script': 'train',
         'llmfoundry/train_loader_name': train_loader_config.get('name'),
     }
+
+    if tokenizer_name is not None:
+        metrics['llmfoundry/tokenizer_name'] = tokenizer_name
 
     if callback_configs is not None:
         metrics['llmfoundry/callbacks'] = [

--- a/tests/data/test_dataloader.py
+++ b/tests/data/test_dataloader.py
@@ -25,7 +25,11 @@ from streaming.base.util import clean_stale_shared_memory
 from llmfoundry.command_utils import convert_dataset_hf
 from llmfoundry.command_utils.data_prep.convert_finetuning_dataset import \
     get_columns_and_format
-from llmfoundry.data import build_dataloader, build_finetuning_dataloader
+from llmfoundry.data import (
+    build_pairs_dataloader,
+    build_dataloader,
+    build_finetuning_dataloader,
+)
 from llmfoundry.data.finetuning.collator import (
     validate_target_settings,
 )
@@ -1593,3 +1597,18 @@ def test_text_dataloader_with_extra_keys():
                 tokenizer=tokenizer,
                 device_batch_size=device_batch_size,
             ).dataloader
+
+
+@pytest.mark.parametrize(
+        'build_fn',
+        [build_finetuning_dataloader, build_text_dataloader, build_pairs_dataloader]) 
+def test_tokenizer_none(build_fn: Callable):
+    params = {
+        "device_batch_size": 2,
+        "dataset": {},
+        "num_workers": 0,
+        "drop_last": False,
+    }
+
+    with pytest.raises(ValueError, match='Tokenizer is required'):
+        _ = build_fn(**params)

--- a/tests/data/test_dataloader.py
+++ b/tests/data/test_dataloader.py
@@ -1611,4 +1611,4 @@ def test_tokenizer_none(build_fn: Callable):
     }
 
     with pytest.raises(ValueError, match='Tokenizer is required'):
-        _ = build_fn(**params)
+        _ = build_fn(tokenizer=None, **params)

--- a/tests/data/test_dataloader.py
+++ b/tests/data/test_dataloader.py
@@ -26,9 +26,9 @@ from llmfoundry.command_utils import convert_dataset_hf
 from llmfoundry.command_utils.data_prep.convert_finetuning_dataset import \
     get_columns_and_format
 from llmfoundry.data import (
-    build_pairs_dataloader,
     build_dataloader,
     build_finetuning_dataloader,
+    build_pairs_dataloader,
 )
 from llmfoundry.data.finetuning.collator import (
     validate_target_settings,
@@ -1601,13 +1601,13 @@ def test_text_dataloader_with_extra_keys():
 
 @pytest.mark.parametrize(
         'build_fn',
-        [build_finetuning_dataloader, build_text_dataloader, build_pairs_dataloader]) 
+        [build_finetuning_dataloader, build_text_dataloader, build_pairs_dataloader])
 def test_tokenizer_none(build_fn: Callable):
     params = {
-        "device_batch_size": 2,
-        "dataset": {},
-        "num_workers": 0,
-        "drop_last": False,
+        'device_batch_size': 2,
+        'dataset': {},
+        'num_workers': 0,
+        'drop_last': False,
     }
 
     with pytest.raises(ValueError, match='Tokenizer is required'):

--- a/tests/eval/test_in_context_learning_datasets.py
+++ b/tests/eval/test_in_context_learning_datasets.py
@@ -2642,6 +2642,11 @@ def test_bc_question_prelimiter(
 def test_icl_no_tokenizer():
     with pytest.raises(ValueError, match='Tokenizer is required for icl tasks'):
         _ = build_evaluators(
+            eval_loader_config=None,
             icl_tasks_config=[],
+            eval_gauntlet_config=None,
             tokenizer=None,
+            device_eval_batch_size=2,
+            icl_seq_len=128,
+            icl_subset_num_batches=2
         )

--- a/tests/eval/test_in_context_learning_datasets.py
+++ b/tests/eval/test_in_context_learning_datasets.py
@@ -37,7 +37,7 @@ from llmfoundry.eval.metrics import (
     InContextLearningLMAccuracy,
     InContextLearningMultipleChoiceAccuracy,
 )
-from llmfoundry.utils.builders import build_icl_evaluators
+from llmfoundry.utils.builders import build_evaluators, build_icl_evaluators
 
 
 def test_strip_data():
@@ -2637,3 +2637,11 @@ def test_bc_question_prelimiter(
     assert len(evaluators) == 1
     evaluator = evaluators[0]
     assert evaluator.dataloader.dataloader.dataset.prelimiter == 'This is a question: '  # type: ignore
+
+
+def test_icl_no_tokenizer():
+    with pytest.raises(ValueError, match='Tokenizer is required for icl tasks'):
+        _ = build_evaluators(
+            icl_tasks_config=[],
+            tokenizer=None,
+        )

--- a/tests/eval/test_in_context_learning_datasets.py
+++ b/tests/eval/test_in_context_learning_datasets.py
@@ -2648,5 +2648,5 @@ def test_icl_no_tokenizer():
             tokenizer=None,
             device_eval_batch_size=2,
             icl_seq_len=128,
-            icl_subset_num_batches=2
+            icl_subset_num_batches=2,
         )


### PR DESCRIPTION
This PR makes it optional to have tokenizers when constructing LLMs, however respective parts that still require tokenizers will error out if it is not provided