### PR TITLE
Add Head Dim as a configurable parameter for Attention and Rope

### DIFF
--- a/llmfoundry/models/layers/attention.py
+++ b/llmfoundry/models/layers/attention.py
@@ -548,7 +548,8 @@ class GroupedQueryAttention(nn.Module):
             self.Wqkv = build_fc(
                 name=qkv_fc_type_name,
                 in_features=self.d_model,
-                out_features=self.n_heads * self.head_dim + 2 * self.kv_n_heads * self.head_dim,
+                out_features=self.n_heads * self.head_dim +
+                2 * self.kv_n_heads * self.head_dim,
                 fc_kwargs=qkv_fc_type,
             )
             # for param init fn; enables shape based init of fused layers

--- a/llmfoundry/models/layers/blocks.py
+++ b/llmfoundry/models/layers/blocks.py
@@ -46,7 +46,7 @@ class MPTBlock(nn.Module):
         fc_type: Optional[dict[str, Any]] = None,
         device: Optional[str] = None,
         no_bias: bool = False,
-        attention_bias: bool = False,
+        attention_bias: bool = True,
         use_pad_tok_in_ffn: bool = True,
         **kwargs: Any,
     ):

--- a/llmfoundry/models/layers/blocks.py
+++ b/llmfoundry/models/layers/blocks.py
@@ -37,6 +37,7 @@ class MPTBlock(nn.Module):
         d_model: int,
         n_heads: int,
         expansion_ratio: int,
+        head_dim: Optional[int] = None,
         attn_config: Optional[dict] = None,
         ffn_config: Optional[dict] = None,
         resid_pdrop: float = 0.0,
@@ -45,7 +46,7 @@ class MPTBlock(nn.Module):
         fc_type: Optional[dict[str, Any]] = None,
         device: Optional[str] = None,
         no_bias: bool = False,
-        attention_bias: bool = True,
+        attention_bias: bool = False,
         use_pad_tok_in_ffn: bool = True,
         **kwargs: Any,
     ):
@@ -89,6 +90,7 @@ class MPTBlock(nn.Module):
                 device=device,
                 no_bias=no_bias,
                 attention_bias=attention_bias,
+                head_dim=head_dim,
             )
         else:
             assert isinstance(attn_config['attn_type'], str)
@@ -110,6 +112,7 @@ class MPTBlock(nn.Module):
                 attn_kwargs={
                     'd_model': d_model,
                     'n_heads': n_heads,
+                    'head_dim': head_dim,
                     'fc_type': fc_type,
                     'device': device,
                     'bias': not no_bias,
@@ -281,6 +284,7 @@ class FusedNormAttentionNorm(nn.Module):
         device: Optional[str] = None,
         no_bias: bool = False,
         attention_bias: bool = True,
+        head_dim: Optional[int] = None,
         **kwargs: Any,
     ):
         super().__init__()
@@ -314,6 +318,7 @@ class FusedNormAttentionNorm(nn.Module):
                 'device': device,
                 'bias': not no_bias,
                 'attention_bias': attention_bias,
+                'head_dim': head_dim,
                 **attn_config_subset_for_attn_class,
             },
         )

--- a/llmfoundry/models/mpt/configuration_mpt.py
+++ b/llmfoundry/models/mpt/configuration_mpt.py
@@ -30,6 +30,7 @@ class MPTConfig(PretrainedConfig):
         d_model: int = 2048,
         n_heads: int = 16,
         n_layers: int = 24,
+        head_dim: Optional[int] = None,
         expansion_ratio: Union[int, float] = 4,
         max_seq_len: int = 2048,
         vocab_size: int = 50368,
@@ -60,6 +61,7 @@ class MPTConfig(PretrainedConfig):
             d_model (int): The size of the embedding dimension of the model.
             n_heads (int): The number of attention heads.
             n_layers (int): The number of layers in the model.
+            head_dim (Optional[int]): If not None, sets the attention head dimension.
             expansion_ratio (Union[int, float]): The ratio of the up/down scale in the ffn.
             max_seq_len (int): The maximum sequence length of the model.
             vocab_size (int): The size of the vocabulary.
@@ -158,6 +160,7 @@ class MPTConfig(PretrainedConfig):
         self.d_model = d_model
         self.n_heads = n_heads
         self.n_layers = n_layers
+        self.head_dim = head_dim
         self.expansion_ratio = expansion_ratio
         if max_seq_len != int(max_seq_len):
             raise ValueError('max_seq_len must be an integer')

--- a/llmfoundry/models/mpt/modeling_mpt.py
+++ b/llmfoundry/models/mpt/modeling_mpt.py
@@ -160,23 +160,14 @@ def gen_rotary_embedding(
         llama_rope_config['rope_type'] = llama_rope_config.pop('type')
         if llama_rope_config['rope_type'] == 'no_scaling':
             llama_rope_config['rope_type'] = 'default'
-        if head_dim is not None:
-            partial_llama_config = PartialLlamaConfig(
-                rope_scaling=llama_rope_config,
-                rope_theta=rope_theta,
-                max_position_embeddings=max_seq_len,
-                hidden_size=d_model,
-                num_attention_heads=n_heads,
-                head_dim=head_dim,
-            )
-        else:
-            partial_llama_config = PartialLlamaConfig(
-                rope_scaling=llama_rope_config,
-                rope_theta=rope_theta,
-                max_position_embeddings=max_seq_len,
-                hidden_size=d_model,
-                num_attention_heads=n_heads,
-            )
+        partial_llama_config = PartialLlamaConfig(
+            rope_scaling=llama_rope_config,
+            rope_theta=rope_theta,
+            max_position_embeddings=max_seq_len,
+            hidden_size=d_model,
+            num_attention_heads=n_heads,
+            head_dim=head_dim,
+        )
         return LlamaRotaryEmbeddingFoundry(config=partial_llama_config)
     raise ValueError('rope_impl needs to be either dail or hf')
 

--- a/llmfoundry/models/mpt/modeling_mpt.py
+++ b/llmfoundry/models/mpt/modeling_mpt.py
@@ -141,6 +141,7 @@ def gen_rotary_embedding(
     max_seq_len: int,
     d_model: int,
     n_heads: int,
+    head_dim: Optional[int] = None,
 ):
     rope_head_dim = d_model // n_heads
     if rope_impl == 'dail':
@@ -159,13 +160,23 @@ def gen_rotary_embedding(
         llama_rope_config['rope_type'] = llama_rope_config.pop('type')
         if llama_rope_config['rope_type'] == 'no_scaling':
             llama_rope_config['rope_type'] = 'default'
-        partial_llama_config = PartialLlamaConfig(
-            rope_scaling=llama_rope_config,
-            rope_theta=rope_theta,
-            max_position_embeddings=max_seq_len,
-            hidden_size=d_model,
-            num_attention_heads=n_heads,
-        )
+        if head_dim is not None:
+            partial_llama_config = PartialLlamaConfig(
+                rope_scaling=llama_rope_config,
+                rope_theta=rope_theta,
+                max_position_embeddings=max_seq_len,
+                hidden_size=d_model,
+                num_attention_heads=n_heads,
+                head_dim=head_dim,
+            )
+        else:
+            partial_llama_config = PartialLlamaConfig(
+                rope_scaling=llama_rope_config,
+                rope_theta=rope_theta,
+                max_position_embeddings=max_seq_len,
+                hidden_size=d_model,
+                num_attention_heads=n_heads,
+            )
         return LlamaRotaryEmbeddingFoundry(config=partial_llama_config)
     raise ValueError('rope_impl needs to be either dail or hf')
 
@@ -486,6 +497,7 @@ class MPTModel(MPTPreTrainedModel):
                 max_seq_len=self.config.max_seq_len,
                 d_model=config.d_model,
                 n_heads=config.n_heads,
+                head_dim=config.head_dim,
             )
 
         if config.init_device != 'meta':

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -949,7 +949,6 @@ def test_mpt_creation(
         else:
             block_head_dim = 64
         assert block.attn.Wqkv.weight.shape == 3 * 4 * block_head_dim
-            
 
         if other_should_have_bias:
             assert block.attn.out_proj.bias.shape == torch.Size([d_model])

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -805,6 +805,7 @@ def test_lora_id():
 @pytest.mark.parametrize('norm_type', norms.get_all())
 @pytest.mark.parametrize('no_bias', [False, True])
 @pytest.mark.parametrize('attention_bias', [False, True, None])
+@pytest.mark.parametrize('head_dim', [64, None])
 @pytest.mark.parametrize('tie_word_embeddings', [True, False])
 @pytest.mark.parametrize(
     'expansion_ratio,ffn_hidden_size',
@@ -848,6 +849,7 @@ def test_mpt_creation(
     norm_type: str,
     no_bias: bool,
     attention_bias: Optional[bool],
+    head_dim: Optional[int],
     tie_word_embeddings: bool,
     expansion_ratio: Union[int, float],
     ffn_hidden_size: Optional[int],
@@ -864,6 +866,7 @@ def test_mpt_creation(
         d_model=128,
         n_heads=4,
         n_layers=2,
+        head_dim=head_dim,
         expansion_ratio=expansion_ratio,
         max_seq_len=2048,
         emb_pdrop=0.1,
@@ -887,6 +890,7 @@ def test_mpt_creation(
     assert mpt.config.d_model == 128
     assert mpt.config.n_heads == 4
     assert mpt.config.n_layers == 2
+    assert mpt.config.head_dim == head_dim
     if ffn_hidden_size is None:
         assert mpt.config.expansion_ratio == expansion_ratio
     else:
@@ -933,10 +937,19 @@ def test_mpt_creation(
         )
         other_should_have_bias = not no_bias
 
+        attn_head_dim_set = head_dim is not None
+
         if attn_should_have_bias:
             assert block.attn.Wqkv.bias.shape == torch.Size([d_model * 3])
         else:
             assert block.attn.Wqkv.bias is None
+
+        if not attn_head_dim_set:
+            block_head_dim = 32
+        else:
+            block_head_dim = 64
+        assert block.attn.Wqkv.weight.shape == 3 * 4 * block_head_dim
+            
 
         if other_should_have_bias:
             assert block.attn.out_proj.bias.shape == torch.Size([d_model])

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -941,9 +941,9 @@ def test_mpt_creation(
         attn_head_dim_set = head_dim is not None
 
         if not attn_head_dim_set:
-            block_head_dim = 32
+            block_head_dim = d_model // n_heads
         else:
-            block_head_dim = 64
+            block_head_dim = head_dim
         assert block.attn.Wqkv.weight.shape == torch.Size([
             3 * n_heads * block_head_dim,
             d_model,


### PR DESCRIPTION
Added head dim as an optional configurable parameter in MPT for Rope implementations and Attention layers.