### PR TITLE
fix(tokenizer): handle signal-file cleanup race on shared filesystems

### DIFF
--- a/llmfoundry/utils/builders.py
+++ b/llmfoundry/utils/builders.py
@@ -542,7 +542,9 @@ def build_tokenizer(
         dist.barrier()
 
         if dist.get_local_rank() == 0:
-            os.remove(signal_file_path)
+            # Another rank can remove the shared signal file first on network filesystems.
+            with contextlib.suppress(FileNotFoundError):
+                os.remove(signal_file_path)
 
     return tokenizer
 

--- a/tests/utils/test_builders.py
+++ b/tests/utils/test_builders.py
@@ -1,6 +1,7 @@
 # Copyright 2022 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
+import contextlib
 import re
 import unittest.mock as mock
 from copy import deepcopy
@@ -64,6 +65,46 @@ def test_tokenizer_no_EOS():
         match='The tokenizer bert-base-uncased must have an eos_token.',
     ):
         build_tokenizer('bert-base-uncased', {})
+
+
+def test_build_tokenizer_handles_missing_signal_file_cleanup():
+    class _DummyTokenizer:
+        eos_token = '</s>'
+        model_max_length = 0
+
+    with mock.patch(
+        'llmfoundry.utils.builders.AutoTokenizer.from_pretrained',
+        return_value=_DummyTokenizer(),
+    ) as patched_tokenizer, mock.patch(
+        'llmfoundry.utils.builders.dist.get_node_signal_file_name',
+        return_value='._signal_file_node0_test',
+    ), mock.patch(
+        'llmfoundry.utils.builders.dist.is_available',
+        return_value=True,
+    ), mock.patch(
+        'llmfoundry.utils.builders.dist.is_initialized',
+        return_value=True,
+    ), mock.patch(
+        'llmfoundry.utils.builders.dist.get_world_size',
+        return_value=2,
+    ), mock.patch(
+        'llmfoundry.utils.builders.dist.get_local_rank',
+        return_value=0,
+    ), mock.patch(
+        'llmfoundry.utils.builders.dist.local_rank_zero_download_and_wait',
+        return_value=contextlib.nullcontext(),
+    ), mock.patch(
+        'llmfoundry.utils.builders.dist.barrier',
+    ), mock.patch(
+        'builtins.open',
+        mock.mock_open(),
+    ), mock.patch(
+        'llmfoundry.utils.builders.os.remove',
+        side_effect=FileNotFoundError,
+    ):
+        tokenizer = build_tokenizer('dummy-tokenizer', {})
+
+    assert tokenizer is patched_tokenizer.return_value
 
 
 def test_build_callback_fails():

--- a/tests/utils/test_builders.py
+++ b/tests/utils/test_builders.py
@@ -95,16 +95,18 @@ def test_build_tokenizer_handles_missing_signal_file_cleanup():
         return_value=contextlib.nullcontext(),
     ), mock.patch(
         'llmfoundry.utils.builders.dist.barrier',
-    ), mock.patch(
+    ) as patched_barrier, mock.patch(
         'builtins.open',
         mock.mock_open(),
     ), mock.patch(
         'llmfoundry.utils.builders.os.remove',
         side_effect=FileNotFoundError,
-    ):
+    ) as patched_remove:
         tokenizer = build_tokenizer('dummy-tokenizer', {})
 
     assert tokenizer is patched_tokenizer.return_value
+    patched_barrier.assert_called_once()
+    patched_remove.assert_called_once_with('._signal_file_node0_test')
 
 
 def test_build_callback_fails():


### PR DESCRIPTION
Fixes #1848.

This makes tokenizer signal-file cleanup resilient to a shared-filesystem race in distributed runs.

Changes:
- wrap rank-0 cleanup in `contextlib.suppress(FileNotFoundError)` inside `build_tokenizer()`
- add regression coverage for the cleanup race path
- assert cleanup path is actually exercised (`barrier()` called and `os.remove()` attempted)

Validation:
- `ruff check llmfoundry/utils/builders.py tests/utils/test_builders.py`
- `python3.11 -m py_compile llmfoundry/utils/builders.py tests/utils/test_builders.py`
- direct function harness for `build_tokenizer()` confirms no exception when `os.remove()` raises `FileNotFoundError`

Note: current CI failures are infrastructure/auth (`mcli` API key expired) before project tests execute.
