### PR TITLE
Fix monolithic checkpointing against composer main

### DIFF
--- a/llmfoundry/callbacks/monolithic_ckpt_callback.py
+++ b/llmfoundry/callbacks/monolithic_ckpt_callback.py
@@ -129,6 +129,7 @@ class MonolithicCheckpointSaver(Callback):
             if self.upload_to_object_store and self.remote_ud is not None and dist.get_global_rank(
             ) == 0:
                 remote_file_name = str(Path(save_dir) / Path(filename))
+                print(f'Saving checkpoint to {remote_file_name}')
                 self.remote_ud.upload_file(
                     state=state,
                     remote_file_name=remote_file_name,

--- a/llmfoundry/callbacks/monolithic_ckpt_callback.py
+++ b/llmfoundry/callbacks/monolithic_ckpt_callback.py
@@ -7,7 +7,6 @@ import tempfile
 from pathlib import Path
 
 import torch
-from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from composer.core import Callback, State
 from composer.core.state import (
     fsdp_get_optim_state_dict,
@@ -21,6 +20,7 @@ from composer.utils import (
     parse_uri,
     reproducibility,
 )
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 
 __all__ = ['MonolithicCheckpointSaver']
 

--- a/llmfoundry/callbacks/monolithic_ckpt_callback.py
+++ b/llmfoundry/callbacks/monolithic_ckpt_callback.py
@@ -9,7 +9,6 @@ from pathlib import Path
 import torch
 from composer.core import Callback, State
 from composer.core.state import (
-    fsdp_get_optim_state_dict,
     fsdp_state_dict_type_context,
 )
 from composer.loggers import Logger


### PR DESCRIPTION
fsdp_get_optim_state_dict was deprecated in Composer, so we update the monolithic checkpointing callback to the correct usage here.

Manual test: `mono-fix-9-2OeweR`

Two full checkpoints uploaded
<img width="1570" alt="Screenshot 2025-05-29 at 11 03 42 AM" src="https://github.com/user-attachments/assets/797b1048-8d31-480d-b70e-468aeccbb4b2" />
