### PR TITLE
Register FileLogger in the loggers module

### DIFF
--- a/llmfoundry/loggers/__init__.py
+++ b/llmfoundry/loggers/__init__.py
@@ -7,6 +7,7 @@ from composer.loggers import (
     MosaicMLLogger,
     TensorboardLogger,
     WandBLogger,
+    FileLogger
 )
 
 from llmfoundry.registry import loggers
@@ -20,3 +21,4 @@ loggers.register(
 )  # for backwards compatibility
 loggers.register('mlflow', func=MLFlowLogger)
 loggers.register('mosaicml', func=MosaicMLLogger)
+loggers.register('filelogger', func=FileLogger)


### PR DESCRIPTION
Import FileLogger from Composer to log into a file.

Use in the yaml config:
```ymal
loggers:
  filelogger:
    filename: /logs/train_rank{rank}.log
```