### PR TITLE
Load model only on global rank 0 for mixed init

### DIFF
--- a/llmfoundry/models/hf/hf_base.py
+++ b/llmfoundry/models/hf/hf_base.py
@@ -428,7 +428,7 @@ class BaseHuggingFaceModel(HuggingFaceModel):
             download_thread.join(timeout=3600)
             log.debug('Download thread joined')
 
-        # Broadcast any
+        # Gather information about which ranks errored
         gathered_errors = dist.all_gather_object(error)
         ranks_with_error = [
             rank for rank, err in enumerate(gathered_errors) if err is not None

--- a/llmfoundry/models/hf/hf_base.py
+++ b/llmfoundry/models/hf/hf_base.py
@@ -406,9 +406,11 @@ class BaseHuggingFaceModel(HuggingFaceModel):
         download_thread.join(timeout=3600)
         log.debug('Download thread joined')
 
-        error = dist.broadcast_object_list([error], src=0)[0]
-        if error:
-            raise error
+        error_for_broadcast = [error]
+        dist.broadcast_object_list(error_for_broadcast, src=0)
+        error_to_maybe_raise = error_for_broadcast[0]
+        if error_to_maybe_raise:
+            raise error_to_maybe_raise
 
         # Use the pretrained generation config for the model if it exists.
         try:

--- a/llmfoundry/models/hf/hf_base.py
+++ b/llmfoundry/models/hf/hf_base.py
@@ -357,7 +357,9 @@ class BaseHuggingFaceModel(HuggingFaceModel):
         # Create a thread to busy wait for download to be complete
         download_thread = threading.Thread(
             target=download_thread_target,
+            daemon=True,
         )
+        log.debug('Starting download thread')
         download_thread.start()
 
         # initialize the model on the correct device
@@ -394,7 +396,9 @@ class BaseHuggingFaceModel(HuggingFaceModel):
             )
 
         rank0_done_global = True
+        log.debug('Joining download thread')
         download_thread.join(timeout=3600)
+        log.debug('Download thread joined')
 
         # Use the pretrained generation config for the model if it exists.
         try:

--- a/llmfoundry/models/hf/hf_base.py
+++ b/llmfoundry/models/hf/hf_base.py
@@ -367,6 +367,7 @@ class BaseHuggingFaceModel(HuggingFaceModel):
             # initialize the model on the correct device
             if resolved_init_device == 'cpu':
                 if pretrained:
+                    raise ValueError('hi')
                     model = auto_model_cls.from_pretrained(
                         pretrained_model_name_or_path,
                         trust_remote_code=trust_remote_code,
@@ -375,7 +376,6 @@ class BaseHuggingFaceModel(HuggingFaceModel):
                         attn_implementation=requested_attention_implementation,
                         config=config,
                     )
-                    raise ValueError('hi')
                 else:
                     model = auto_model_cls.from_config(  # type: ignore
                         config,

--- a/llmfoundry/models/hf/hf_base.py
+++ b/llmfoundry/models/hf/hf_base.py
@@ -384,6 +384,7 @@ class BaseHuggingFaceModel(HuggingFaceModel):
             # initialize the model on the correct device
             if resolved_init_device == 'cpu':
                 if pretrained:
+                    raise ValueError('hi')
                     model = auto_model_cls.from_pretrained(
                         pretrained_model_name_or_path,
                         trust_remote_code=trust_remote_code,

--- a/llmfoundry/models/hf/hf_base.py
+++ b/llmfoundry/models/hf/hf_base.py
@@ -340,11 +340,10 @@ class BaseHuggingFaceModel(HuggingFaceModel):
 
             device = get_device(None)
             
-            done_tensor = torch.tensor(
+            done_tensor = device.tensor_to_device(torch.tensor(
                 [rank0_done_global],
                 dtype=torch.int,
-                device=device,
-            )
+            ))
 
             dist.broadcast(done_tensor, src=0)
             all_done = done_tensor.item()

--- a/llmfoundry/models/hf/hf_base.py
+++ b/llmfoundry/models/hf/hf_base.py
@@ -375,6 +375,7 @@ class BaseHuggingFaceModel(HuggingFaceModel):
                         attn_implementation=requested_attention_implementation,
                         config=config,
                     )
+                    raise ValueError('hi')
                 else:
                     model = auto_model_cls.from_config(  # type: ignore
                         config,

--- a/llmfoundry/models/hf/hf_base.py
+++ b/llmfoundry/models/hf/hf_base.py
@@ -411,7 +411,7 @@ class BaseHuggingFaceModel(HuggingFaceModel):
                     )
             else:
                 raise ValueError(
-                    f'init_device="{init_device}" must be either "cpu" or "meta".',
+                    f'Got {init_device=} which resolved to unknown device {resolved_init_device=} on global rank {dist.get_global_rank()}.',
                 )
         except Exception as e:
             error = e

--- a/llmfoundry/models/hf/hf_base.py
+++ b/llmfoundry/models/hf/hf_base.py
@@ -367,7 +367,6 @@ class BaseHuggingFaceModel(HuggingFaceModel):
             # initialize the model on the correct device
             if resolved_init_device == 'cpu':
                 if pretrained:
-                    raise ValueError('hi')
                     model = auto_model_cls.from_pretrained(
                         pretrained_model_name_or_path,
                         trust_remote_code=trust_remote_code,

--- a/llmfoundry/models/hf/hf_base.py
+++ b/llmfoundry/models/hf/hf_base.py
@@ -407,6 +407,7 @@ class BaseHuggingFaceModel(HuggingFaceModel):
         log.debug('Download thread joined')
 
         if error:
+            error = dist.broadcast_object_list([error], src=0)[0]
             raise error
 
         # Use the pretrained generation config for the model if it exists.

--- a/llmfoundry/models/hf/hf_base.py
+++ b/llmfoundry/models/hf/hf_base.py
@@ -339,11 +339,13 @@ class BaseHuggingFaceModel(HuggingFaceModel):
             nonlocal rank0_done_global
 
             device = get_device(None)
-            
-            done_tensor = device.tensor_to_device(torch.tensor(
-                [rank0_done_global],
-                dtype=torch.int,
-            ))
+
+            done_tensor = device.tensor_to_device(
+                torch.tensor(
+                    [rank0_done_global],
+                    dtype=torch.int,
+                ),
+            )
 
             dist.broadcast(done_tensor, src=0)
             all_done = done_tensor.item()
@@ -362,6 +364,7 @@ class BaseHuggingFaceModel(HuggingFaceModel):
         log.debug('Starting download thread')
         download_thread.start()
 
+        model = None
         error = None
         try:
             # initialize the model on the correct device
@@ -411,6 +414,7 @@ class BaseHuggingFaceModel(HuggingFaceModel):
         if error_to_maybe_raise:
             raise error_to_maybe_raise
 
+        assert model is not None
         # Use the pretrained generation config for the model if it exists.
         try:
             model.generation_config = GenerationConfig.from_pretrained(

--- a/llmfoundry/models/hf/hf_base.py
+++ b/llmfoundry/models/hf/hf_base.py
@@ -384,7 +384,6 @@ class BaseHuggingFaceModel(HuggingFaceModel):
             # initialize the model on the correct device
             if resolved_init_device == 'cpu':
                 if pretrained:
-                    raise ValueError('hi')
                     model = auto_model_cls.from_pretrained(
                         pretrained_model_name_or_path,
                         trust_remote_code=trust_remote_code,

--- a/llmfoundry/models/hf/hf_base.py
+++ b/llmfoundry/models/hf/hf_base.py
@@ -406,8 +406,8 @@ class BaseHuggingFaceModel(HuggingFaceModel):
         download_thread.join(timeout=3600)
         log.debug('Download thread joined')
 
+        error = dist.broadcast_object_list([error], src=0)[0]
         if error:
-            error = dist.broadcast_object_list([error], src=0)[0]
             raise error
 
         # Use the pretrained generation config for the model if it exists.

--- a/llmfoundry/models/hf/hf_fsdp.py
+++ b/llmfoundry/models/hf/hf_fsdp.py
@@ -119,7 +119,7 @@ def hf_get_init_device(init_device: Optional[str]) -> Optional[str]:
     """Returns the appropriate device to initialize models."""
     from composer.utils import dist
     if init_device == 'mixed':
-        if dist.get_local_rank() == 0:
+        if dist.get_global_rank() == 0:
             return 'cpu'
         return 'meta'
     return init_device

--- a/tests/models/hf/test_hf_base.py
+++ b/tests/models/hf/test_hf_base.py
@@ -73,7 +73,7 @@ def test_build_inner_model_download_thread(
     error_context = contextlib.nullcontext(
     ) if error_rank is None else pytest.raises(
         RuntimeError,
-        match=f'Error initializing model on ranks {error_rank}. See individual rank logs for more details',
+        match=f'Error initializing model on ranks [{error_rank}]. See individual rank logs for more details',
     )
 
     with patch(

--- a/tests/models/hf/test_hf_base.py
+++ b/tests/models/hf/test_hf_base.py
@@ -74,7 +74,7 @@ def test_build_inner_model_download_thread(
     ) if error_rank is None else pytest.raises(
         RuntimeError,
         match=
-        f'Error initializing model on ranks \[{error_rank}\]. See individual rank logs for more details',
+        rf'Error initializing model on ranks \[{error_rank}\]. See individual rank logs for more details',
     )
 
     with patch(

--- a/tests/models/hf/test_hf_base.py
+++ b/tests/models/hf/test_hf_base.py
@@ -71,8 +71,9 @@ def test_build_inner_model_download_thread(
         return tiny_gpt2_model
 
     error_context = contextlib.nullcontext(
-    ) if error_rank is not None else pytest.raises(
-        RuntimeError, match=f'Error initializing model on ranks {error_rank}'
+    ) if error_rank is None else pytest.raises(
+        RuntimeError,
+        match=f'Error initializing model on ranks {error_rank}',
     )
 
     with patch(

--- a/tests/models/hf/test_hf_base.py
+++ b/tests/models/hf/test_hf_base.py
@@ -74,7 +74,7 @@ def test_build_inner_model_download_thread(
     ) if error_rank is None else pytest.raises(
         RuntimeError,
         match=
-        f'Error initializing model on ranks [{error_rank}]. See individual rank logs for more details',
+        f'Error initializing model on ranks \[{error_rank}\]. See individual rank logs for more details',
     )
 
     with patch(

--- a/tests/models/hf/test_hf_base.py
+++ b/tests/models/hf/test_hf_base.py
@@ -73,7 +73,8 @@ def test_build_inner_model_download_thread(
     error_context = contextlib.nullcontext(
     ) if error_rank is None else pytest.raises(
         RuntimeError,
-        match=f'Error initializing model on ranks [{error_rank}]. See individual rank logs for more details',
+        match=
+        f'Error initializing model on ranks [{error_rank}]. See individual rank logs for more details',
     )
 
     with patch(

--- a/tests/models/hf/test_hf_base.py
+++ b/tests/models/hf/test_hf_base.py
@@ -76,7 +76,7 @@ def test_build_inner_model_download_thread(
 
     with patch(
         'llmfoundry.models.hf.hf_base.AutoModelForCausalLM.from_pretrained',
-        mock_build_func
+        mock_build_func,
     ):
         with error_context:
             _ = BaseHuggingFaceModel.build_inner_model(

--- a/tests/models/hf/test_hf_base.py
+++ b/tests/models/hf/test_hf_base.py
@@ -73,7 +73,7 @@ def test_build_inner_model_download_thread(
     error_context = contextlib.nullcontext(
     ) if error_rank is None else pytest.raises(
         RuntimeError,
-        match=f'Error initializing model on ranks {error_rank}',
+        match=f'Error initializing model on ranks {error_rank}. See individual rank logs for more details',
     )
 
     with patch(


### PR DESCRIPTION
Since `sync_module_states` syncs from global rank 0, we only actually need to download the model from HF on global rank 0, even though we were doing it on all local rank 0 just cause the code is a bit simpler that way. This adds a thread based synchronization so that we can download only on global rank 0 without needing to increase the dist timeout dramatically.

Manual testing:
- Big model loads: `405b-after-23-bp8HYb`
- Smaller model with multinode before and after:
before: `small-before-4-hxnlMv`, after: `small-after-12-UOTZcG`
<img width="518" alt="Screenshot 2025-04-21 at 1 54 45 PM" src="https://github.com/user-attachments/assets/14a94eee-79f7-4080-a14d-d4196a96f075" />

