### PR TITLE
fix(eval): include non-Accuracy metrics in markdown results

### DIFF
--- a/llmfoundry/command_utils/eval.py
+++ b/llmfoundry/command_utils/eval.py
@@ -397,10 +397,16 @@ def calculate_markdown_results(
     results = {}
 
     for key in logger_keys:
-        # dl_name is either 2-tuple (benchmark_name, num_fewshot)
-        # or 3-tuple (benchmark_name, num_fewshot, subcategory)
-        dl_name, metric_name = key.split('/')[1:-1], key.split('/')[-1]
-        if 'Accuracy' not in metric_name:
+        parts = key.split('/')
+        # Metrics are expected to be:
+        # metrics/{benchmark}/{num_fewshot}/{metric_name}
+        # or metrics/{benchmark}/{num_fewshot}/{subcategory}/{metric_name}
+        if len(parts) < 4 or parts[0] != 'metrics':
+            continue
+
+        dl_name, metric_name = parts[1:-1], parts[-1]
+        # Skip malformed keys and keep processing other metrics.
+        if len(dl_name) not in (2, 3):
             continue
 
         metric = trainer.state.eval_metrics.get('/'.join(dl_name),
@@ -408,6 +414,9 @@ def calculate_markdown_results(
 
         if metric is None:
             continue
+        metric_value = metric.compute()
+        if hasattr(metric_value, 'item'):
+            metric_value = metric_value.item()
         if dl_name[1] not in results:
             results[dl_name[1]] = {}
 
@@ -418,7 +427,7 @@ def calculate_markdown_results(
             results[dl_name[1]][dl_name[0]][metric_name] = []
 
         results[dl_name[1]][dl_name[0]][metric_name].append({
-            'val': metric.compute(),
+            'val': metric_value,
             'subcat': dl_name[-1] if len(dl_name) == 3 else 'no_subcat',
         })
 
@@ -427,7 +436,8 @@ def calculate_markdown_results(
             'Category',
             'Benchmark',
             'Subtask',
-            'Accuracy',
+            'Metric',
+            'Value',
             'Number few shot',
             'Model',
         ],
@@ -442,7 +452,8 @@ def calculate_markdown_results(
                         'Category': benchmark_to_taxonomy.get(benchmark, ''),
                         'Benchmark': benchmark,
                         'Subtask': None,
-                        'Accuracy': subscores[0]['val'],
+                        'Metric': metric,
+                        'Value': subscores[0]['val'],
                         'Number few shot': num_shot,
                         'Model': model_name,
                     }
@@ -455,7 +466,9 @@ def calculate_markdown_results(
                             benchmark,
                         'Subtask':
                             'Average',
-                        'Accuracy':
+                        'Metric':
+                            metric,
+                        'Value':
                             sum(s['val'] for s in subscores) / len(subscores),
                         'Number few shot':
                             num_shot,
@@ -471,7 +484,9 @@ def calculate_markdown_results(
                                 None,
                             'Subtask':
                                 sub['subcat'],
-                            'Accuracy':
+                            'Metric':
+                                metric,
+                            'Value':
                                 sub['val'],
                             'Number few shot':
                                 num_shot,

--- a/llmfoundry/command_utils/eval.py
+++ b/llmfoundry/command_utils/eval.py
@@ -437,7 +437,8 @@ def calculate_markdown_results(
             'Benchmark',
             'Subtask',
             'Metric',
-            'Value',
+            # Backward-compatible column name; now stores generic metric values.
+            'Accuracy',
             'Number few shot',
             'Model',
         ],
@@ -453,7 +454,7 @@ def calculate_markdown_results(
                         'Benchmark': benchmark,
                         'Subtask': None,
                         'Metric': metric,
-                        'Value': subscores[0]['val'],
+                        'Accuracy': subscores[0]['val'],
                         'Number few shot': num_shot,
                         'Model': model_name,
                     }
@@ -468,7 +469,7 @@ def calculate_markdown_results(
                             'Average',
                         'Metric':
                             metric,
-                        'Value':
+                        'Accuracy':
                             sum(s['val'] for s in subscores) / len(subscores),
                         'Number few shot':
                             num_shot,
@@ -486,7 +487,7 @@ def calculate_markdown_results(
                                 sub['subcat'],
                             'Metric':
                                 metric,
-                            'Value':
+                            'Accuracy':
                                 sub['val'],
                             'Number few shot':
                                 num_shot,

--- a/tests/a_scripts/eval/test_eval.py
+++ b/tests/a_scripts/eval/test_eval.py
@@ -8,7 +8,6 @@ from typing import Any, Union
 
 import omegaconf as om
 import pytest
-import torch
 from composer import Trainer
 from composer.loggers import InMemoryLogger
 
@@ -79,7 +78,7 @@ def test_icl_eval(
     assert isinstance(eval_cfg, om.DictConfig)
     evaluate(eval_cfg)
     out, _ = capfd.readouterr()
-    expected_results = '| Category                    | Benchmark      | Subtask   | Metric                      |   Value | Number few shot   | Model    |\n|:----------------------------|:---------------|:----------|:----------------------------|--------:|:------------------|:---------|\n| language_understanding_lite | lambada_openai |           | InContextLearningLMAccuracy |       0 | 0-shot            | tiny_mpt |'
+    expected_results = '| Category                    | Benchmark      | Subtask   | Metric                      |   Accuracy | Number few shot   | Model    |\n|:----------------------------|:---------------|:----------|:----------------------------|-----------:|:------------------|:---------|\n| language_understanding_lite | lambada_openai |           | InContextLearningLMAccuracy |          0 | 0-shot            | tiny_mpt |'
     assert expected_results in out
     expected_results = '| model_name   |   default_average |   language_understanding_lite |\n|:-------------|------------------:|------------------------------:|\n| tiny_mpt     |                 0 |                             0 |'
     assert expected_results in out
@@ -91,7 +90,16 @@ class _DummyMetric:
         self.value = value
 
     def compute(self):
-        return torch.tensor(self.value)
+        return _DummyTensor(self.value)
+
+
+class _DummyTensor:
+
+    def __init__(self, value: float):
+        self.value = value
+
+    def item(self):
+        return self.value
 
 
 def test_calculate_markdown_results_includes_non_accuracy_metric_names():
@@ -148,14 +156,14 @@ def test_calculate_markdown_results_includes_non_accuracy_metric_names():
         (results['Metric'] == 'LanguageCrossEntropy')
     ]
     assert len(lambada_ce) == 1
-    assert lambada_ce.iloc[0]['Value'] == pytest.approx(1.25)
+    assert lambada_ce.iloc[0]['Accuracy'] == pytest.approx(1.25)
 
     mmlu_avg = results[
         (results['Benchmark'] == 'mmlu') & (results['Subtask'] == 'Average') &
         (results['Metric'] == 'CustomF1')
     ]
     assert len(mmlu_avg) == 1
-    assert mmlu_avg.iloc[0]['Value'] == pytest.approx(0.7)
+    assert mmlu_avg.iloc[0]['Accuracy'] == pytest.approx(0.7)
 
 
 def test_loader_eval(

--- a/tests/a_scripts/eval/test_eval.py
+++ b/tests/a_scripts/eval/test_eval.py
@@ -8,10 +8,12 @@ from typing import Any, Union
 
 import omegaconf as om
 import pytest
+import torch
 from composer import Trainer
 from composer.loggers import InMemoryLogger
 
 from llmfoundry.command_utils import evaluate
+from llmfoundry.command_utils.eval import calculate_markdown_results
 from llmfoundry.utils import build_tokenizer
 from llmfoundry.utils.builders import build_composer_model
 from llmfoundry.utils.config_utils import EVAL_CONFIG_KEYS, to_dict_container
@@ -77,10 +79,83 @@ def test_icl_eval(
     assert isinstance(eval_cfg, om.DictConfig)
     evaluate(eval_cfg)
     out, _ = capfd.readouterr()
-    expected_results = '| Category                    | Benchmark      | Subtask   |   Accuracy | Number few shot   | Model    |\n|:----------------------------|:---------------|:----------|-----------:|:------------------|:---------|\n| language_understanding_lite | lambada_openai |           |          0 | 0-shot            | tiny_mpt |'
+    expected_results = '| Category                    | Benchmark      | Subtask   | Metric                      |   Value | Number few shot   | Model    |\n|:----------------------------|:---------------|:----------|:----------------------------|--------:|:------------------|:---------|\n| language_understanding_lite | lambada_openai |           | InContextLearningLMAccuracy |       0 | 0-shot            | tiny_mpt |'
     assert expected_results in out
     expected_results = '| model_name   |   default_average |   language_understanding_lite |\n|:-------------|------------------:|------------------------------:|\n| tiny_mpt     |                 0 |                             0 |'
     assert expected_results in out
+
+
+class _DummyMetric:
+
+    def __init__(self, value: float):
+        self.value = value
+
+    def compute(self):
+        return torch.tensor(self.value)
+
+
+def test_calculate_markdown_results_includes_non_accuracy_metric_names():
+    logger_keys = [
+        'metrics/lambada_openai/0-shot/InContextLearningLMAccuracy',
+        'metrics/lambada_openai/0-shot/LanguageCrossEntropy',
+        'metrics/mmlu/5-shot/computer_security/CustomF1',
+        'metrics/mmlu/5-shot/human_aging/CustomF1',
+    ]
+    eval_metrics = {
+        'lambada_openai/0-shot': {
+            'InContextLearningLMAccuracy': _DummyMetric(0.5),
+            'LanguageCrossEntropy': _DummyMetric(1.25),
+        },
+        'mmlu/5-shot/computer_security': {
+            'CustomF1': _DummyMetric(0.8),
+        },
+        'mmlu/5-shot/human_aging': {
+            'CustomF1': _DummyMetric(0.6),
+        },
+    }
+
+    trainer = type(
+        'TrainerStub',
+        (),
+        {
+            'state': type(
+                'TrainerStateStub',
+                (),
+                {
+                    'eval_metrics': eval_metrics,
+                },
+            )(),
+        },
+    )()
+    results = calculate_markdown_results(
+        logger_keys=logger_keys,
+        trainer=trainer,  # pyright: ignore[reportArgumentType]
+        benchmark_to_taxonomy={
+            'lambada_openai': 'language_understanding_lite',
+            'mmlu': 'knowledge',
+        },
+        model_name='tiny_mpt',
+    )
+
+    assert set(results['Metric']) == {
+        'InContextLearningLMAccuracy',
+        'LanguageCrossEntropy',
+        'CustomF1',
+    }
+
+    lambada_ce = results[
+        (results['Benchmark'] == 'lambada_openai') &
+        (results['Metric'] == 'LanguageCrossEntropy')
+    ]
+    assert len(lambada_ce) == 1
+    assert lambada_ce.iloc[0]['Value'] == pytest.approx(1.25)
+
+    mmlu_avg = results[
+        (results['Benchmark'] == 'mmlu') & (results['Subtask'] == 'Average') &
+        (results['Metric'] == 'CustomF1')
+    ]
+    assert len(mmlu_avg) == 1
+    assert mmlu_avg.iloc[0]['Value'] == pytest.approx(0.7)
 
 
 def test_loader_eval(


### PR DESCRIPTION
Fixes #1722.

This removes the hardcoded `"Accuracy"` name filter in `calculate_markdown_results()` so all metrics present in `logger_keys` are included.

Changes:
- parse metric keys defensively (`metrics/{benchmark}/{fewshot}/{metric}` and subcategory form)
- include metric names in markdown output via a `Metric` column
- keep the existing `Accuracy` column name for compatibility (it now stores generic metric values)
- convert tensor-like metric outputs with `.item()` when available
- add regression coverage for non-accuracy metrics (`LanguageCrossEntropy`, `CustomF1`) and averaged subcategory rows

Validation:
- `ruff check llmfoundry/command_utils/eval.py tests/a_scripts/eval/test_eval.py`
- `python3.11 -m py_compile llmfoundry/command_utils/eval.py tests/a_scripts/eval/test_eval.py`
- direct function harness for `calculate_markdown_results()` (full local pytest is blocked in this environment by missing `composer` dependency)
