### PR TITLE
Fix Dtensor initialization

### DIFF
--- a/llmfoundry/models/utils/param_init_fns.py
+++ b/llmfoundry/models/utils/param_init_fns.py
@@ -97,7 +97,7 @@ def materialize_module(
         nn.Module: The module with materialized parameters that can be initialized.
     """
     param_placement_map: dict[tuple[nn.Module, str],
-                              tuple[DeviceMesh, list[Placement]]] = {}
+                              tuple[DeviceMesh, tuple[Placement, ...]]] = {}
     with torch.no_grad():
         for submodule in module.modules():
             for name, param in submodule.named_parameters(recurse=False):
@@ -127,11 +127,8 @@ def materialize_module(
                     )
 
 
-def summon_dtensor(
-    init_fn: Callable[[nn.Module | torch.Tensor, Any], bool],
-) -> Callable[[nn.Module | torch.Tensor, Any], bool]:
-    """Decorator that makes initialization functions compatible with DTensor
-    parameters.
+def summon_dtensor(init_fn: Callable) -> Callable:
+    """Unshard and Reshard DTensor parameters for initialization.
 
     This decorator wraps an initialization function to handle both regular tensors/modules
     and those containing DTensor parameters by temporarily materializing DTensors as full

--- a/llmfoundry/models/utils/param_init_fns.py
+++ b/llmfoundry/models/utils/param_init_fns.py
@@ -128,8 +128,8 @@ def materialize_module(
 
 
 def summon_dtensor(
-    init_fn: Callable[[nn.Module | torch.Tensor, Any], None],
-) -> Callable[[nn.Module | torch.Tensor, Any], None]:
+    init_fn: Callable[[nn.Module | torch.Tensor, Any], bool],
+) -> Callable[[nn.Module | torch.Tensor, Any], bool]:
     """Decorator that makes initialization functions compatible with DTensor
     parameters.
 
@@ -148,13 +148,13 @@ def summon_dtensor(
         obj: nn.Module | torch.Tensor,
         *args: Any,
         **kwargs: Any,
-    ) -> None:
+    ) -> bool:
         if isinstance(obj, nn.Module):
             with materialize_module(obj) as obj:
-                init_fn(obj, *args, **kwargs)
+                return init_fn(obj, *args, **kwargs)
         elif isinstance(obj, torch.Tensor):
             with materialize_tensor(obj) as obj:
-                init_fn(obj, *args, **kwargs)
+                return init_fn(obj, *args, **kwargs)
         else:
             raise TypeError(f"Invalid object type: {type(obj)}")
 
@@ -579,7 +579,7 @@ def generic_param_init_fn_(
     did_init = False
     for module_init_fn in all_module_init_fns:
         did_init = module_init_fn(
-            module=module,
+            module,
             init_fn_=init_fn_,
             d_model=d_model,
             init_div_is_residual=init_div_is_residual,

--- a/llmfoundry/models/utils/param_init_fns.py
+++ b/llmfoundry/models/utils/param_init_fns.py
@@ -36,6 +36,103 @@ __all__ = [
 ]
 
 
+@contextmanager
+def materialize_tensor(
+    tensor: torch.Tensor,
+) -> Generator[torch.Tensor, None, None]:
+    """Context manager for initializing DTensor parameters.
+
+    This context manager temporarily materializes a DTensor as a full tensor for initialization,
+    then redistributes the initialized values back to the original DTensor.
+
+    NOTE: This approach is not memory-efficient as it materializes a full tensor on every rank
+    and then redistributes it back to a DTensor. However, since model initialization happens
+    only once, this overhead is generally acceptable.
+
+    Args:
+        tensor: The tensor to materialize. Can be either a regular Tensor or a DTensor.
+
+    Yields:
+        torch.Tensor: The materialized full tensor that can be initialized.
+    """
+    is_dtensor = isinstance(tensor, DTensor)
+
+    with torch.no_grad():
+        if is_dtensor:
+            full_tensor = tensor.full_tensor()
+        else:
+            full_tensor = tensor
+
+        yield full_tensor
+        if is_dtensor:
+            # Redistribute the updated full tensor back to the original DTensor
+            with torch.no_grad():
+                temp_tensor = distribute_tensor(
+                    full_tensor,
+                    device_mesh=tensor.device_mesh,
+                    placements=tensor.placements,
+                )
+                tensor.to_local().copy_(temp_tensor.to_local())
+
+
+@contextmanager
+def materialize_module(
+    module: nn.Module,
+) -> Generator[nn.Module, None, None]:
+    """Context manager for initializing modules containing DTensor parameters.
+
+    This context manager temporarily materializes all DTensor parameters in a module
+    as full tensors for initialization, then redistributes the initialized values back
+    to the original DTensor parameters.
+
+    Args:
+        module: The module whose parameters should be materialized.
+
+    Yields:
+        nn.Module: The module with materialized parameters that can be initialized.
+    """
+    param_placement_map: dict[tuple[nn.Module, str], tuple[DeviceMesh, list[Placement]]] = {}
+    with torch.no_grad():
+        for submodule in module.modules():
+            for name, param in submodule.named_parameters(recurse=False):
+                if isinstance(param, DTensor):
+                    param_placement_map[(submodule, name)] = (param.device_mesh, param.placements)
+                    setattr(submodule, name, nn.Parameter(param.full_tensor()))
+
+        yield module
+
+        for submodule in module.modules():
+            for name, param in submodule.named_parameters(recurse=False):
+                if (submodule, name) in param_placement_map:
+                    device_mesh, placements = param_placement_map[(submodule, name)]
+                    setattr(submodule, name, nn.Parameter(distribute_tensor(param, device_mesh=device_mesh, placements=placements)))
+
+
+def summon_dtensor(init_fn: Callable[[nn.Module | torch.Tensor, Any], None]) -> Callable[[nn.Module | torch.Tensor, Any], None]:
+    """Decorator that makes initialization functions compatible with DTensor parameters.
+
+    This decorator wraps an initialization function to handle both regular tensors/modules
+    and those containing DTensor parameters by temporarily materializing DTensors as full
+    tensors during initialization.
+
+    Args:
+        init_fn: The initialization function to wrap.
+
+    Returns:
+        A wrapped initialization function that can handle DTensor parameters.
+    """
+    def init_fn_wrapper(obj: nn.Module | torch.Tensor, *args, **kwargs) -> None:
+        if isinstance(obj, nn.Module):
+            with materialize_module(obj) as obj:
+                init_fn(obj, *args, **kwargs)
+        elif isinstance(obj, torch.Tensor):
+            with materialize_tensor(obj) as obj:
+                init_fn(obj, *args, **kwargs)
+        else:
+            raise TypeError(f"Invalid object type: {type(obj)}")
+    return init_fn_wrapper
+
+
 def torch_default_param_init_fn_(
     module: nn.Module,
     **kwargs: Any,
@@ -72,70 +169,6 @@ def fused_init_helper_(
         raise RuntimeError(f'Internal logic error')
 
     fused_param_init_helper(getattr(module, name_param), init_fn_, _fused)
-
-
-@contextmanager
-def materialize_tensor(
-    tensor: torch.Tensor,
-) -> Generator[torch.Tensor, None, None]:
-    """Context manager for initializing DTensor parameters.
-
-    NOTE: This DTensorInitContext is not efficient as it initializes
-    a full tensor on every rank and then slices it back to a DTensor,
-    yet since we only init a model once, this overhead is negligible
-    """
-    is_dtensor = isinstance(tensor, DTensor)
-
-    with torch.no_grad():
-        if is_dtensor:
-            full_tensor = tensor.full_tensor()
-        else:
-            full_tensor = tensor
-
-        yield full_tensor
-        if is_dtensor:
-            # Redistribute the updated full tensor back to the original DTensor
-            with torch.no_grad():
-                temp_tensor = distribute_tensor(
-                    full_tensor,
-                    device_mesh=tensor.device_mesh,
-                    placements=tensor.placements,
-                )
-                tensor.to_local().copy_(temp_tensor.to_local())
-
-
-@contextmanager
-def materialize_module(
-    module: nn.Module,
-) -> Generator[nn.Module, None, None]:
-    param_placement_map: dict[tuple[nn.Module, str], tuple[DeviceMesh, list[Placement]]] = {}
-    with torch.no_grad():
-        for submodule in module.modules():
-            for name, param in submodule.named_parameters(recurse=False):
-                if isinstance(param, DTensor):
-                    param_placement_map[(submodule, name)] = (param.device_mesh, param.placements)
-                    setattr(submodule, name, nn.Parameter(param.full_tensor()))
-
-        yield module
-
-        for submodule in module.modules():
-            for name, param in submodule.named_parameters(recurse=False):
-                if (submodule, name) in param_placement_map:
-                    device_mesh, placements = param_placement_map[(submodule, name)]
-                    setattr(submodule, name, nn.Parameter(distribute_tensor(param, device_mesh=device_mesh, placements=placements)))
-
-
-def summon_dtensor(init_fn: Callable[[nn.Module | torch.Tensor, ...], None]) -> Callable[[nn.Module | torch.Tensor, Any, ...], None]:
-    def init_fn_wrapper(obj: nn.Module | torch.Tensor, *args, **kwargs) -> None:
-        if isinstance(obj, nn.Module):
-            with materialize_module(obj) as obj:
-                init_fn(obj, *args, **kwargs)
-        elif isinstance(obj, torch.Tensor):
-            with materialize_tensor(obj) as obj:
-                init_fn(obj, *args, **kwargs)
-        else:
-            raise TypeError(f"Invalid object type: {type(obj)}")
-    return init_fn_wrapper
 
 
 @summon_dtensor

--- a/llmfoundry/models/utils/param_init_fns.py
+++ b/llmfoundry/models/utils/param_init_fns.py
@@ -153,7 +153,7 @@ def summon_dtensor(init_fn: Callable) -> Callable:
             with materialize_tensor(obj) as obj:
                 return init_fn(obj, *args, **kwargs)
         else:
-            raise TypeError(f"Invalid object type: {type(obj)}")
+            raise TypeError(f'Invalid object type: {type(obj)}')
 
     return init_fn_wrapper
 

--- a/llmfoundry/models/utils/param_init_fns.py
+++ b/llmfoundry/models/utils/param_init_fns.py
@@ -121,7 +121,7 @@ def summon_dtensor(init_fn: Callable[[nn.Module | torch.Tensor, Any], None]) -> 
     Returns:
         A wrapped initialization function that can handle DTensor parameters.
     """
-    def init_fn_wrapper(obj: nn.Module | torch.Tensor, *args, **kwargs) -> None:
+    def init_fn_wrapper(obj: nn.Module | torch.Tensor, *args: Any, **kwargs: Any) -> None:
         if isinstance(obj, nn.Module):
             with materialize_module(obj) as obj:
                 init_fn(obj, *args, **kwargs)

--- a/llmfoundry/models/utils/param_init_fns.py
+++ b/llmfoundry/models/utils/param_init_fns.py
@@ -11,8 +11,12 @@ from typing import Any, Callable, Generator, Optional, Union
 
 import torch
 from torch import nn
-from torch.distributed._tensor import (DeviceMesh, DTensor, Placement,
-                                       distribute_tensor,)
+from torch.distributed._tensor import (
+    DeviceMesh,
+    DTensor,
+    Placement,
+    distribute_tensor,
+)
 
 from llmfoundry.layers_registry import (
     fcs,
@@ -111,19 +115,20 @@ def materialize_module(
                     device_mesh, placements = param_placement_map[
                         (submodule, name)]
                     setattr(
-                        submodule, name,
+                        submodule,
+                        name,
                         nn.Parameter(
                             distribute_tensor(
                                 param,
                                 device_mesh=device_mesh,
-                                placements=placements
-                            )
-                        )
+                                placements=placements,
+                            ),
+                        ),
                     )
 
 
 def summon_dtensor(
-    init_fn: Callable[[nn.Module | torch.Tensor, Any], None]
+    init_fn: Callable[[nn.Module | torch.Tensor, Any], None],
 ) -> Callable[[nn.Module | torch.Tensor, Any], None]:
     """Decorator that makes initialization functions compatible with DTensor
     parameters.
@@ -140,7 +145,9 @@ def summon_dtensor(
     """
 
     def init_fn_wrapper(
-        obj: nn.Module | torch.Tensor, *args: Any, **kwargs: Any
+        obj: nn.Module | torch.Tensor,
+        *args: Any,
+        **kwargs: Any,
     ) -> None:
         if isinstance(obj, nn.Module):
             with materialize_module(obj) as obj:

--- a/llmfoundry/models/utils/param_init_fns.py
+++ b/llmfoundry/models/utils/param_init_fns.py
@@ -4,13 +4,14 @@
 import math
 import warnings
 from collections.abc import Sequence
+from contextlib import contextmanager
 from copy import deepcopy
 from functools import partial
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable, Generator, Optional, Union
 
 import torch
 from torch import nn
-from torch.distributed._tensor import DTensor
+from torch.distributed._tensor import DTensor, distribute_tensor
 
 from llmfoundry.layers_registry import (
     fcs,
@@ -73,6 +74,28 @@ def fused_init_helper_(
     fused_param_init_helper(getattr(module, name_param), init_fn_, _fused)
 
 
+@contextmanager
+def DTensorInitContext(tensor: torch.Tensor) -> Generator[torch.Tensor, None, None]:
+    is_dtensor = isinstance(tensor, DTensor)
+    original_tensor = tensor
+    
+    if is_dtensor:
+        full_tensor = tensor.full_tensor()
+        yield full_tensor
+    else:
+        yield tensor
+    
+    if is_dtensor:
+        # Redistribute the updated full tensor back to the original DTensor
+        with torch.no_grad():
+            temp_tensor = distribute_tensor(
+                full_tensor, 
+                device_mesh=original_tensor.device_mesh, 
+                placements=original_tensor.placements
+            )
+            original_tensor.copy_(temp_tensor)
+
+
 def fused_param_init_helper(
     param: torch.Tensor,
     init_fn_: Callable,
@@ -86,13 +109,15 @@ def fused_param_init_helper(
         fused_parameters (tuple[int, list[int]]): First element of _fused is the dimension
             along which the tensor is fused. Second element is a an iterable of split indices.
     """
-    p_ndims = param.ndim
-    dim, splits = fused_parameters
-    splits = (0, *splits, param.size(dim))  # type: ignore
-    for s, e in zip(splits[:-1], splits[1:]):
-        slice_indices = [slice(None)] * p_ndims  # type: ignore
-        slice_indices[dim] = slice(s, e)
-        init_fn_(param[slice_indices])  # type: ignore
+    
+    with torch.no_grad(), DTensorInitContext(param) as tensor:
+        p_ndims = tensor.ndim
+        dim, splits = fused_parameters
+        splits = (0, *splits, tensor.size(dim))  # type: ignore
+        for s, e in zip(splits[:-1], splits[1:]):
+            slice_indices = [slice(None)] * p_ndims  # type: ignore
+            slice_indices[dim] = slice(s, e)
+            init_fn_(tensor[slice_indices])  # type: ignore
 
 
 def stacked_init_helper_(

--- a/llmfoundry/models/utils/param_init_fns.py
+++ b/llmfoundry/models/utils/param_init_fns.py
@@ -116,24 +116,19 @@ def fused_param_init_helper(
             along which the tensor is fused. Second element is a an iterable of split indices.
     """
     
-    # with torch.no_grad(), DTensorInitContext(param) as tensor:
-    tensor = param
-    p_ndims = tensor.ndim
-    dim, splits = fused_parameters
-    splits = (0, *splits, tensor.size(dim))  # type: ignore
-    for s, e in zip(splits[:-1], splits[1:]):
-        # DTensor slicing results in CC and thus produces new Tensor
-        # so the update is not inplace, additionally, the init_fn is
-        # designed for full tensors, not for a (sharded) DTensor, so
-        # we need this context manager to handle the DTensor case
-        slice_indices = [slice(None)] * p_ndims  # type: ignore
-        slice_indices[dim] = slice(s, e)
-        init_fn_(tensor[slice_indices])  # type: ignore
-    if isinstance(tensor, DTensor):
-        print('DTensor')
-        print(tensor)
-        print('sliced DTensor')
-        print(tensor[slice_indices])
+    with torch.no_grad(), DTensorInitContext(param) as tensor:
+        p_ndims = tensor.ndim
+        dim, splits = fused_parameters
+        splits = (0, *splits, tensor.size(dim))  # type: ignore
+        for s, e in zip(splits[:-1], splits[1:]):
+            # DTensor slicing results in CC and thus produces new Tensor
+            # so the update is not inplace, additionally, the init_fn is
+            # designed for full tensors, not for a (sharded) DTensor, so
+            # we need this context manager to handle the DTensor case
+            slice_indices = [slice(None)] * p_ndims  # type: ignore
+            slice_indices[dim] = slice(s, e)
+            init_fn_(tensor[slice_indices])  # type: ignore
+
 
 def stacked_init_helper_(
     module: nn.Module,

--- a/llmfoundry/models/utils/param_init_fns.py
+++ b/llmfoundry/models/utils/param_init_fns.py
@@ -189,6 +189,7 @@ def stacked_init_helper_(
     stacked_param_init_helper(getattr(module, name_param), init_fn_, stack_dim)
 
 
+@summon_dtensor
 def stacked_param_init_helper(
     param: torch.Tensor,
     init_fn_: Callable,
@@ -259,6 +260,7 @@ def fc_init(
     return False
 
 
+@summon_dtensor
 def embedding_init(
     module: nn.Module,
     init_fn_: Callable,
@@ -325,6 +327,7 @@ def norm_init(
     return False
 
 
+@summon_dtensor
 def multihead_attention_init(
     module: nn.Module,
     init_fn_: Callable,

--- a/tests/models/utils/test_param_init_fns.py
+++ b/tests/models/utils/test_param_init_fns.py
@@ -240,8 +240,7 @@ def test_emb_padding_init(
 @pytest.mark.world_size(2)
 def test_fused_init_helper_dtensor_vs_tensor():
     """Test that fused_param_init_helper produces the same results for a regular
-    tensor and a DTensor.
-    """
+    tensor and a DTensor."""
     # Create a simple device mesh for CPU
     mesh = DeviceMesh('cpu', [0, 1])
 

--- a/tests/models/utils/test_param_init_fns.py
+++ b/tests/models/utils/test_param_init_fns.py
@@ -340,6 +340,14 @@ def test_fc_init_dtensor_vs_tensor(is_fused: bool):
     fc_init(dtensor_linear, init_arange_, init_div_is_residual, div_is_residual)
 
     # For comparison, convert DTensor to regular tensor
+    assert isinstance(
+        dtensor_linear.weight,
+        DTensor,
+    ), f'DTensor is not a DTensor: {type(dtensor_linear.weight)}'
+    assert isinstance(
+        dtensor_linear.bias,
+        DTensor,
+    ), f'DTensor is not a DTensor: {type(dtensor_linear.bias)}'
     dtensor_weight = dtensor_linear.weight.full_tensor()
     dtensor_bias = dtensor_linear.bias.full_tensor()
 
@@ -463,6 +471,10 @@ def test_embedding_init_dtensor_vs_tensor(
     embedding_init(dtensor_embedding, init_arange_, None, None)
 
     # For comparison, convert DTensor to regular tensor
+    assert isinstance(
+        dtensor_embedding.weight,
+        DTensor,
+    ), f'DTensor is not a DTensor: {type(dtensor_embedding.weight)}'
     dtensor_weight = dtensor_embedding.weight.full_tensor()
 
     # Verify weight results are identical
@@ -541,10 +553,18 @@ def test_multihead_attention_init_dtensor_vs_tensor(
             distribute_tensor(dtensor_mha.v_proj_weight, mesh, [Shard(0)]),
         )
         dtensor_mha.bias_k = torch.nn.Parameter(
-            distribute_tensor(dtensor_mha.bias_k, mesh, [Shard(0)]),
+            distribute_tensor(
+                dtensor_mha.bias_k,  # type: ignore
+                mesh,
+                [Shard(0)],
+            ),
         )
         dtensor_mha.bias_v = torch.nn.Parameter(
-            distribute_tensor(dtensor_mha.bias_v, mesh, [Shard(0)]),
+            distribute_tensor(
+                dtensor_mha.bias_v,  # type: ignore
+                mesh,
+                [Shard(0)],
+            ),
         )
 
     # Convert out_proj parameters to DTensor
@@ -574,35 +594,73 @@ def test_multihead_attention_init_dtensor_vs_tensor(
     # Convert DTensor parameters to regular tensors for comparison
     if qkv_same_dim:
         # Compare in_proj_weight
+        assert isinstance(
+            dtensor_mha.in_proj_weight,
+            DTensor,
+        ), f'DTensor is not a DTensor: {type(dtensor_mha.in_proj_weight)}'
         dtensor_in_proj_weight = dtensor_mha.in_proj_weight.full_tensor()
         assert torch.equal(regular_mha.in_proj_weight, dtensor_in_proj_weight), \
             f'regular in_proj_weight: {regular_mha.in_proj_weight} vs DTensor: {dtensor_in_proj_weight}'
+        assert isinstance(
+            dtensor_mha.in_proj_bias,
+            DTensor,
+        ), f'DTensor is not a DTensor: {type(dtensor_mha.in_proj_bias)}'
         dtensor_in_proj_bias = dtensor_mha.in_proj_bias.full_tensor()
         assert torch.equal(regular_mha.in_proj_bias, dtensor_in_proj_bias), \
             f'regular in_proj_bias: {regular_mha.in_proj_bias} vs DTensor: {dtensor_in_proj_bias}'
     else:
         # Compare q/k/v_proj_weight
+        assert isinstance(
+            dtensor_mha.q_proj_weight,
+            DTensor,
+        ), f'DTensor is not a DTensor: {type(dtensor_mha.q_proj_weight)}'
         dtensor_q_proj_weight = dtensor_mha.q_proj_weight.full_tensor()
+        assert isinstance(
+            dtensor_mha.k_proj_weight,
+            DTensor,
+        ), f'DTensor is not a DTensor: {type(dtensor_mha.k_proj_weight)}'
         dtensor_k_proj_weight = dtensor_mha.k_proj_weight.full_tensor()
+        assert isinstance(
+            dtensor_mha.v_proj_weight,
+            DTensor,
+        ), f'DTensor is not a DTensor: {type(dtensor_mha.v_proj_weight)}'
         dtensor_v_proj_weight = dtensor_mha.v_proj_weight.full_tensor()
-
         assert torch.equal(regular_mha.q_proj_weight, dtensor_q_proj_weight), \
             f'regular q_proj_weight: {regular_mha.q_proj_weight} vs DTensor: {dtensor_q_proj_weight}'
         assert torch.equal(regular_mha.k_proj_weight, dtensor_k_proj_weight), \
             f'regular k_proj_weight: {regular_mha.k_proj_weight} vs DTensor: {dtensor_k_proj_weight}'
         assert torch.equal(regular_mha.v_proj_weight, dtensor_v_proj_weight), \
             f'regular v_proj_weight: {regular_mha.v_proj_weight} vs DTensor: {dtensor_v_proj_weight}'
+        assert isinstance(
+            dtensor_mha.bias_k,
+            DTensor,
+        ), f'DTensor is not a DTensor: {type(dtensor_mha.bias_k)}'
         dtensor_bias_k = dtensor_mha.bias_k.full_tensor()
+        assert isinstance(
+            dtensor_mha.bias_v,
+            DTensor,
+        ), f'DTensor is not a DTensor: {type(dtensor_mha.bias_v)}'
         dtensor_bias_v = dtensor_mha.bias_v.full_tensor()
-        assert torch.equal(regular_mha.bias_k, dtensor_bias_k), \
-            f'regular bias_k: {regular_mha.bias_k} vs DTensor: {dtensor_bias_k}'
-        assert torch.equal(regular_mha.bias_v, dtensor_bias_v), \
-            f'regular bias_v: {regular_mha.bias_v} vs DTensor: {dtensor_bias_v}'
+        assert torch.equal(
+            regular_mha.bias_k,  # type: ignore
+            dtensor_bias_k,
+        ), f'regular bias_k: {regular_mha.bias_k} vs DTensor: {dtensor_bias_k}'
+        assert torch.equal(
+            regular_mha.bias_v,  # type: ignore
+            dtensor_bias_v,
+        ), f'regular bias_v: {regular_mha.bias_v} vs DTensor: {dtensor_bias_v}'
 
     # Compare out_proj parameters
+    assert isinstance(
+        dtensor_mha.out_proj.weight,
+        DTensor,
+    ), f'DTensor is not a DTensor: {type(dtensor_mha.out_proj.weight)}'
     dtensor_out_proj_weight = dtensor_mha.out_proj.weight.full_tensor()
+    assert isinstance(
+        dtensor_mha.out_proj.bias,
+        DTensor,
+    ), f'DTensor is not a DTensor: {type(dtensor_mha.out_proj.bias)}'
     dtensor_out_proj_bias = dtensor_mha.out_proj.bias.full_tensor()
-
     assert torch.equal(regular_mha.out_proj.weight, dtensor_out_proj_weight), \
         f'regular out_proj.weight: {regular_mha.out_proj.weight} vs DTensor: {dtensor_out_proj_weight}'
     assert torch.equal(regular_mha.out_proj.bias, dtensor_out_proj_bias), \

--- a/tests/models/utils/test_param_init_fns.py
+++ b/tests/models/utils/test_param_init_fns.py
@@ -254,6 +254,8 @@ def test_fused_init_helper_dtensor_vs_tensor():
     fused_param_init_helper(regular_tensor, init_fn_, fused_params)
     fused_param_init_helper(dtensor, init_fn_, fused_params)
     
+    assert isinstance(dtensor, torch.nn.Parameter), f'param is not an nn.Parameter anymore: {type(dtensor)}'
+
     # For comparison, convert DTensor to regular tensor
     dtensor_result = dtensor.full_tensor()
     

--- a/tests/models/utils/test_param_init_fns.py
+++ b/tests/models/utils/test_param_init_fns.py
@@ -8,10 +8,10 @@ from typing import Optional, Union
 
 import pytest
 import torch
-from torch.distributed._tensor import distribute_tensor, DeviceMesh, Shard
 from omegaconf import DictConfig, ListConfig
 from omegaconf import OmegaConf as om
 from torch import nn
+from torch.distributed._tensor import DeviceMesh, Shard, distribute_tensor
 
 from llmfoundry.layers_registry import param_init_fns
 from llmfoundry.models.utils import generic_param_init_fn_
@@ -234,36 +234,48 @@ def test_emb_padding_init(
 
 @pytest.mark.world_size(2)
 def test_fused_init_helper_dtensor_vs_tensor():
-    """Test that fused_param_init_helper produces the same results for a regular tensor and a DTensor."""
+    """Test that fused_param_init_helper produces the same results for a regular
+    tensor and a DTensor."""
     # Create a simple device mesh for CPU
     mesh = DeviceMesh('cpu', [0, 1])
-    
+
     regular_tensor = torch.nn.Parameter(torch.zeros(4, 4))
-    
-    dtensor = torch.nn.Parameter(distribute_tensor(regular_tensor, mesh, [Shard(0)]))
-    
+
+    dtensor = torch.nn.Parameter(
+        distribute_tensor(regular_tensor, mesh, [Shard(0)])
+    )
+
     # Create a simple initialization function for testing
     def init_fn_(weight: torch.Tensor) -> None:
         with torch.no_grad():
-            weight.copy_(torch.arange(weight.numel()).reshape(weight.shape).float())
-    
+            weight.copy_(
+                torch.arange(weight.numel()).reshape(weight.shape).float()
+            )
+
     # Define fused parameters (dimension 0, split at index 2)
     fused_params = (0, [2])
-    
+
     # Initialize both tensors using fused_param_init_helper
     fused_param_init_helper(regular_tensor, init_fn_, fused_params)
     fused_param_init_helper(dtensor, init_fn_, fused_params)
-    
-    assert isinstance(dtensor, torch.nn.Parameter), f'param is not an nn.Parameter anymore: {type(dtensor)}'
+
+    assert isinstance(
+        dtensor, torch.nn.Parameter
+    ), f'param is not an nn.Parameter anymore: {type(dtensor)}'
 
     # For comparison, convert DTensor to regular tensor
     dtensor_result = dtensor.full_tensor()
-    
+
     # Verify results are identical
     assert torch.equal(regular_tensor, dtensor_result), \
         f"fused_param_init_helper produced different results for regular tensor: {regular_tensor} vs DTensor: {dtensor_result}"
-    
+
     # Check that each partition was separately initialized as expected
     numel_half = dtensor_result.numel() // 2
-    expected_result = torch.cat([torch.arange(numel_half), torch.arange(numel_half)]).reshape(dtensor_result.shape).float()
-    assert torch.equal(dtensor_result, expected_result), f'DTensor was not initialized correctly: {dtensor_result} vs {expected_result}'
+    expected_result = torch.cat([
+        torch.arange(numel_half),
+        torch.arange(numel_half)
+    ]).reshape(dtensor_result.shape).float()
+    assert torch.equal(
+        dtensor_result, expected_result
+    ), f'DTensor was not initialized correctly: {dtensor_result} vs {expected_result}'

--- a/tests/models/utils/test_param_init_fns.py
+++ b/tests/models/utils/test_param_init_fns.py
@@ -11,7 +11,12 @@ import torch
 from omegaconf import DictConfig, ListConfig
 from omegaconf import OmegaConf as om
 from torch import nn
-from torch.distributed._tensor import DeviceMesh, Shard, distribute_tensor
+from torch.distributed._tensor import (
+    DeviceMesh,
+    DTensor,
+    Shard,
+    distribute_tensor,
+)
 
 from llmfoundry.layers_registry import param_init_fns
 from llmfoundry.models.utils import generic_param_init_fn_
@@ -235,21 +240,22 @@ def test_emb_padding_init(
 @pytest.mark.world_size(2)
 def test_fused_init_helper_dtensor_vs_tensor():
     """Test that fused_param_init_helper produces the same results for a regular
-    tensor and a DTensor."""
+    tensor and a DTensor.
+    """
     # Create a simple device mesh for CPU
     mesh = DeviceMesh('cpu', [0, 1])
 
     regular_tensor = torch.nn.Parameter(torch.zeros(4, 4))
 
     dtensor = torch.nn.Parameter(
-        distribute_tensor(regular_tensor, mesh, [Shard(0)])
+        distribute_tensor(regular_tensor, mesh, [Shard(0)]),
     )
 
     # Create a simple initialization function for testing
     def init_fn_(weight: torch.Tensor) -> None:
         with torch.no_grad():
             weight.copy_(
-                torch.arange(weight.numel()).reshape(weight.shape).float()
+                torch.arange(weight.numel()).reshape(weight.shape).float(),
             )
 
     # Define fused parameters (dimension 0, split at index 2)
@@ -260,8 +266,13 @@ def test_fused_init_helper_dtensor_vs_tensor():
     fused_param_init_helper(dtensor, init_fn_, fused_params)
 
     assert isinstance(
-        dtensor, torch.nn.Parameter
+        dtensor,
+        torch.nn.Parameter,
     ), f'param is not an nn.Parameter anymore: {type(dtensor)}'
+    assert isinstance(
+        dtensor,
+        DTensor,
+    ), f'DTensor is not a DTensor: {type(dtensor)}'
 
     # For comparison, convert DTensor to regular tensor
     dtensor_result = dtensor.full_tensor()
@@ -274,8 +285,13 @@ def test_fused_init_helper_dtensor_vs_tensor():
     numel_half = dtensor_result.numel() // 2
     expected_result = torch.cat([
         torch.arange(numel_half),
-        torch.arange(numel_half)
+        torch.arange(numel_half),
     ]).reshape(dtensor_result.shape).float()
     assert torch.equal(
-        dtensor_result, expected_result
+        regular_tensor,
+        expected_result,
+    ), f'Regular tensor was not initialized correctly: {regular_tensor} vs {expected_result}'
+    assert torch.equal(
+        dtensor_result,
+        expected_result,
     ), f'DTensor was not initialized correctly: {dtensor_result} vs {expected_result}'

--- a/tests/models/utils/test_param_init_fns.py
+++ b/tests/models/utils/test_param_init_fns.py
@@ -278,7 +278,7 @@ def test_fused_init_helper_dtensor_vs_tensor():
 
     # Verify results are identical
     assert torch.equal(regular_tensor, dtensor_result), \
-        f"fused_param_init_helper produced different results for regular tensor: {regular_tensor} vs DTensor: {dtensor_result}"
+        f'fused_param_init_helper produced different results for regular tensor: {regular_tensor} vs DTensor: {dtensor_result}'
 
     # Check that each partition was separately initialized as expected
     numel_half = dtensor_result.numel() // 2

--- a/tests/models/utils/test_param_init_fns.py
+++ b/tests/models/utils/test_param_init_fns.py
@@ -8,12 +8,14 @@ from typing import Optional, Union
 
 import pytest
 import torch
+from torch.distributed._tensor import distribute_tensor, DeviceMesh, Shard
 from omegaconf import DictConfig, ListConfig
 from omegaconf import OmegaConf as om
 from torch import nn
 
 from llmfoundry.layers_registry import param_init_fns
 from llmfoundry.models.utils import generic_param_init_fn_
+from llmfoundry.models.utils.param_init_fns import fused_param_init_helper
 
 
 class MLP(nn.Module):
@@ -228,3 +230,38 @@ def test_emb_padding_init(
 
     if dict_cfg.get('emb_init_std') is not None:
         assert (model.weight[padding_idx] == 0).all()
+
+
+@pytest.mark.world_size(2)
+def test_fused_init_helper_dtensor_vs_tensor():
+    """Test that fused_param_init_helper produces the same results for a regular tensor and a DTensor."""
+    # Create a simple device mesh for CPU
+    mesh = DeviceMesh('cpu', [0, 1])
+    
+    regular_tensor = torch.nn.Parameter(torch.zeros(4, 4))
+    
+    dtensor = torch.nn.Parameter(distribute_tensor(regular_tensor, mesh, [Shard(0)]))
+    
+    # Create a simple initialization function for testing
+    def init_fn_(weight: torch.Tensor) -> None:
+        with torch.no_grad():
+            weight.copy_(torch.arange(weight.numel()).reshape(weight.shape).float())
+    
+    # Define fused parameters (dimension 0, split at index 2)
+    fused_params = (0, [2])
+    
+    # Initialize both tensors using fused_param_init_helper
+    fused_param_init_helper(regular_tensor, init_fn_, fused_params)
+    fused_param_init_helper(dtensor, init_fn_, fused_params)
+    
+    # For comparison, convert DTensor to regular tensor
+    dtensor_result = dtensor.full_tensor()
+    
+    # Verify results are identical
+    assert torch.equal(regular_tensor, dtensor_result), \
+        f"fused_param_init_helper produced different results for regular tensor: {regular_tensor} vs DTensor: {dtensor_result}"
+    
+    # Check that each partition was separately initialized as expected
+    numel_half = dtensor_result.numel() // 2
+    expected_result = torch.cat([torch.arange(numel_half), torch.arange(numel_half)]).reshape(dtensor_result.shape).float()
+    assert torch.equal(dtensor_result, expected_result), f'DTensor was not initialized correctly: {dtensor_result} vs {expected_result}'

--- a/tests/models/utils/test_param_init_fns.py
+++ b/tests/models/utils/test_param_init_fns.py
@@ -20,7 +20,10 @@ from torch.distributed._tensor import (
 
 from llmfoundry.layers_registry import param_init_fns
 from llmfoundry.models.utils import generic_param_init_fn_
-from llmfoundry.models.utils.param_init_fns import fc_init, fused_param_init_helper, stacked_param_init_helper, embedding_init, multihead_attention_init
+from llmfoundry.models.utils.param_init_fns import (embedding_init, fc_init,
+                                                    fused_param_init_helper,
+                                                    multihead_attention_init,
+                                                    stacked_param_init_helper,)
 
 
 class MLP(nn.Module):
@@ -237,8 +240,6 @@ def test_emb_padding_init(
         assert (model.weight[padding_idx] == 0).all()
 
 
-
-
 def init_arange_(weight: torch.Tensor) -> None:
     with torch.no_grad():
         weight.copy_(
@@ -301,17 +302,17 @@ def test_fused_init_helper_dtensor_vs_tensor():
 def test_fc_init_dtensor_vs_tensor(is_fused: bool):
     # Create a simple device mesh for CPU
     mesh = DeviceMesh('cpu', [0, 1])
-    
-    # Set up minimal config 
+
+    # Set up minimal config
     init_div_is_residual = True
     div_is_residual = 2.0
-    
+
     # Create a regular linear layer
     regular_linear = nn.Linear(8, 4)
-    
+
     # Create a linear layer with DTensor parameters
     dtensor_linear = nn.Linear(8, 4)
-    
+
     # Convert the weight and bias to DTensor
     dtensor_linear.weight = torch.nn.Parameter(
         distribute_tensor(dtensor_linear.weight, mesh, [Shard(0)]),
@@ -319,34 +320,34 @@ def test_fc_init_dtensor_vs_tensor(is_fused: bool):
     dtensor_linear.bias = torch.nn.Parameter(
         distribute_tensor(dtensor_linear.bias, mesh, [Shard(0)]),
     )
-    
+
     # Mark one of the layers as residual to test the residual path
     regular_linear._is_residual = True
     dtensor_linear._is_residual = True
-    
+
     # For fused case, add the _fused attribute
     if is_fused:
         # Define fused parameters (dimension 0, split at index 2)
         fused_params = (0, [2])
         regular_linear._fused = fused_params
         dtensor_linear._fused = fused_params
-    
+
     # Initialize both modules using fc_init
     fc_init(regular_linear, init_arange_, init_div_is_residual, div_is_residual)
     fc_init(dtensor_linear, init_arange_, init_div_is_residual, div_is_residual)
-    
+
     # For comparison, convert DTensor to regular tensor
     dtensor_weight = dtensor_linear.weight.full_tensor()
     dtensor_bias = dtensor_linear.bias.full_tensor()
-    
+
     # Verify weight results are identical
     assert torch.equal(regular_linear.weight, dtensor_weight), \
         f'regular tensor: {regular_linear.weight} vs DTensor: {dtensor_weight}'
-    
+
     # Verify bias results are identical (should be all zeros)
     assert torch.equal(regular_linear.bias, dtensor_bias), \
         f'regular tensor: {regular_linear.bias} vs DTensor: {dtensor_bias}'
-    
+
     if is_fused:
         # For fused case, check that each partition was separately initialized as expected
         # Following the same verification logic as in test_fused_init_helper_dtensor_vs_tensor
@@ -355,17 +356,19 @@ def test_fc_init_dtensor_vs_tensor(is_fused: bool):
             torch.arange(numel_half),
             torch.arange(numel_half),
         ]).reshape(regular_linear.weight.shape).float()
-        
+
         # Apply div_is_residual factor for residual path
         expected_weight = expected_weight / div_is_residual
     else:
         # For non-fused case, the initialization is simpler
-        expected_weight = torch.arange(regular_linear.weight.numel()).reshape(regular_linear.weight.shape).float() / div_is_residual
+        expected_weight = torch.arange(regular_linear.weight.numel()).reshape(
+            regular_linear.weight.shape
+        ).float() / div_is_residual
     assert torch.equal(
         dtensor_weight,
         expected_weight,
     ), f'DTensor weight was not initialized correctly: {dtensor_weight} vs {expected_weight}'
-    
+
     # Bias should be all zeros in both cases
     assert torch.all(dtensor_bias == 0), \
         f'DTensor bias was not initialized correctly: {dtensor_bias}'
@@ -414,7 +417,7 @@ def test_stacked_param_init_helper_dtensor_vs_tensor():
         else:
             expected_slice = torch.arange(rows).float()
             actual_slice = regular_tensor[:, idx]
-        
+
         assert torch.equal(actual_slice, expected_slice), \
             f'Slice {idx} was not initialized correctly: {actual_slice} vs {expected_slice}'
 
@@ -422,36 +425,42 @@ def test_stacked_param_init_helper_dtensor_vs_tensor():
 @pytest.mark.world_size(2)
 @pytest.mark.parametrize('use_padding_idx', [False, True])
 @pytest.mark.parametrize('init_type', ['std', 'uniform', 'default'])
-def test_embedding_init_dtensor_vs_tensor(use_padding_idx: bool, init_type: str):
+def test_embedding_init_dtensor_vs_tensor(
+    use_padding_idx: bool, init_type: str
+):
     # Create a simple device mesh for CPU
     mesh = DeviceMesh('cpu', [0, 1])
-    
+
     # Setup parameters
     vocab_size, embed_dim = 10, 4
     padding_idx = 2 if use_padding_idx else None
-    
+
     # Create a regular embedding layer
-    regular_embedding = nn.Embedding(vocab_size, embed_dim, padding_idx=padding_idx)
-    
+    regular_embedding = nn.Embedding(
+        vocab_size, embed_dim, padding_idx=padding_idx
+    )
+
     # Create an embedding layer with DTensor parameters
-    dtensor_embedding = nn.Embedding(vocab_size, embed_dim, padding_idx=padding_idx)
-    
+    dtensor_embedding = nn.Embedding(
+        vocab_size, embed_dim, padding_idx=padding_idx
+    )
+
     # Convert the weight to DTensor
     dtensor_embedding.weight = torch.nn.Parameter(
         distribute_tensor(dtensor_embedding.weight, mesh, [Shard(0)]),
     )
-    
+
     # Initialize both modules using embedding_init
     embedding_init(regular_embedding, init_arange_, None, None)
     embedding_init(dtensor_embedding, init_arange_, None, None)
-    
+
     # For comparison, convert DTensor to regular tensor
     dtensor_weight = dtensor_embedding.weight.full_tensor()
-    
+
     # Verify weight results are identical
     assert torch.equal(regular_embedding.weight, dtensor_weight), \
         f'regular tensor: {regular_embedding.weight} vs DTensor: {dtensor_weight}'
-    
+
     # Additional test for padding_idx
     if padding_idx is not None:
         assert torch.all(regular_embedding.weight[padding_idx] == 0), \
@@ -463,43 +472,45 @@ def test_embedding_init_dtensor_vs_tensor(use_padding_idx: bool, init_type: str)
 @pytest.mark.world_size(2)
 @pytest.mark.parametrize('qkv_same_dim', [True, False])
 @pytest.mark.parametrize('is_residual', [True, False])
-def test_multihead_attention_init_dtensor_vs_tensor(qkv_same_dim: bool, is_residual: bool):
+def test_multihead_attention_init_dtensor_vs_tensor(
+    qkv_same_dim: bool, is_residual: bool
+):
     # Create a simple device mesh for CPU
     mesh = DeviceMesh('cpu', [0, 1])
-    
+
     # Setup parameters
     d_model = 8
     nhead = 2
-    
-    # Set up minimal config 
+
+    # Set up minimal config
     init_div_is_residual = True
     div_is_residual = 2.0
-    
+
     # Create regular MultiheadAttention
     regular_mha = nn.MultiheadAttention(
         embed_dim=d_model,
         num_heads=nhead,
-        kdim=d_model if qkv_same_dim else d_model*2,
-        vdim=d_model if qkv_same_dim else d_model*2,
+        kdim=d_model if qkv_same_dim else d_model * 2,
+        vdim=d_model if qkv_same_dim else d_model * 2,
         batch_first=True,
         add_bias_kv=not qkv_same_dim,
     )
-    
+
     # Create MultiheadAttention with DTensor parameters
     dtensor_mha = nn.MultiheadAttention(
         embed_dim=d_model,
         num_heads=nhead,
-        kdim=d_model if qkv_same_dim else d_model*2,
-        vdim=d_model if qkv_same_dim else d_model*2,
+        kdim=d_model if qkv_same_dim else d_model * 2,
+        vdim=d_model if qkv_same_dim else d_model * 2,
         batch_first=True,
         add_bias_kv=not qkv_same_dim,
     )
-    
+
     # Mark out_proj as residual if needed
     if is_residual:
         regular_mha.out_proj._is_residual = True
         dtensor_mha.out_proj._is_residual = True
-    
+
     # Convert parameters to DTensor
     if qkv_same_dim:
         # In case of same dimensions, in_proj_weight is used
@@ -526,7 +537,7 @@ def test_multihead_attention_init_dtensor_vs_tensor(qkv_same_dim: bool, is_resid
         dtensor_mha.bias_v = torch.nn.Parameter(
             distribute_tensor(dtensor_mha.bias_v, mesh, [Shard(0)]),
         )
-    
+
     # Convert out_proj parameters to DTensor
     dtensor_mha.out_proj.weight = torch.nn.Parameter(
         distribute_tensor(dtensor_mha.out_proj.weight, mesh, [Shard(0)]),
@@ -534,11 +545,17 @@ def test_multihead_attention_init_dtensor_vs_tensor(qkv_same_dim: bool, is_resid
     dtensor_mha.out_proj.bias = torch.nn.Parameter(
         distribute_tensor(dtensor_mha.out_proj.bias, mesh, [Shard(0)]),
     )
-    
+
     # Initialize both modules using multihead_attention_init
-    multihead_attention_init(regular_mha, init_arange_, d_model, init_div_is_residual, div_is_residual)
-    multihead_attention_init(dtensor_mha, init_arange_, d_model, init_div_is_residual, div_is_residual)
-    
+    multihead_attention_init(
+        regular_mha, init_arange_, d_model, init_div_is_residual,
+        div_is_residual
+    )
+    multihead_attention_init(
+        dtensor_mha, init_arange_, d_model, init_div_is_residual,
+        div_is_residual
+    )
+
     # Convert DTensor parameters to regular tensors for comparison
     if qkv_same_dim:
         # Compare in_proj_weight
@@ -553,7 +570,7 @@ def test_multihead_attention_init_dtensor_vs_tensor(qkv_same_dim: bool, is_resid
         dtensor_q_proj_weight = dtensor_mha.q_proj_weight.full_tensor()
         dtensor_k_proj_weight = dtensor_mha.k_proj_weight.full_tensor()
         dtensor_v_proj_weight = dtensor_mha.v_proj_weight.full_tensor()
-        
+
         assert torch.equal(regular_mha.q_proj_weight, dtensor_q_proj_weight), \
             f'regular q_proj_weight: {regular_mha.q_proj_weight} vs DTensor: {dtensor_q_proj_weight}'
         assert torch.equal(regular_mha.k_proj_weight, dtensor_k_proj_weight), \
@@ -566,21 +583,22 @@ def test_multihead_attention_init_dtensor_vs_tensor(qkv_same_dim: bool, is_resid
             f'regular bias_k: {regular_mha.bias_k} vs DTensor: {dtensor_bias_k}'
         assert torch.equal(regular_mha.bias_v, dtensor_bias_v), \
             f'regular bias_v: {regular_mha.bias_v} vs DTensor: {dtensor_bias_v}'
-    
+
     # Compare out_proj parameters
     dtensor_out_proj_weight = dtensor_mha.out_proj.weight.full_tensor()
     dtensor_out_proj_bias = dtensor_mha.out_proj.bias.full_tensor()
-    
+
     assert torch.equal(regular_mha.out_proj.weight, dtensor_out_proj_weight), \
         f'regular out_proj.weight: {regular_mha.out_proj.weight} vs DTensor: {dtensor_out_proj_weight}'
     assert torch.equal(regular_mha.out_proj.bias, dtensor_out_proj_bias), \
         f'regular out_proj.bias: {regular_mha.out_proj.bias} vs DTensor: {dtensor_out_proj_bias}'
-    
+
     # For residual case, verify scaling was applied correctly
     if is_residual:
         # The out_proj weight should be scaled by div_is_residual
-        expected_out_proj_weight = torch.arange(regular_mha.out_proj.weight.numel()).reshape(
-            regular_mha.out_proj.weight.shape).float() / div_is_residual
-        
+        expected_out_proj_weight = torch.arange(
+            regular_mha.out_proj.weight.numel()
+        ).reshape(regular_mha.out_proj.weight.shape).float() / div_is_residual
+
         assert torch.equal(dtensor_out_proj_weight, expected_out_proj_weight), \
             f'DTensor out_proj.weight was not scaled correctly: {dtensor_out_proj_weight} vs {expected_out_proj_weight}'

--- a/tests/models/utils/test_param_init_fns.py
+++ b/tests/models/utils/test_param_init_fns.py
@@ -239,9 +239,9 @@ def test_emb_padding_init(
 
 @pytest.mark.world_size(2)
 def test_fused_init_helper_dtensor_vs_tensor():
-    """Test that fused_param_init_helper produces the same results for a regular
-    tensor and a DTensor."""
-    # Create a simple device mesh for CPU
+    #Test that fused_param_init_helper produces the same results for a regular
+    # tensor and a DTensor.
+
     mesh = DeviceMesh('cpu', [0, 1])
 
     regular_tensor = torch.nn.Parameter(torch.zeros(4, 4))

--- a/tests/models/utils/test_param_init_fns.py
+++ b/tests/models/utils/test_param_init_fns.py
@@ -248,9 +248,7 @@ def init_arange_(weight: torch.Tensor) -> None:
 
 @pytest.mark.world_size(2)
 def test_fused_init_helper_dtensor_vs_tensor():
-    #Test that fused_param_init_helper produces the same results for a regular
-    # tensor and a DTensor.
-
+    # Create a simple device mesh for CPU
     mesh = DeviceMesh('cpu', [0, 1])
 
     regular_tensor = torch.nn.Parameter(torch.zeros(4, 4))
@@ -301,8 +299,6 @@ def test_fused_init_helper_dtensor_vs_tensor():
 @pytest.mark.world_size(2)
 @pytest.mark.parametrize('is_fused', [False, True])
 def test_fc_init_dtensor_vs_tensor(is_fused: bool):
-    """Test that fc_init initializes the same way for a regular linear layer
-    and a linear layer with DTensor parameters."""
     # Create a simple device mesh for CPU
     mesh = DeviceMesh('cpu', [0, 1])
     
@@ -377,8 +373,6 @@ def test_fc_init_dtensor_vs_tensor(is_fused: bool):
 
 @pytest.mark.world_size(2)
 def test_stacked_param_init_helper_dtensor_vs_tensor():
-    """Test that stacked_param_init_helper produces the same results for a regular
-    tensor and a DTensor."""
     # Create a simple device mesh for CPU
     mesh = DeviceMesh('cpu', [0, 1])
 
@@ -409,7 +403,7 @@ def test_stacked_param_init_helper_dtensor_vs_tensor():
 
     # Verify results are identical
     assert torch.equal(regular_tensor, dtensor_result), \
-        f"stacked_param_init_helper produced different results for regular tensor: {regular_tensor} vs DTensor: {dtensor_result}"
+        f'stacked_param_init_helper produced different results for regular tensor: {regular_tensor} vs DTensor: {dtensor_result}'
 
     # Check that each slice along stack_dim was separately initialized as expected
     rows, cols = regular_tensor.shape
@@ -429,8 +423,6 @@ def test_stacked_param_init_helper_dtensor_vs_tensor():
 @pytest.mark.parametrize('use_padding_idx', [False, True])
 @pytest.mark.parametrize('init_type', ['std', 'uniform', 'default'])
 def test_embedding_init_dtensor_vs_tensor(use_padding_idx: bool, init_type: str):
-    """Test that embedding_init initializes the same way for a regular embedding layer
-    and an embedding layer with DTensor parameters."""
     # Create a simple device mesh for CPU
     mesh = DeviceMesh('cpu', [0, 1])
     
@@ -472,8 +464,6 @@ def test_embedding_init_dtensor_vs_tensor(use_padding_idx: bool, init_type: str)
 @pytest.mark.parametrize('qkv_same_dim', [True, False])
 @pytest.mark.parametrize('is_residual', [True, False])
 def test_multihead_attention_init_dtensor_vs_tensor(qkv_same_dim: bool, is_residual: bool):
-    """Test that multihead_attention_init initializes the same way for a regular 
-    MultiheadAttention and one with DTensor parameters."""
     # Create a simple device mesh for CPU
     mesh = DeviceMesh('cpu', [0, 1])
     

--- a/tests/models/utils/test_param_init_fns.py
+++ b/tests/models/utils/test_param_init_fns.py
@@ -20,7 +20,7 @@ from torch.distributed._tensor import (
 
 from llmfoundry.layers_registry import param_init_fns
 from llmfoundry.models.utils import generic_param_init_fn_
-from llmfoundry.models.utils.param_init_fns import fc_init, fused_param_init_helper
+from llmfoundry.models.utils.param_init_fns import fc_init, fused_param_init_helper, stacked_param_init_helper, embedding_init, multihead_attention_init
 
 
 class MLP(nn.Module):
@@ -373,3 +373,221 @@ def test_fc_init_dtensor_vs_tensor(is_fused: bool):
     # Bias should be all zeros in both cases
     assert torch.all(dtensor_bias == 0), \
         f'DTensor bias was not initialized correctly: {dtensor_bias}'
+
+
+@pytest.mark.world_size(2)
+def test_stacked_param_init_helper_dtensor_vs_tensor():
+    """Test that stacked_param_init_helper produces the same results for a regular
+    tensor and a DTensor."""
+    # Create a simple device mesh for CPU
+    mesh = DeviceMesh('cpu', [0, 1])
+
+    regular_tensor = torch.nn.Parameter(torch.zeros(4, 4))
+
+    dtensor = torch.nn.Parameter(
+        distribute_tensor(regular_tensor, mesh, [Shard(0)]),
+    )
+
+    # Choose a stack dimension
+    stack_dim = 0
+
+    # Initialize both tensors using stacked_param_init_helper
+    stacked_param_init_helper(regular_tensor, init_arange_, stack_dim)
+    stacked_param_init_helper(dtensor, init_arange_, stack_dim)
+
+    assert isinstance(
+        dtensor,
+        torch.nn.Parameter,
+    ), f'param is not an nn.Parameter anymore: {type(dtensor)}'
+    assert isinstance(
+        dtensor,
+        DTensor,
+    ), f'DTensor is not a DTensor: {type(dtensor)}'
+
+    # For comparison, convert DTensor to regular tensor
+    dtensor_result = dtensor.full_tensor()
+
+    # Verify results are identical
+    assert torch.equal(regular_tensor, dtensor_result), \
+        f"stacked_param_init_helper produced different results for regular tensor: {regular_tensor} vs DTensor: {dtensor_result}"
+
+    # Check that each slice along stack_dim was separately initialized as expected
+    rows, cols = regular_tensor.shape
+    for idx in range(regular_tensor.size(stack_dim)):
+        if stack_dim == 0:
+            expected_slice = torch.arange(cols).float()
+            actual_slice = regular_tensor[idx]
+        else:
+            expected_slice = torch.arange(rows).float()
+            actual_slice = regular_tensor[:, idx]
+        
+        assert torch.equal(actual_slice, expected_slice), \
+            f'Slice {idx} was not initialized correctly: {actual_slice} vs {expected_slice}'
+
+
+@pytest.mark.world_size(2)
+@pytest.mark.parametrize('use_padding_idx', [False, True])
+@pytest.mark.parametrize('init_type', ['std', 'uniform', 'default'])
+def test_embedding_init_dtensor_vs_tensor(use_padding_idx: bool, init_type: str):
+    """Test that embedding_init initializes the same way for a regular embedding layer
+    and an embedding layer with DTensor parameters."""
+    # Create a simple device mesh for CPU
+    mesh = DeviceMesh('cpu', [0, 1])
+    
+    # Setup parameters
+    vocab_size, embed_dim = 10, 4
+    padding_idx = 2 if use_padding_idx else None
+    
+    # Create a regular embedding layer
+    regular_embedding = nn.Embedding(vocab_size, embed_dim, padding_idx=padding_idx)
+    
+    # Create an embedding layer with DTensor parameters
+    dtensor_embedding = nn.Embedding(vocab_size, embed_dim, padding_idx=padding_idx)
+    
+    # Convert the weight to DTensor
+    dtensor_embedding.weight = torch.nn.Parameter(
+        distribute_tensor(dtensor_embedding.weight, mesh, [Shard(0)]),
+    )
+    
+    # Initialize both modules using embedding_init
+    embedding_init(regular_embedding, init_arange_, None, None)
+    embedding_init(dtensor_embedding, init_arange_, None, None)
+    
+    # For comparison, convert DTensor to regular tensor
+    dtensor_weight = dtensor_embedding.weight.full_tensor()
+    
+    # Verify weight results are identical
+    assert torch.equal(regular_embedding.weight, dtensor_weight), \
+        f'regular tensor: {regular_embedding.weight} vs DTensor: {dtensor_weight}'
+    
+    # Additional test for padding_idx
+    if padding_idx is not None:
+        assert torch.all(regular_embedding.weight[padding_idx] == 0), \
+            f'Regular embedding padding not initialized to zero: {regular_embedding.weight[padding_idx]}'
+        assert torch.all(dtensor_weight[padding_idx] == 0), \
+            f'DTensor embedding padding not initialized to zero: {dtensor_weight[padding_idx]}'
+
+
+@pytest.mark.world_size(2)
+@pytest.mark.parametrize('qkv_same_dim', [True, False])
+@pytest.mark.parametrize('is_residual', [True, False])
+def test_multihead_attention_init_dtensor_vs_tensor(qkv_same_dim: bool, is_residual: bool):
+    """Test that multihead_attention_init initializes the same way for a regular 
+    MultiheadAttention and one with DTensor parameters."""
+    # Create a simple device mesh for CPU
+    mesh = DeviceMesh('cpu', [0, 1])
+    
+    # Setup parameters
+    d_model = 8
+    nhead = 2
+    
+    # Set up minimal config 
+    init_div_is_residual = True
+    div_is_residual = 2.0
+    
+    # Create regular MultiheadAttention
+    regular_mha = nn.MultiheadAttention(
+        embed_dim=d_model,
+        num_heads=nhead,
+        kdim=d_model if qkv_same_dim else d_model*2,
+        vdim=d_model if qkv_same_dim else d_model*2,
+        batch_first=True,
+    )
+    
+    # Create MultiheadAttention with DTensor parameters
+    dtensor_mha = nn.MultiheadAttention(
+        embed_dim=d_model,
+        num_heads=nhead,
+        kdim=d_model if qkv_same_dim else d_model*2,
+        vdim=d_model if qkv_same_dim else d_model*2,
+        batch_first=True,
+    )
+    
+    # Mark out_proj as residual if needed
+    if is_residual:
+        regular_mha.out_proj._is_residual = True
+        dtensor_mha.out_proj._is_residual = True
+    
+    # Convert parameters to DTensor
+    if qkv_same_dim:
+        # In case of same dimensions, in_proj_weight is used
+        dtensor_mha.in_proj_weight = torch.nn.Parameter(
+            distribute_tensor(dtensor_mha.in_proj_weight, mesh, [Shard(0)]),
+        )
+        dtensor_mha.in_proj_bias = torch.nn.Parameter(
+            distribute_tensor(dtensor_mha.in_proj_bias, mesh, [Shard(0)]),
+        )
+    else:
+        # In case of different dimensions, q/k/v_proj_weight are used
+        dtensor_mha.q_proj_weight = torch.nn.Parameter(
+            distribute_tensor(dtensor_mha.q_proj_weight, mesh, [Shard(0)]),
+        )
+        dtensor_mha.k_proj_weight = torch.nn.Parameter(
+            distribute_tensor(dtensor_mha.k_proj_weight, mesh, [Shard(0)]),
+        )
+        dtensor_mha.v_proj_weight = torch.nn.Parameter(
+            distribute_tensor(dtensor_mha.v_proj_weight, mesh, [Shard(0)]),
+        )
+        dtensor_mha.in_proj_bias = torch.nn.Parameter(
+            distribute_tensor(dtensor_mha.in_proj_bias, mesh, [Shard(0)]),
+        )
+    
+    # Convert out_proj parameters to DTensor
+    dtensor_mha.out_proj.weight = torch.nn.Parameter(
+        distribute_tensor(dtensor_mha.out_proj.weight, mesh, [Shard(0)]),
+    )
+    dtensor_mha.out_proj.bias = torch.nn.Parameter(
+        distribute_tensor(dtensor_mha.out_proj.bias, mesh, [Shard(0)]),
+    )
+    
+    # Initialize both modules using multihead_attention_init
+    multihead_attention_init(regular_mha, init_arange_, d_model, init_div_is_residual, div_is_residual)
+    multihead_attention_init(dtensor_mha, init_arange_, d_model, init_div_is_residual, div_is_residual)
+    
+    # Convert DTensor parameters to regular tensors for comparison
+    if qkv_same_dim:
+        # Compare in_proj_weight
+        dtensor_in_proj_weight = dtensor_mha.in_proj_weight.full_tensor()
+        assert torch.equal(regular_mha.in_proj_weight, dtensor_in_proj_weight), \
+            f'regular in_proj_weight: {regular_mha.in_proj_weight} vs DTensor: {dtensor_in_proj_weight}'
+    else:
+        # Compare q/k/v_proj_weight
+        dtensor_q_proj_weight = dtensor_mha.q_proj_weight.full_tensor()
+        dtensor_k_proj_weight = dtensor_mha.k_proj_weight.full_tensor()
+        dtensor_v_proj_weight = dtensor_mha.v_proj_weight.full_tensor()
+        
+        assert torch.equal(regular_mha.q_proj_weight, dtensor_q_proj_weight), \
+            f'regular q_proj_weight: {regular_mha.q_proj_weight} vs DTensor: {dtensor_q_proj_weight}'
+        assert torch.equal(regular_mha.k_proj_weight, dtensor_k_proj_weight), \
+            f'regular k_proj_weight: {regular_mha.k_proj_weight} vs DTensor: {dtensor_k_proj_weight}'
+        assert torch.equal(regular_mha.v_proj_weight, dtensor_v_proj_weight), \
+            f'regular v_proj_weight: {regular_mha.v_proj_weight} vs DTensor: {dtensor_v_proj_weight}'
+    
+    # Compare in_proj_bias
+    dtensor_in_proj_bias = dtensor_mha.in_proj_bias.full_tensor()
+    assert torch.equal(regular_mha.in_proj_bias, dtensor_in_proj_bias), \
+        f'regular in_proj_bias: {regular_mha.in_proj_bias} vs DTensor: {dtensor_in_proj_bias}'
+    
+    # Compare out_proj parameters
+    dtensor_out_proj_weight = dtensor_mha.out_proj.weight.full_tensor()
+    dtensor_out_proj_bias = dtensor_mha.out_proj.bias.full_tensor()
+    
+    assert torch.equal(regular_mha.out_proj.weight, dtensor_out_proj_weight), \
+        f'regular out_proj.weight: {regular_mha.out_proj.weight} vs DTensor: {dtensor_out_proj_weight}'
+    assert torch.equal(regular_mha.out_proj.bias, dtensor_out_proj_bias), \
+        f'regular out_proj.bias: {regular_mha.out_proj.bias} vs DTensor: {dtensor_out_proj_bias}'
+    
+    # Verify biases are zeros
+    assert torch.all(dtensor_in_proj_bias == 0), \
+        f'DTensor in_proj_bias not initialized to zero: {dtensor_in_proj_bias}'
+    assert torch.all(dtensor_out_proj_bias == 0), \
+        f'DTensor out_proj.bias not initialized to zero: {dtensor_out_proj_bias}'
+    
+    # For residual case, verify scaling was applied correctly
+    if is_residual:
+        # The out_proj weight should be scaled by div_is_residual
+        expected_out_proj_weight = torch.arange(regular_mha.out_proj.weight.numel()).reshape(
+            regular_mha.out_proj.weight.shape).float() / div_is_residual
+        
+        assert torch.equal(dtensor_out_proj_weight, expected_out_proj_weight), \
+            f'DTensor out_proj.weight was not scaled correctly: {dtensor_out_proj_weight} vs {expected_out_proj_weight}'

--- a/tests/models/utils/test_param_init_fns.py
+++ b/tests/models/utils/test_param_init_fns.py
@@ -324,7 +324,7 @@ def test_fc_init_dtensor_vs_tensor(is_fused: bool):
         distribute_tensor(dtensor_linear.bias, mesh, [Shard(0)]),
     )
 
-    # Mark one of the layers as residual to test the residual path
+    # Test the residual path
     regular_linear._is_residual = True
     dtensor_linear._is_residual = True
 

--- a/tests/models/utils/test_param_init_fns.py
+++ b/tests/models/utils/test_param_init_fns.py
@@ -20,10 +20,13 @@ from torch.distributed._tensor import (
 
 from llmfoundry.layers_registry import param_init_fns
 from llmfoundry.models.utils import generic_param_init_fn_
-from llmfoundry.models.utils.param_init_fns import (embedding_init, fc_init,
-                                                    fused_param_init_helper,
-                                                    multihead_attention_init,
-                                                    stacked_param_init_helper,)
+from llmfoundry.models.utils.param_init_fns import (
+    embedding_init,
+    fc_init,
+    fused_param_init_helper,
+    multihead_attention_init,
+    stacked_param_init_helper,
+)
 
 
 class MLP(nn.Module):
@@ -362,7 +365,7 @@ def test_fc_init_dtensor_vs_tensor(is_fused: bool):
     else:
         # For non-fused case, the initialization is simpler
         expected_weight = torch.arange(regular_linear.weight.numel()).reshape(
-            regular_linear.weight.shape
+            regular_linear.weight.shape,
         ).float() / div_is_residual
     assert torch.equal(
         dtensor_weight,
@@ -426,7 +429,8 @@ def test_stacked_param_init_helper_dtensor_vs_tensor():
 @pytest.mark.parametrize('use_padding_idx', [False, True])
 @pytest.mark.parametrize('init_type', ['std', 'uniform', 'default'])
 def test_embedding_init_dtensor_vs_tensor(
-    use_padding_idx: bool, init_type: str
+    use_padding_idx: bool,
+    init_type: str,
 ):
     # Create a simple device mesh for CPU
     mesh = DeviceMesh('cpu', [0, 1])
@@ -437,12 +441,16 @@ def test_embedding_init_dtensor_vs_tensor(
 
     # Create a regular embedding layer
     regular_embedding = nn.Embedding(
-        vocab_size, embed_dim, padding_idx=padding_idx
+        vocab_size,
+        embed_dim,
+        padding_idx=padding_idx,
     )
 
     # Create an embedding layer with DTensor parameters
     dtensor_embedding = nn.Embedding(
-        vocab_size, embed_dim, padding_idx=padding_idx
+        vocab_size,
+        embed_dim,
+        padding_idx=padding_idx,
     )
 
     # Convert the weight to DTensor
@@ -473,7 +481,8 @@ def test_embedding_init_dtensor_vs_tensor(
 @pytest.mark.parametrize('qkv_same_dim', [True, False])
 @pytest.mark.parametrize('is_residual', [True, False])
 def test_multihead_attention_init_dtensor_vs_tensor(
-    qkv_same_dim: bool, is_residual: bool
+    qkv_same_dim: bool,
+    is_residual: bool,
 ):
     # Create a simple device mesh for CPU
     mesh = DeviceMesh('cpu', [0, 1])
@@ -548,12 +557,18 @@ def test_multihead_attention_init_dtensor_vs_tensor(
 
     # Initialize both modules using multihead_attention_init
     multihead_attention_init(
-        regular_mha, init_arange_, d_model, init_div_is_residual,
-        div_is_residual
+        regular_mha,
+        init_arange_,
+        d_model,
+        init_div_is_residual,
+        div_is_residual,
     )
     multihead_attention_init(
-        dtensor_mha, init_arange_, d_model, init_div_is_residual,
-        div_is_residual
+        dtensor_mha,
+        init_arange_,
+        d_model,
+        init_div_is_residual,
+        div_is_residual,
     )
 
     # Convert DTensor parameters to regular tensors for comparison
@@ -597,7 +612,7 @@ def test_multihead_attention_init_dtensor_vs_tensor(
     if is_residual:
         # The out_proj weight should be scaled by div_is_residual
         expected_out_proj_weight = torch.arange(
-            regular_mha.out_proj.weight.numel()
+            regular_mha.out_proj.weight.numel(),
         ).reshape(regular_mha.out_proj.weight.shape).float() / div_is_residual
 
         assert torch.equal(dtensor_out_proj_weight, expected_out_proj_weight), \

--- a/tests/tp/test_tp_strategies.py
+++ b/tests/tp/test_tp_strategies.py
@@ -169,7 +169,12 @@ def test_tp_train(
     # Compare loss and expected loss for TP
     import numpy as np
     expected_tp_loss = np.array([
-        11.779396, 11.750473, 11.720526, 11.778467, 11.735085, 11.741872
+        11.779396,
+        11.750473,
+        11.720526,
+        11.778467,
+        11.735085,
+        11.741872,
     ])
     np.testing.assert_allclose(tp_loss, expected_tp_loss)
 

--- a/tests/tp/test_tp_strategies.py
+++ b/tests/tp/test_tp_strategies.py
@@ -169,12 +169,7 @@ def test_tp_train(
     # Compare loss and expected loss for TP
     import numpy as np
     expected_tp_loss = np.array([
-        11.846275,
-        11.854343,
-        11.881471,
-        11.873639,
-        11.814651,
-        11.809362,
+        11.779396, 11.750473, 11.720526, 11.778467, 11.735085, 11.741872
     ])
     np.testing.assert_allclose(tp_loss, expected_tp_loss)
 


### PR DESCRIPTION
Existing initialization utils can not handle DTensor slice properly, as DTensor slice could be a new DTensor (with a different sharding layout/placement) instead of a view to the original Tensor.

Solution: Init on DTensor.full_tensor and then copy the shard of the full_tensor to original Dtensor.

Test:
1. Added unit test
2. Manually tested param norm are the same between FSDP1 and FSDP2
3. 7B Pretrain Loss:
green: FSDP1
violet: FSDP2 w/o this PR
red: FSDP2 w/ this PR
w/ this PR FSDP2 and FSDP1 are bits wise the same at first 2 steps
![loss_train_total (4)](https://github.com/user-attachments/assets/0b36305a-78c4-4f72-a591-a8cdfee54190)
4. Init time:
FSDP1:  Trainer construction took 2.95 seconds
FSDP2 w/ this PR:  Trainer construction took 4.05 seconds, Prepare FSDP2 took 0.12 seconds, Meta Init Device took 1.61 seconds
FSDP2 w/o this PR:  Trainer construction took 3.99 seconds, Prepare FSDP2 took 0.12 seconds, Meta Init Device took 1.56 seconds
Per iteration time: 1.84 seconds
