### PR TITLE
Update grouped-gemm version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ extra_deps['openai'] = [
 
 extra_deps['megablocks'] = [
     'megablocks<1.0',
-    'grouped-gemm==0.1.6',
+    'grouped-gemm-db==0.2.0',
 ]
 
 extra_deps['te'] = [

--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ extra_deps['openai'] = [
 
 extra_deps['megablocks'] = [
     'megablocks<1.0',
-    'grouped-gemm-db==0.3.0',
+    'grouped-gemm==0.2.0',
 ]
 
 extra_deps['te'] = [

--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ extra_deps['openai'] = [
 
 extra_deps['megablocks'] = [
     'megablocks<1.0',
-    'grouped-gemm-db==0.2.0',
+    'grouped-gemm-db==0.3.0',
 ]
 
 extra_deps['te'] = [


### PR DESCRIPTION
Previous versions of grouped-gemm had too loose of a torch pin, so grouped-gemm install is now failing if not on torch 2.7. This updates to a version with a tighter pin, since we are still on 2.6.