### PR TITLE
Bump docformatter for python3.12 and change blank_line_before_module_docstring = false

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,7 +73,7 @@ repos:
     - --allow-past-years
     types: [python]
 - repo: https://github.com/PyCQA/docformatter
-  rev: v1.5.0
+  rev: v1.7.7
   hooks:
   - id: docformatter
     args: [--in-place, --wrap-summaries=80, --wrap-descriptions=80]

--- a/llmfoundry/_version.py
+++ b/llmfoundry/_version.py
@@ -1,6 +1,5 @@
 # Copyright 2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
-
 """The LLM Foundry Version."""
 
 __version__ = '0.21.0.dev0'

--- a/llmfoundry/callbacks/async_eval_callback.py
+++ b/llmfoundry/callbacks/async_eval_callback.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Run the eval loop asynchronously as part of a MosaicML platform run.
 
 This callback is currently experimental. The API may change in the future.

--- a/llmfoundry/callbacks/curriculum_learning_callback.py
+++ b/llmfoundry/callbacks/curriculum_learning_callback.py
@@ -1,6 +1,5 @@
 # Copyright 2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Enable curriculum learning by specifying a schedule of datasets to train on.
 
 This module provides a CurriculumLearning callback that allows for dynamic

--- a/llmfoundry/callbacks/dataset_swap_callback.py
+++ b/llmfoundry/callbacks/dataset_swap_callback.py
@@ -1,6 +1,5 @@
 # Copyright 2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Enable curriculum learning by resuming with a different dataset.
 
 This callback is currently experimental. The API may change without warning in

--- a/llmfoundry/callbacks/eval_gauntlet_callback.py
+++ b/llmfoundry/callbacks/eval_gauntlet_callback.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Aggregate ICL evals into composite scores."""
 
 import logging

--- a/llmfoundry/callbacks/eval_output_logging_callback.py
+++ b/llmfoundry/callbacks/eval_output_logging_callback.py
@@ -1,6 +1,5 @@
 # Copyright 2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Log model outputs and expected outputs during ICL evaluation."""
 
 import warnings

--- a/llmfoundry/callbacks/fdiff_callback.py
+++ b/llmfoundry/callbacks/fdiff_callback.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Monitor rate of change of loss."""
 from __future__ import annotations
 

--- a/llmfoundry/callbacks/kill_loss_spike_callback.py
+++ b/llmfoundry/callbacks/kill_loss_spike_callback.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Track training runs for loss spikes or persistently high training loss."""
 from __future__ import annotations
 

--- a/llmfoundry/callbacks/log_mbmoe_tok_per_expert_callback.py
+++ b/llmfoundry/callbacks/log_mbmoe_tok_per_expert_callback.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Log tokens per expert for MegaBlocks MoE."""
 from __future__ import annotations
 

--- a/llmfoundry/command_utils/data_prep/convert_dataset_hf.py
+++ b/llmfoundry/command_utils/data_prep/convert_dataset_hf.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Streaming dataset conversion scripts for C4 and The Pile."""
 import json
 import os

--- a/llmfoundry/command_utils/data_prep/convert_dataset_json.py
+++ b/llmfoundry/command_utils/data_prep/convert_dataset_json.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Streaming dataset conversion scripts for json files."""
 import os
 from enum import Enum

--- a/llmfoundry/data/contrastive_pairs/dataloader.py
+++ b/llmfoundry/data/contrastive_pairs/dataloader.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Dataset and dataloader for contrastive training.
 
 Build a StreamingPairsDataset dataset and dataloader for contrastive training.

--- a/llmfoundry/data/data.py
+++ b/llmfoundry/data/data.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Datasets for converting to MDS Shards."""
 import os
 import warnings

--- a/llmfoundry/data/dataloader.py
+++ b/llmfoundry/data/dataloader.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Dataloader builder utilities."""
 
 from typing import Any, Optional, Union

--- a/llmfoundry/data/finetuning/tasks.py
+++ b/llmfoundry/data/finetuning/tasks.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Includes code for task-specific seq-to-seq data formatting.
 
 This file provides some templates/examples of preprocessing functions

--- a/llmfoundry/data/text_data.py
+++ b/llmfoundry/data/text_data.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Build a StreamingTextDataset dataset and dataloader for training."""
 
 import inspect

--- a/llmfoundry/eval/datasets/__init__.py
+++ b/llmfoundry/eval/datasets/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Natively supported in-context learning evaluation datasets."""
 
 from llmfoundry.eval.datasets.in_context_learning_evaluation import (

--- a/llmfoundry/eval/datasets/utils.py
+++ b/llmfoundry/eval/datasets/utils.py
@@ -1,6 +1,5 @@
 # Copyright 2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Utility and helper functions for datasets."""
 from __future__ import annotations
 

--- a/llmfoundry/eval/metrics/__init__.py
+++ b/llmfoundry/eval/metrics/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
-
 """A collection of common torchmetrics."""
 
 from llmfoundry.eval.metrics.nlp import (

--- a/llmfoundry/eval/metrics/nlp.py
+++ b/llmfoundry/eval/metrics/nlp.py
@@ -1,6 +1,5 @@
 # Copyright 2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
-
 """A collection of common torchmetrics for NLP tasks."""
 
 import copy
@@ -130,7 +129,8 @@ class InContextLearningGenerationExactMatchAccuracy(InContextLearningMetric):
     def normalize_answer(self, answer: str):
         """Lower text and remove punctuation, articles and extra whitespace.
 
-        Copied from https://github.com/mandarjoshi90/triviaqa/blob/master/evaluation/triviaqa_evaluation.py
+        Copied from
+        https://github.com/mandarjoshi90/triviaqa/blob/master/evaluation/triviaqa_evaluation.py
         """
 
         def remove_articles(text: str) -> str:

--- a/llmfoundry/models/hf/hf_base.py
+++ b/llmfoundry/models/hf/hf_base.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Re-usable :class:`.ComposerModel` for LLM HF Models."""
 
 from __future__ import annotations

--- a/llmfoundry/models/hf/hf_causal_lm.py
+++ b/llmfoundry/models/hf/hf_causal_lm.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Implements a Hugging Causal LM wrapped inside a :class:`.ComposerModel`."""
 
 import logging

--- a/llmfoundry/models/hf/hf_t5.py
+++ b/llmfoundry/models/hf/hf_t5.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Implements a Hugging Face T5 wrapped inside a :class:`.ComposerModel`."""
 
 from __future__ import annotations

--- a/llmfoundry/models/inference_api_wrapper/openai_causal_lm.py
+++ b/llmfoundry/models/inference_api_wrapper/openai_causal_lm.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Implements a OpenAI chat and causal LM inference API wrappers."""
 
 import logging

--- a/llmfoundry/models/layers/attention.py
+++ b/llmfoundry/models/layers/attention.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Attention layers."""
 
 import copy

--- a/llmfoundry/models/layers/blocks.py
+++ b/llmfoundry/models/layers/blocks.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
-
 """GPT Blocks used for the GPT Model."""
 
 import copy

--- a/llmfoundry/models/layers/ffn.py
+++ b/llmfoundry/models/layers/ffn.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
-
 """MPT Blocks used for the MPT Model."""
 
 import logging

--- a/llmfoundry/models/llm_embed/modeling_llm_embed.py
+++ b/llmfoundry/models/llm_embed/modeling_llm_embed.py
@@ -1,10 +1,9 @@
 # Copyright 2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
-
 """LLM Contrastive Embedding Model.
 
-Implements InfoNCE Loss using the MPT architecture. The resulting model can
-be used as a vector embedding model.
+Implements InfoNCE Loss using the MPT architecture. The resulting model can be
+used as a vector embedding model.
 
 This is inspired by Microsoft Research's unilm repository
 https://github.com/microsoft/unilm
@@ -297,8 +296,10 @@ class ContrastiveModel(HuggingFaceModel):
     def _cat_gather(self, t: torch.Tensor, group: Any = None) -> torch.Tensor:
         """Applies an all gather operation necessary for InfoNCELoss.
 
-        See https://github.com/pytorch/pytorch/blob/63d5e9221bedd1546b7d364b5ce4171547db12a9/torch/distributed/nn/functional.py#L314
-        as well as https://github.com/pytorch/pytorch/issues/121587#issuecomment-1989070351
+        See
+        https://github.com/pytorch/pytorch/blob/63d5e9221bedd1546b7d364b5ce4171547db12a9/torch/distributed/nn/functional.py#L314
+         as well as
+        https://github.com/pytorch/pytorch/issues/121587#issuecomment-1989070351
         """
         if self.use_legacy_gradient_passthrough:
             all_tensors = list(dist.all_gather(t, group))

--- a/llmfoundry/models/mpt/configuration_mpt.py
+++ b/llmfoundry/models/mpt/configuration_mpt.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
-
 """A HuggingFace-style model configuration."""
 
 import copy

--- a/llmfoundry/models/mpt/modeling_mpt.py
+++ b/llmfoundry/models/mpt/modeling_mpt.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
-
 """A simple, flexible implementation of a GPT model.
 
 Inspired by https://github.com/karpathy/minGPT/blob/master/mingpt/model.py
@@ -1375,7 +1374,8 @@ class MPTForCausalLM(MPTPreTrainedModel):
     ) -> list[tuple[torch.Tensor, ...]]:
         """Used by HuggingFace generate when using beam search with kv-caching.
 
-        See https://github.com/huggingface/transformers/blob/3ec7a47664ebe40c40f4b722f6bb1cd30c3821ec/src/transformers/models/gpt2/modeling_gpt2.py#L1122-L1133
+        See
+        https://github.com/huggingface/transformers/blob/3ec7a47664ebe40c40f4b722f6bb1cd30c3821ec/src/transformers/models/gpt2/modeling_gpt2.py#L1122-L1133
         for an example in transformers.
         """
         reordered_past = []

--- a/llmfoundry/models/utils/config_defaults.py
+++ b/llmfoundry/models/utils/config_defaults.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Defaults for MPT model component configs."""
 
 ffn_config_defaults: dict = {

--- a/llmfoundry/models/utils/config_moe_args.py
+++ b/llmfoundry/models/utils/config_moe_args.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Helper function to configure MPT with MoEs."""
 
 import inspect

--- a/llmfoundry/models/utils/mpt_param_count.py
+++ b/llmfoundry/models/utils/mpt_param_count.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Helper functions for computing parameter counts for MPT model.
 
 Use if generic `sum(p.numel() for p in self.parameters())`

--- a/llmfoundry/models/utils/param_init_fns.py
+++ b/llmfoundry/models/utils/param_init_fns.py
@@ -854,9 +854,10 @@ def neox_param_init_fn_(
 ) -> None:
     """From section 2.3.1 of GPT-NeoX-20B:
 
-    An Open-Source AutoregressiveLanguage Model — Black et. al. (2022)
-    see https://github.com/EleutherAI/gpt-neox/blob/9610391ab319403cef079b438edd016a2443af54/megatron/model/init_functions.py#L151
-    and https://github.com/EleutherAI/gpt-neox/blob/main/megatron/model/transformer.py
+    An Open-Source AutoregressiveLanguage Model — Black et. al. (2022) see
+    https://github.com/EleutherAI/gpt-neox/blob/9610391ab319403cef079b438edd016a2443af54/megatron/model/init_functions.py#L151
+     and
+    https://github.com/EleutherAI/gpt-neox/blob/main/megatron/model/transformer.py
     """
     del kwargs  # unused, just to capture any extra args from the config
     residual_div = n_layers / math.sqrt(10)  # small std / wang std

--- a/llmfoundry/optim/scheduler.py
+++ b/llmfoundry/optim/scheduler.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Experimental learning rate schedulers used for training LLMs."""
 
 import textwrap

--- a/llmfoundry/utils/checkpoint_conversion_helpers.py
+++ b/llmfoundry/utils/checkpoint_conversion_helpers.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Helper methods for the checkpoint conversion scripts.
 
 The checkpoint conversion scripts are located in the

--- a/llmfoundry/utils/exceptions.py
+++ b/llmfoundry/utils/exceptions.py
@@ -1,6 +1,5 @@
 # Copyright 2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Custom exceptions for the LLMFoundry."""
 from typing import Any, Literal, Optional, Union
 

--- a/llmfoundry/utils/model_download_utils.py
+++ b/llmfoundry/utils/model_download_utils.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Utility functions for downloading models."""
 import copy
 import logging

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,7 +179,7 @@ blank_lines_around_top_level_definition = 2
 blank_line_before_class_docstring = false
 
 # Insert a blank line before a module docstring.
-blank_line_before_module_docstring = true
+blank_line_before_module_docstring = false
 
 # Insert a blank line before a 'def' or 'class' immediately nested
 # within another 'def' or 'class'. For example:

--- a/scripts/data_prep/convert_dataset_hf.py
+++ b/scripts/data_prep/convert_dataset_hf.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Streaming dataset conversion scripts for C4 and The Pile."""
 from argparse import ArgumentParser, Namespace
 

--- a/scripts/data_prep/convert_dataset_json.py
+++ b/scripts/data_prep/convert_dataset_json.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Streaming dataset conversion scripts for json files."""
 from argparse import ArgumentParser, Namespace
 

--- a/scripts/inference/convert_hf_mpt_to_ft.py
+++ b/scripts/inference/convert_hf_mpt_to_ft.py
@@ -14,7 +14,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Convert MPT model checkpoint to FT format.
 
 It's a modified version of

--- a/scripts/inference/convert_hf_to_onnx.py
+++ b/scripts/inference/convert_hf_to_onnx.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Basic HuggingFace -> ONNX export script.
 
 This scripts show a basic HuggingFace -> ONNX export workflow. This works for a MPT model

--- a/scripts/inference/endpoint_generate.py
+++ b/scripts/inference/endpoint_generate.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Batch generate text completion results from an endpoint.
 
 Warning: This script is experimental and could change or be removed at any time

--- a/scripts/inference/run_mpt_with_ft.py
+++ b/scripts/inference/run_mpt_with_ft.py
@@ -15,7 +15,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Run MPT model with FT.
 
 This script is a modified version of

--- a/scripts/misc/download_model.py
+++ b/scripts/misc/download_model.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Script to download model weights from Hugging Face Hub or a cache server.
 
 Download from Hugging Face Hub:

--- a/scripts/misc/profile_packing.py
+++ b/scripts/misc/profile_packing.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Script to profile example packing."""
 import os
 

--- a/scripts/train/finetune_example/preprocessing.py
+++ b/scripts/train/finetune_example/preprocessing.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
-
 r"""Example custom preprocessing function.
 
 This is here to help illustrate the way to set up finetuning

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 # Copyright 2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
-
 """MosaicML LLM Foundry package setup."""
 
 import copy


### PR DESCRIPTION
Bumping docformatter to v1.7.7 and change yapf setting to resolve conflict between docformatter and yapf.

Other files (outside of precommit and pyproject.toml) are auto-formatted by pre-commit