### PR TITLE
Fix backwards compatibility with attention_bias

### DIFF
--- a/llmfoundry/models/mpt/configuration_mpt.py
+++ b/llmfoundry/models/mpt/configuration_mpt.py
@@ -41,7 +41,7 @@ class MPTConfig(PretrainedConfig):
         init_device: str = 'cpu',
         logit_scale: Optional[Union[float, str]] = None,
         no_bias: bool = False,
-        attention_bias: bool = True,
+        attention_bias: Optional[bool] = None,
         embedding_fraction: float = 1.0,
         norm_type: str = 'low_precision_layernorm',
         norm_eps: float = 1e-05,
@@ -103,7 +103,8 @@ class MPTConfig(PretrainedConfig):
             logit_scale (Optional[Union[float, str]]): If not None, scale the logits by this value.
             no_bias (bool): Whether to use bias in all layers.
             attention_bias (bool): Whether to use bias in the QKV projections of the attention layer. This takes precedence over the
-                `no_bias` flag. If `no_bias` is True and this is True, then bias for QKV projections will be used.
+                `no_bias` flag. If `no_bias` is True and this is True, then bias for QKV projections will be used. Default is None,
+                which means it will use the value of `no_bias` flag.
             embedding_fraction (float): The fraction to scale the gradients of the embedding layer by.
             norm_type (str): choose type of norm to use
             norm_eps (float): epsilon value for norm layer
@@ -174,7 +175,7 @@ class MPTConfig(PretrainedConfig):
         self.init_device = init_device
         self.logit_scale = logit_scale
         self.no_bias = no_bias
-        self.attention_bias = attention_bias
+        self.attention_bias = attention_bias if attention_bias is not None else not no_bias
         self.embedding_fraction = embedding_fraction
         self.norm_type = norm_type
         self.norm_eps = norm_eps


### PR DESCRIPTION
#1837 accidentally changed default behavior. If a user was specifying `no_bias=True`, that PR would result in there still being qkv bias because it defaults `attention_bias` to `True`. This PR preserved backwards compatibility by defaulting `attention_bias` to `None`, and only using it to override the `no_bias` value if `attention_bias` is explicitly set to `True` or `False`.