### PR TITLE
Configurable shard size

### DIFF
--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -219,6 +219,11 @@ def _log_model_with_multi_process(
 class HuggingFaceCheckpointer(Callback):
     """Save a huggingface formatted checkpoint during training.
 
+    The shard size for saving a checkpoint can be controlled by setting the
+    environment variable ``LLM_FOUNDRY_NON_REGISTER_HF_MAX_SHARD_SIZE``.
+    Documentation for this parameter can be found at
+    https://huggingface.co/docs/transformers/en/main_classes/model#transformers.PreTrainedModel.push_to_hub.max_shard_size
+
     Args:
         save_folder (str): Top level folder to save checkpoints to (can be a
             URI). It is likely that this would be the same as your save_folder.

--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -842,10 +842,12 @@ class HuggingFaceCheckpointer(Callback):
                     True,
                 ) if is_te_imported and state.precision == Precision.AMP_FP8 else contextlib.nullcontext(
                 )
+
+                _NON_MLFLOW_HF_MAX_SHARD_SIZE = os.environ.get('LLM_FOUNDRY_NON_MLFLOW_HF_MAX_SHARD_SIZE', '1GB')
                 with context_manager:
                     new_model_instance.save_pretrained(
                         temp_save_dir,
-                        max_shard_size='1GB',
+                        max_shard_size=_NON_MLFLOW_HF_MAX_SHARD_SIZE,
                     )
                 if original_tokenizer is not None:  # type: ignore
                     assert isinstance(

--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -844,7 +844,7 @@ class HuggingFaceCheckpointer(Callback):
                 )
 
                 _NON_MLFLOW_HF_MAX_SHARD_SIZE = os.environ.get(
-                    'LLM_FOUNDRY_NON_MLFLOW_HF_MAX_SHARD_SIZE', '1GB'
+                    'LLM_FOUNDRY_NON_REGISTER_HF_MAX_SHARD_SIZE', '1GB'
                 )
                 with context_manager:
                     new_model_instance.save_pretrained(

--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -843,7 +843,9 @@ class HuggingFaceCheckpointer(Callback):
                 ) if is_te_imported and state.precision == Precision.AMP_FP8 else contextlib.nullcontext(
                 )
 
-                _NON_MLFLOW_HF_MAX_SHARD_SIZE = os.environ.get('LLM_FOUNDRY_NON_MLFLOW_HF_MAX_SHARD_SIZE', '1GB')
+                _NON_MLFLOW_HF_MAX_SHARD_SIZE = os.environ.get(
+                    'LLM_FOUNDRY_NON_MLFLOW_HF_MAX_SHARD_SIZE', '1GB'
+                )
                 with context_manager:
                     new_model_instance.save_pretrained(
                         temp_save_dir,

--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -220,7 +220,7 @@ class HuggingFaceCheckpointer(Callback):
     """Save a huggingface formatted checkpoint during training.
 
     The shard size for saving a checkpoint can be controlled by setting the
-    environment variable ``LLM_FOUNDRY_NON_REGISTER_HF_MAX_SHARD_SIZE``.
+    environment variable ``LLM_FOUNDRY_SAVE_FOLDER_HF_MAX_SHARD_SIZE``.
     Documentation for this parameter can be found at
     https://huggingface.co/docs/transformers/en/main_classes/model#transformers.PreTrainedModel.push_to_hub.max_shard_size
 
@@ -848,14 +848,15 @@ class HuggingFaceCheckpointer(Callback):
                 ) if is_te_imported and state.precision == Precision.AMP_FP8 else contextlib.nullcontext(
                 )
 
-                _NON_MLFLOW_HF_MAX_SHARD_SIZE = os.environ.get(
-                    'LLM_FOUNDRY_NON_REGISTER_HF_MAX_SHARD_SIZE',
+                _LLM_FOUNDRY_SAVE_FOLDER_HF_MAX_SHARD_SIZE = os.environ.get(
+                    'LLM_FOUNDRY_SAVE_FOLDER_HF_MAX_SHARD_SIZE',
                     '1GB',
                 )
                 with context_manager:
                     new_model_instance.save_pretrained(
                         temp_save_dir,
-                        max_shard_size=_NON_MLFLOW_HF_MAX_SHARD_SIZE,
+                        max_shard_size=
+                        _LLM_FOUNDRY_SAVE_FOLDER_HF_MAX_SHARD_SIZE,
                     )
                 if original_tokenizer is not None:  # type: ignore
                     assert isinstance(

--- a/llmfoundry/callbacks/hf_checkpointer.py
+++ b/llmfoundry/callbacks/hf_checkpointer.py
@@ -844,7 +844,8 @@ class HuggingFaceCheckpointer(Callback):
                 )
 
                 _NON_MLFLOW_HF_MAX_SHARD_SIZE = os.environ.get(
-                    'LLM_FOUNDRY_NON_REGISTER_HF_MAX_SHARD_SIZE', '1GB'
+                    'LLM_FOUNDRY_NON_REGISTER_HF_MAX_SHARD_SIZE',
+                    '1GB',
                 )
                 with context_manager:
                     new_model_instance.save_pretrained(


### PR DESCRIPTION
Allows configuring the HF shard size for saving via environment variable `LLM_FOUNDRY_NON_REGISTER_HF_MAX_SHARD_SIZE`

<img width="1154" alt="Screenshot 2025-05-28 at 11 49 22 AM" src="https://github.com/user-attachments/assets/f34183c1-5e56-4ff3-9dbc-94ec89102233" />
<img width="1205" alt="Screenshot 2025-05-28 at 12 31 44 PM" src="https://github.com/user-attachments/assets/819ffe9f-5905-447c-9748-2b149bfc2624" />
