### PR TITLE
Allow subselecting the appropriate config for llama4

### DIFF
--- a/llmfoundry/models/hf/hf_base.py
+++ b/llmfoundry/models/hf/hf_base.py
@@ -185,7 +185,7 @@ class BaseHuggingFaceModel(HuggingFaceModel):
         transformers_version = transformers.__version__
         from packaging.version import parse
         transformers_version_is_dev = parse(transformers_version).is_devrelease
-        if not transformers_version_is_dev and cls.use_text_config and hasattr(config, 'text_config') and transformers_version_is_dev:
+        if cls.use_text_config and hasattr(config, 'text_config') and transformers_version_is_dev:
             config = config.text_config
 
         config.text_config.use_cache = False

--- a/llmfoundry/models/hf/hf_base.py
+++ b/llmfoundry/models/hf/hf_base.py
@@ -56,6 +56,16 @@ class BaseHuggingFaceModel(HuggingFaceModel):
     """Wrapper around HuggingFaceModel.
 
     Base class for HuggingFace based models.
+
+    Attributes:
+        model_cls (type): The model class to use. Default: ``AutoModelForCausalLM``.
+        subselect_config_attr (str): The attribute to use to subselect the config.
+            This is used if you want to select only using the text_config or vision_config
+            for a multimodal model. For example, AutoConfig.from_pretrained on Llama4 produces
+            a Llama4Config, and to use as a causal LM, we need to get the Llama4TextConfig.
+            Default: ``None``, which will use whatever AutoConfig produces.
+        default_train_metrics (tuple): The default training metrics to use.
+        default_eval_metrics (tuple): The default evaluation metrics to use.
     """
 
     model_cls: Union[type[_BaseAutoModelClass],
@@ -339,7 +349,6 @@ class BaseHuggingFaceModel(HuggingFaceModel):
             attn_implementation=attn_implementation,
             config_overrides=config_overrides,
         )
-        print(config)
 
         # We need to have all non-zero local ranks be not-pretrained
         # Rank 0 will still be pretrained, and distribute the weights appropriately
@@ -508,7 +517,6 @@ class BaseHuggingFaceModel(HuggingFaceModel):
         if prepare_for_fsdp:
             cls.prepare_inner_model(model, init_device)
 
-        print(model)
         return model
 
     def get_peft_config(self, peft_config_dict: dict[str, Any]) -> 'PeftConfig':

--- a/llmfoundry/models/hf/hf_base.py
+++ b/llmfoundry/models/hf/hf_base.py
@@ -182,7 +182,10 @@ class BaseHuggingFaceModel(HuggingFaceModel):
             False,  # Necessary due to https://github.com/huggingface/transformers/issues/28056
         )
 
-        if cls.use_text_config and hasattr(config, 'text_config'):
+        transformers_version = transformers.__version__
+        from packaging.version import parse
+        transformers_version_is_dev = parse(transformers_version).is_devrelease
+        if not transformers_version_is_dev and cls.use_text_config and hasattr(config, 'text_config') and transformers_version_is_dev:
             config = config.text_config
 
         set_config_overrides(config, config_overrides)

--- a/llmfoundry/models/hf/hf_base.py
+++ b/llmfoundry/models/hf/hf_base.py
@@ -194,20 +194,17 @@ class BaseHuggingFaceModel(HuggingFaceModel):
             use_cache=use_cache,
         )
 
-        if cls.subselect_config_attr is not None and hasattr(
-            config,
-            cls.subselect_config_attr,
-        ):
+        if cls.subselect_config_attr is not None:
+            if not hasattr(config, cls.subselect_config_attr):
+                raise ValueError(
+                    f'Config {cls.subselect_config_attr} not found in {config}.',
+                )
             config = getattr(config, cls.subselect_config_attr)
 
             # Forward the above overrides to the subselected config too
             config.use_cache = use_cache
             config.attn_implementation = attn_implementation
             config.torch_dtype = _MASTER_WEIGHTS_PRECISION
-        elif cls.subselect_config_attr is not None:
-            raise ValueError(
-                f'Config {cls.subselect_config_attr} not found in {config}.',
-            )
 
         set_config_overrides(config, config_overrides)
 

--- a/llmfoundry/models/hf/hf_base.py
+++ b/llmfoundry/models/hf/hf_base.py
@@ -188,9 +188,9 @@ class BaseHuggingFaceModel(HuggingFaceModel):
         if cls.use_text_config and hasattr(config, 'text_config') and transformers_version_is_dev:
             config = config.text_config
 
-        config.text_config.use_cache = False
-        config.text_config.attn_implementation = attn_implementation
-        config.text_config.torch_dtype = _MASTER_WEIGHTS_PRECISION
+        config.use_cache = False
+        config.attn_implementation = attn_implementation
+        config.torch_dtype = _MASTER_WEIGHTS_PRECISION
         set_config_overrides(config, config_overrides)
 
         return config

--- a/llmfoundry/models/hf/hf_base.py
+++ b/llmfoundry/models/hf/hf_base.py
@@ -183,7 +183,8 @@ class BaseHuggingFaceModel(HuggingFaceModel):
         )
 
         if cls.subselect_config_attr is not None and hasattr(
-            config, cls.subselect_config_attr
+            config,
+            cls.subselect_config_attr,
         ):
             config = getattr(config, cls.subselect_config_attr)
 

--- a/llmfoundry/models/hf/hf_base.py
+++ b/llmfoundry/models/hf/hf_base.py
@@ -60,6 +60,7 @@ class BaseHuggingFaceModel(HuggingFaceModel):
 
     model_cls: Union[type[_BaseAutoModelClass],
                      type[PreTrainedModel]] = AutoModelForCausalLM
+    use_text_config: bool = False
     default_train_metrics: tuple = ()
     default_eval_metrics: tuple = ()
 
@@ -180,6 +181,9 @@ class BaseHuggingFaceModel(HuggingFaceModel):
             use_cache=
             False,  # Necessary due to https://github.com/huggingface/transformers/issues/28056
         )
+
+        if cls.use_text_config and hasattr(config, 'text_config'):
+            config = config.text_config
 
         set_config_overrides(config, config_overrides)
 

--- a/llmfoundry/models/hf/hf_base.py
+++ b/llmfoundry/models/hf/hf_base.py
@@ -331,6 +331,7 @@ class BaseHuggingFaceModel(HuggingFaceModel):
             attn_implementation=attn_implementation,
             config_overrides=config_overrides,
         )
+        print(config)
 
         # We need to have all non-zero local ranks be not-pretrained
         # Rank 0 will still be pretrained, and distribute the weights appropriately
@@ -499,6 +500,7 @@ class BaseHuggingFaceModel(HuggingFaceModel):
         if prepare_for_fsdp:
             cls.prepare_inner_model(model, init_device)
 
+        print(model)
         return model
 
     def get_peft_config(self, peft_config_dict: dict[str, Any]) -> 'PeftConfig':

--- a/llmfoundry/models/hf/hf_base.py
+++ b/llmfoundry/models/hf/hf_base.py
@@ -181,6 +181,7 @@ class BaseHuggingFaceModel(HuggingFaceModel):
             use_cache=
             False,  # Necessary due to https://github.com/huggingface/transformers/issues/28056
         )
+        print(config)
 
         if cls.use_text_config and hasattr(config, 'text_config'):
             config = config.text_config
@@ -189,6 +190,8 @@ class BaseHuggingFaceModel(HuggingFaceModel):
             config.use_cache = False
             config.attn_implementation = attn_implementation
             config.torch_dtype = _MASTER_WEIGHTS_PRECISION
+
+        print(config)
 
         set_config_overrides(config, config_overrides)
 

--- a/llmfoundry/models/hf/hf_base.py
+++ b/llmfoundry/models/hf/hf_base.py
@@ -60,7 +60,7 @@ class BaseHuggingFaceModel(HuggingFaceModel):
 
     model_cls: Union[type[_BaseAutoModelClass],
                      type[PreTrainedModel]] = AutoModelForCausalLM
-    use_text_config: bool = False
+    subselect_config_attr: Optional[str] = None
     default_train_metrics: tuple = ()
     default_eval_metrics: tuple = ()
 
@@ -181,7 +181,6 @@ class BaseHuggingFaceModel(HuggingFaceModel):
             use_cache=
             False,  # Necessary due to https://github.com/huggingface/transformers/issues/28056
         )
-        print(config)
 
         if cls.use_text_config and hasattr(config, 'text_config'):
             config = config.text_config
@@ -190,8 +189,6 @@ class BaseHuggingFaceModel(HuggingFaceModel):
             config.use_cache = False
             config.attn_implementation = attn_implementation
             config.torch_dtype = _MASTER_WEIGHTS_PRECISION
-
-        print(config)
 
         set_config_overrides(config, config_overrides)
 

--- a/llmfoundry/models/hf/hf_base.py
+++ b/llmfoundry/models/hf/hf_base.py
@@ -182,15 +182,14 @@ class BaseHuggingFaceModel(HuggingFaceModel):
             False,  # Necessary due to https://github.com/huggingface/transformers/issues/28056
         )
 
-        transformers_version = transformers.__version__
-        from packaging.version import parse
-        transformers_version_is_dev = parse(transformers_version).is_devrelease
-        if cls.use_text_config and hasattr(config, 'text_config') and transformers_version_is_dev:
+        if cls.use_text_config and hasattr(config, 'text_config'):
             config = config.text_config
 
-        config.use_cache = False
-        config.attn_implementation = attn_implementation
-        config.torch_dtype = _MASTER_WEIGHTS_PRECISION
+            # Forward the above overrides to the text config too
+            config.use_cache = False
+            config.attn_implementation = attn_implementation
+            config.torch_dtype = _MASTER_WEIGHTS_PRECISION
+
         set_config_overrides(config, config_overrides)
 
         return config

--- a/llmfoundry/models/hf/hf_base.py
+++ b/llmfoundry/models/hf/hf_base.py
@@ -188,6 +188,9 @@ class BaseHuggingFaceModel(HuggingFaceModel):
         if not transformers_version_is_dev and cls.use_text_config and hasattr(config, 'text_config') and transformers_version_is_dev:
             config = config.text_config
 
+        config.text_config.use_cache = False
+        config.text_config.attn_implementation = attn_implementation
+        config.text_config.torch_dtype = _MASTER_WEIGHTS_PRECISION
         set_config_overrides(config, config_overrides)
 
         return config

--- a/llmfoundry/models/hf/hf_base.py
+++ b/llmfoundry/models/hf/hf_base.py
@@ -182,10 +182,12 @@ class BaseHuggingFaceModel(HuggingFaceModel):
             False,  # Necessary due to https://github.com/huggingface/transformers/issues/28056
         )
 
-        if cls.use_text_config and hasattr(config, 'text_config'):
-            config = config.text_config
+        if cls.subselect_config_attr is not None and hasattr(
+            config, cls.subselect_config_attr
+        ):
+            config = getattr(config, cls.subselect_config_attr)
 
-            # Forward the above overrides to the text config too
+            # Forward the above overrides to the subselected config too
             config.use_cache = False
             config.attn_implementation = attn_implementation
             config.torch_dtype = _MASTER_WEIGHTS_PRECISION

--- a/llmfoundry/models/hf/hf_base.py
+++ b/llmfoundry/models/hf/hf_base.py
@@ -194,7 +194,10 @@ class BaseHuggingFaceModel(HuggingFaceModel):
             use_cache=use_cache,
         )
 
-        if cls.subselect_config_attr is not None:
+        if cls.subselect_config_attr is not None and hasattr(
+            config,
+            cls.subselect_config_attr,
+        ):
             config = getattr(config, cls.subselect_config_attr)
 
             # Forward the above overrides to the subselected config too

--- a/llmfoundry/models/hf/hf_base.py
+++ b/llmfoundry/models/hf/hf_base.py
@@ -195,10 +195,6 @@ class BaseHuggingFaceModel(HuggingFaceModel):
         )
 
         if cls.subselect_config_attr is not None:
-            if not hasattr(config, cls.subselect_config_attr):
-                raise ValueError(
-                    f'Config {cls.subselect_config_attr} not found in {config}.',
-                )
             config = getattr(config, cls.subselect_config_attr)
 
             # Forward the above overrides to the subselected config too

--- a/llmfoundry/models/hf/hf_causal_lm.py
+++ b/llmfoundry/models/hf/hf_causal_lm.py
@@ -59,11 +59,12 @@ class ComposerHFCausalLM(BaseHuggingFaceModel):
             Default: ``None``.
     """
 
+    model_cls: Union[type[_BaseAutoModelClass],
+                     type[PreTrainedModel]] = AutoModelForCausalLM
+
     # The text_config attr should be correct for most multimodal models, although
     # there is not an official standard for this and this may need to be updated in future
     # transformers versions.
-    model_cls: Union[type[_BaseAutoModelClass],
-                     type[PreTrainedModel]] = AutoModelForCausalLM
     subselect_config_attr: Optional[str] = 'text_config'
     default_train_metrics: tuple = tuple(DEFAULT_CAUSAL_LM_TRAIN_METRICS)
     default_eval_metrics: tuple = tuple(DEFAULT_CAUSAL_LM_EVAL_METRICS)

--- a/llmfoundry/models/hf/hf_causal_lm.py
+++ b/llmfoundry/models/hf/hf_causal_lm.py
@@ -61,6 +61,7 @@ class ComposerHFCausalLM(BaseHuggingFaceModel):
 
     model_cls: Union[type[_BaseAutoModelClass],
                      type[PreTrainedModel]] = AutoModelForCausalLM
+    use_text_config: bool = True
     default_train_metrics: tuple = tuple(DEFAULT_CAUSAL_LM_TRAIN_METRICS)
     default_eval_metrics: tuple = tuple(DEFAULT_CAUSAL_LM_EVAL_METRICS)
 

--- a/llmfoundry/models/hf/hf_causal_lm.py
+++ b/llmfoundry/models/hf/hf_causal_lm.py
@@ -59,6 +59,9 @@ class ComposerHFCausalLM(BaseHuggingFaceModel):
             Default: ``None``.
     """
 
+    # The text_config attr should be correct for most multimodal models, although
+    # there is not an official standard for this and this may need to be updated in future
+    # transformers versions.
     model_cls: Union[type[_BaseAutoModelClass],
                      type[PreTrainedModel]] = AutoModelForCausalLM
     subselect_config_attr: Optional[str] = 'text_config'

--- a/llmfoundry/models/hf/hf_causal_lm.py
+++ b/llmfoundry/models/hf/hf_causal_lm.py
@@ -61,7 +61,7 @@ class ComposerHFCausalLM(BaseHuggingFaceModel):
 
     model_cls: Union[type[_BaseAutoModelClass],
                      type[PreTrainedModel]] = AutoModelForCausalLM
-    use_text_config: bool = True
+    subselect_config_attr: Optional[str] = 'text_config'
     default_train_metrics: tuple = tuple(DEFAULT_CAUSAL_LM_TRAIN_METRICS)
     default_eval_metrics: tuple = tuple(DEFAULT_CAUSAL_LM_EVAL_METRICS)
 

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ install_requires = [
     'onnx==1.17.0',
     'onnxruntime==1.19.2',
     'boto3>=1.21.45,<2',
-    'huggingface-hub>=0.19.0,<0.31',
+    'huggingface-hub[hf_xet]>=0.30.0,<0.31',
     'beautifulsoup4>=4.12.2,<5',  # required for model download utils
     'tenacity>=8.2.3,<10',
     'catalogue>=2,<3',

--- a/tests/fixtures/models.py
+++ b/tests/fixtures/models.py
@@ -167,6 +167,93 @@ def tiny_codellama_config_helper(tie_word_embeddings: bool = False):
     return config_object
 
 
+def tiny_llama4_config_helper():
+    pytest.importorskip('transformers')
+    from transformers.models.llama4.configuration_llama4 import Llama4Config
+
+    config_dict = {
+        'architectures': ['Llama4ForConditionalGeneration',],
+        'boi_token_index': 200080,
+        'eoi_token_index': 200081,
+        'image_token_index': 200092,
+        'model_type': 'llama4',
+        'text_config': {
+            '_attn_implementation_autoset': True,
+            'attention_bias': False,
+            'attention_chunk_size': 8192,
+            'attention_dropout': 0.0,
+            'bos_token_id': 200000,
+            'eos_token_id': [
+                200001,
+                200007,
+                200008,
+            ],
+            'for_llm_compressor': False,
+            'head_dim': 128,
+            'hidden_act': 'silu',
+            'hidden_size': 5120,
+            'initializer_range': 0.02,
+            'interleave_moe_layer_step': 1,
+            'intermediate_size': 8192,
+            'intermediate_size_mlp': 16384,
+            'max_position_embeddings': 10485760,
+            'model_type': 'llama4_text',
+            'no_rope_layers': [],
+            'num_attention_heads': 40,
+            'num_experts_per_tok': 1,
+            'num_hidden_layers': 48,
+            'num_key_value_heads': 8,
+            'num_local_experts': 16,
+            'output_router_logits': False,
+            'pad_token_id': 200018,
+            'rms_norm_eps': 1e-05,
+            'rope_scaling': {
+                'factor': 16.0,
+                'high_freq_factor': 1.0,
+                'low_freq_factor': 1.0,
+                'original_max_position_embeddings': 8192,
+                'rope_type': 'llama3',
+            },
+            'rope_theta': 500000.0,
+            'router_aux_loss_coef': 0.001,
+            'router_jitter_noise': 0.0,
+            'torch_dtype': 'bfloat16',
+            'use_cache': True,
+            'use_qk_norm': True,
+            'vocab_size': 202048,
+        },
+        'torch_dtype': 'bfloat16',
+        'transformers_version': '4.51.0.dev0',
+        'vision_config': {
+            '_attn_implementation_autoset': True,
+            'attention_dropout': 0.0,
+            'hidden_act': 'gelu',
+            'hidden_size': 1408,
+            'image_size': 336,
+            'initializer_range': 0.02,
+            'intermediate_size': 5632,
+            'model_type': 'llama4_vision_model',
+            'multi_modal_projector_bias': False,
+            'norm_eps': 1e-05,
+            'num_attention_heads': 16,
+            'num_channels': 3,
+            'num_hidden_layers': 34,
+            'patch_size': 14,
+            'pixel_shuffle_ratio': 0.5,
+            'projector_dropout': 0.0,
+            'projector_input_dim': 4096,
+            'projector_output_dim': 4096,
+            'rope_theta': 10000,
+            'vision_feature_layer': -1,
+            'vision_feature_select_strategy': 'default',
+            'vision_output_dim': 4096,
+        },
+    }
+
+    config_object = Llama4Config(**config_dict)
+    return config_object
+
+
 def tiny_bert_config_helper():
     pytest.importorskip('transformers')
     from transformers.models.bert.configuration_bert import BertConfig
@@ -312,6 +399,11 @@ def _session_tiny_bert_config():  # type: ignore
     return tiny_bert_config_helper()
 
 
+@pytest.fixture(scope='session')
+def _session_tiny_llama4_config():  # type: ignore
+    return tiny_llama4_config_helper()
+
+
 ## SESSION TOKENIZERS ##
 @pytest.fixture(scope='session')
 def _session_tiny_gpt2_tokenizer(tokenizers_assets):  # type: ignore
@@ -380,6 +472,11 @@ def tiny_codellama_model(_session_tiny_codellama_model):  # type: ignore
 @pytest.fixture
 def tiny_bert_config(_session_tiny_bert_config):  # type: ignore
     return copy.deepcopy(_session_tiny_bert_config)
+
+
+@pytest.fixture
+def tiny_llama4_config(_session_tiny_llama4_config):  # type: ignore
+    return copy.deepcopy(_session_tiny_llama4_config)
 
 
 ## TOKENIZER FIXTURES ##


### PR DESCRIPTION
Multimodal models may return a config with subconfigs from `AutoConfig`. This PR allows subclasses to automatically select a subconfig (and sets up the causal LM training class to select text config). With this, llama4 scout finetuning works (`llama4-scout-hf-real-7-a3JTUJ`). llama4 also works with flex attention (`llama4-scout-hf-flex-1-EUH7iy`)

Along for the ride, install the new HF extra that supposedly speeds up download `hf_xet`, and bumps the minimum hf hub version that supports it.