### PR TITLE
feat: add MiniMax as inference API provider (default M3)

### DIFF
--- a/llmfoundry/models/__init__.py
+++ b/llmfoundry/models/__init__.py
@@ -5,6 +5,7 @@ from llmfoundry.models.hf import ComposerHFCausalLM, ComposerHFT5
 from llmfoundry.models.inference_api_wrapper import (
     FMAPICasualLMEvalWrapper,
     FMAPIChatAPIEvalWrapper,
+    MiniMaxChatAPIEvalWrapper,
     OpenAICausalLMEvalWrapper,
     OpenAIChatAPIEvalWrapper,
 )
@@ -25,6 +26,7 @@ models.register('openai_causal_lm', func=OpenAICausalLMEvalWrapper)
 models.register('fmapi_causal_lm', func=FMAPICasualLMEvalWrapper)
 models.register('openai_chat', func=OpenAIChatAPIEvalWrapper)
 models.register('fmapi_chat', func=FMAPIChatAPIEvalWrapper)
+models.register('minimax_chat', func=MiniMaxChatAPIEvalWrapper)
 models.register('finetune_embedding_model', func=FinetuneEmbeddingModel)
 models.register('contrastive_lm', func=ContrastiveModel)
 
@@ -40,4 +42,5 @@ __all__ = [
     'FMAPICasualLMEvalWrapper',
     'OpenAIChatAPIEvalWrapper',
     'FMAPIChatAPIEvalWrapper',
+    'MiniMaxChatAPIEvalWrapper',
 ]

--- a/llmfoundry/models/inference_api_wrapper/__init__.py
+++ b/llmfoundry/models/inference_api_wrapper/__init__.py
@@ -8,6 +8,10 @@ from llmfoundry.models.inference_api_wrapper.fmapi import (
 )
 from llmfoundry.models.inference_api_wrapper.interface import \
     InferenceAPIEvalWrapper
+from llmfoundry.models.inference_api_wrapper.minimax import (
+    MiniMaxChatAPIEvalWrapper,
+    MiniMaxEvalInterface,
+)
 from llmfoundry.models.inference_api_wrapper.openai_causal_lm import (
     OpenAICausalLMEvalWrapper,
     OpenAIChatAPIEvalWrapper,
@@ -22,4 +26,6 @@ __all__ = [
     'FMAPICasualLMEvalWrapper',
     'FMAPIChatAPIEvalWrapper',
     'FMAPIEvalInterface',
+    'MiniMaxChatAPIEvalWrapper',
+    'MiniMaxEvalInterface',
 ]

--- a/llmfoundry/models/inference_api_wrapper/minimax.py
+++ b/llmfoundry/models/inference_api_wrapper/minimax.py
@@ -3,7 +3,8 @@
 """Implements MiniMax chat and causal LM inference API wrappers.
 
 MiniMax provides an OpenAI-compatible API at https://api.minimax.io/v1,
-supporting models such as MiniMax-M2.7 and MiniMax-M2.5-highspeed.
+supporting models such as MiniMax-M3 (default), MiniMax-M2.7, and
+MiniMax-M2.7-highspeed.
 """
 
 import logging
@@ -84,5 +85,6 @@ class MiniMaxChatAPIEvalWrapper(MiniMaxEvalInterface, OpenAIChatAPIEvalWrapper):
 
     Uses the OpenAI-compatible ``/v1/chat/completions`` endpoint.
     Configure the model version via the ``version`` field in the model
-    config (e.g. ``MiniMax-M2.7`` or ``MiniMax-M2.5-highspeed``).
+    config (e.g. ``MiniMax-M3``, ``MiniMax-M2.7`` or
+    ``MiniMax-M2.7-highspeed``).
     """

--- a/llmfoundry/models/inference_api_wrapper/minimax.py
+++ b/llmfoundry/models/inference_api_wrapper/minimax.py
@@ -1,0 +1,88 @@
+# Copyright 2022 MosaicML LLM Foundry authors
+# SPDX-License-Identifier: Apache-2.0
+"""Implements MiniMax chat and causal LM inference API wrappers.
+
+MiniMax provides an OpenAI-compatible API at https://api.minimax.io/v1,
+supporting models such as MiniMax-M2.7 and MiniMax-M2.5-highspeed.
+"""
+
+import logging
+import os
+
+from composer.utils.import_helpers import MissingConditionalImportError
+from omegaconf import DictConfig
+from transformers import PreTrainedTokenizerBase
+
+from llmfoundry.models.inference_api_wrapper.openai_causal_lm import (
+    OpenAIChatAPIEvalWrapper,
+    OpenAIEvalInterface,
+)
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    'MiniMaxChatAPIEvalWrapper',
+    'MiniMaxEvalInterface',
+]
+
+MINIMAX_API_BASE_URL = 'https://api.minimax.io/v1'
+
+
+class MiniMaxEvalInterface(OpenAIEvalInterface):
+    """MiniMax evaluation interface using the OpenAI-compatible API.
+
+    Automatically configures the base URL and API key for MiniMax.
+    The API key is read from the ``MINIMAX_API_KEY`` environment variable,
+    falling back to ``OPENAI_API_KEY`` if set.
+    """
+
+    def __init__(
+        self,
+        om_model_config: DictConfig,
+        tokenizer: PreTrainedTokenizerBase,
+    ) -> None:
+        try:
+            import openai
+        except ImportError as e:
+            raise MissingConditionalImportError(
+                extra_deps_group='openai',
+                conda_package='openai',
+                conda_channel='conda-forge',
+            ) from e
+
+        # Resolve the API key: prefer MINIMAX_API_KEY, fall back to
+        # OPENAI_API_KEY
+        api_key = os.environ.get('MINIMAX_API_KEY')
+        if api_key is None:
+            api_key = os.environ.get('OPENAI_API_KEY')
+        if api_key is None:
+            raise ValueError(
+                'No MiniMax API key found. Set the MINIMAX_API_KEY '
+                'environment variable.',
+            )
+
+        # Set base_url to MiniMax default if not already specified
+        base_url = om_model_config.get('base_url', MINIMAX_API_BASE_URL)
+
+        # Initialize the InferenceAPIEvalWrapper grandparent directly,
+        # bypassing OpenAIEvalInterface which would overwrite the API key
+        # with 'placeholder' for custom base URLs.
+        from llmfoundry.models.inference_api_wrapper.interface import \
+            InferenceAPIEvalWrapper
+        InferenceAPIEvalWrapper.__init__(self, om_model_config, tokenizer)
+
+        self.client = openai.OpenAI(base_url=base_url, api_key=api_key)
+
+        if 'version' in om_model_config:
+            self.model_name = om_model_config['version']
+        else:
+            self.model_name = om_model_config['name']
+
+
+class MiniMaxChatAPIEvalWrapper(MiniMaxEvalInterface, OpenAIChatAPIEvalWrapper):
+    """MiniMax chat API wrapper for evaluating chat models.
+
+    Uses the OpenAI-compatible ``/v1/chat/completions`` endpoint.
+    Configure the model version via the ``version`` field in the model
+    config (e.g. ``MiniMax-M2.7`` or ``MiniMax-M2.5-highspeed``).
+    """

--- a/scripts/eval/yamls/minimax_eval.yaml
+++ b/scripts/eval/yamls/minimax_eval.yaml
@@ -1,0 +1,24 @@
+seed: 1
+max_seq_len: 1024
+device_eval_batch_size: 4
+models:
+-
+  model_name: minimax/MiniMax-M2.7
+  model:
+    name: minimax_chat
+    version: MiniMax-M2.7
+  tokenizer:
+    name: tiktoken
+    kwargs:
+      model_name: gpt-4
+-
+  model_name: minimax/MiniMax-M2.5-highspeed
+  model:
+    name: minimax_chat
+    version: MiniMax-M2.5-highspeed
+  tokenizer:
+    name: tiktoken
+    kwargs:
+      model_name: gpt-4
+
+icl_tasks: "eval/yamls/lm_tasks_v0.2.yaml"

--- a/scripts/eval/yamls/minimax_eval.yaml
+++ b/scripts/eval/yamls/minimax_eval.yaml
@@ -3,6 +3,15 @@ max_seq_len: 1024
 device_eval_batch_size: 4
 models:
 -
+  model_name: minimax/MiniMax-M3
+  model:
+    name: minimax_chat
+    version: MiniMax-M3
+  tokenizer:
+    name: tiktoken
+    kwargs:
+      model_name: gpt-4
+-
   model_name: minimax/MiniMax-M2.7
   model:
     name: minimax_chat
@@ -12,10 +21,10 @@ models:
     kwargs:
       model_name: gpt-4
 -
-  model_name: minimax/MiniMax-M2.5-highspeed
+  model_name: minimax/MiniMax-M2.7-highspeed
   model:
     name: minimax_chat
-    version: MiniMax-M2.5-highspeed
+    version: MiniMax-M2.7-highspeed
   tokenizer:
     name: tiktoken
     kwargs:

--- a/tests/models/inference_api_wrapper/test_minimax.py
+++ b/tests/models/inference_api_wrapper/test_minimax.py
@@ -1,0 +1,226 @@
+# Copyright 2022 MosaicML LLM Foundry authors
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from omegaconf import DictConfig
+
+from llmfoundry.models.inference_api_wrapper.minimax import (
+    MINIMAX_API_BASE_URL,
+    MiniMaxChatAPIEvalWrapper,
+    MiniMaxEvalInterface,
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_env():
+    """Save and restore env vars around each test."""
+    old_openai = os.environ.get('OPENAI_API_KEY')
+    old_minimax = os.environ.get('MINIMAX_API_KEY')
+    yield
+    # Restore
+    if old_openai is not None:
+        os.environ['OPENAI_API_KEY'] = old_openai
+    else:
+        os.environ.pop('OPENAI_API_KEY', None)
+    if old_minimax is not None:
+        os.environ['MINIMAX_API_KEY'] = old_minimax
+    else:
+        os.environ.pop('MINIMAX_API_KEY', None)
+
+
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
+def test_minimax_api_base_url_constant():
+    """Test that the MiniMax API base URL constant is correct."""
+    assert MINIMAX_API_BASE_URL == 'https://api.minimax.io/v1'
+
+
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
+def test_minimax_model_registered():
+    """Test that minimax_chat is registered in the models registry."""
+    from llmfoundry.registry import models
+
+    assert 'minimax_chat' in models.get_all()
+
+
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
+def test_minimax_missing_api_key():
+    """Test that missing API key raises ValueError."""
+    _ = pytest.importorskip('openai')
+
+    os.environ.pop('OPENAI_API_KEY', None)
+    os.environ.pop('MINIMAX_API_KEY', None)
+
+    mock_tokenizer = MagicMock()
+    mock_tokenizer.pad_token_id = 0
+    mock_tokenizer.eos_token_id = 1
+
+    with pytest.raises(ValueError, match='No MiniMax API key found'):
+        MiniMaxChatAPIEvalWrapper(
+            om_model_config=DictConfig({
+                'version': 'MiniMax-M2.7',
+            }),
+            tokenizer=mock_tokenizer,
+        )
+
+
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
+def test_minimax_uses_minimax_api_key():
+    """Test that MINIMAX_API_KEY is used when OPENAI_API_KEY is not set."""
+    _ = pytest.importorskip('openai')
+
+    os.environ.pop('OPENAI_API_KEY', None)
+    os.environ['MINIMAX_API_KEY'] = 'test-minimax-key-123'
+
+    mock_tokenizer = MagicMock()
+    mock_tokenizer.pad_token_id = 0
+    mock_tokenizer.eos_token_id = 1
+
+    model = MiniMaxChatAPIEvalWrapper(
+        om_model_config=DictConfig({
+            'version': 'MiniMax-M2.7',
+        }),
+        tokenizer=mock_tokenizer,
+    )
+    assert model.model_name == 'MiniMax-M2.7'
+    assert model.client.base_url.host == 'api.minimax.io'
+
+
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
+def test_minimax_uses_openai_key_if_set():
+    """Test that OPENAI_API_KEY takes precedence when already set."""
+    _ = pytest.importorskip('openai')
+
+    os.environ['OPENAI_API_KEY'] = 'existing-openai-key'
+    os.environ.pop('MINIMAX_API_KEY', None)
+
+    mock_tokenizer = MagicMock()
+    mock_tokenizer.pad_token_id = 0
+    mock_tokenizer.eos_token_id = 1
+
+    model = MiniMaxChatAPIEvalWrapper(
+        om_model_config=DictConfig({
+            'version': 'MiniMax-M2.7',
+        }),
+        tokenizer=mock_tokenizer,
+    )
+    # Should succeed without MINIMAX_API_KEY when OPENAI_API_KEY is set
+    assert model.model_name == 'MiniMax-M2.7'
+
+
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
+def test_minimax_default_base_url():
+    """Test that the MiniMax wrapper sets the correct default base URL."""
+    _ = pytest.importorskip('openai')
+
+    os.environ['MINIMAX_API_KEY'] = 'test-minimax-key'
+    os.environ.pop('OPENAI_API_KEY', None)
+
+    mock_tokenizer = MagicMock()
+    mock_tokenizer.pad_token_id = 0
+    mock_tokenizer.eos_token_id = 1
+
+    model = MiniMaxChatAPIEvalWrapper(
+        om_model_config=DictConfig({
+            'version': 'MiniMax-M2.7',
+        }),
+        tokenizer=mock_tokenizer,
+    )
+    assert model.client.base_url.host == 'api.minimax.io'
+    assert '/v1' in str(model.client.base_url)
+
+
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
+def test_minimax_custom_base_url():
+    """Test that a custom base URL overrides the default MiniMax URL."""
+    _ = pytest.importorskip('openai')
+
+    os.environ['MINIMAX_API_KEY'] = 'test-minimax-key'
+    os.environ.pop('OPENAI_API_KEY', None)
+
+    mock_tokenizer = MagicMock()
+    mock_tokenizer.pad_token_id = 0
+    mock_tokenizer.eos_token_id = 1
+
+    model = MiniMaxChatAPIEvalWrapper(
+        om_model_config=DictConfig({
+            'version': 'MiniMax-M2.7',
+            'base_url': 'https://custom.minimax.io/v1',
+        }),
+        tokenizer=mock_tokenizer,
+    )
+    assert 'custom.minimax.io' in str(model.client.base_url)
+
+
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
+def test_minimax_model_name_from_version():
+    """Test that model_name is set from the version config field."""
+    _ = pytest.importorskip('openai')
+
+    os.environ['MINIMAX_API_KEY'] = 'test-minimax-key'
+    os.environ.pop('OPENAI_API_KEY', None)
+
+    mock_tokenizer = MagicMock()
+    mock_tokenizer.pad_token_id = 0
+    mock_tokenizer.eos_token_id = 1
+
+    model = MiniMaxChatAPIEvalWrapper(
+        om_model_config=DictConfig({
+            'version': 'MiniMax-M2.5-highspeed',
+        }),
+        tokenizer=mock_tokenizer,
+    )
+    assert model.model_name == 'MiniMax-M2.5-highspeed'
+
+
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
+def test_minimax_model_name_from_name_field():
+    """Test model_name fallback to name field when version is not set."""
+    _ = pytest.importorskip('openai')
+
+    os.environ['MINIMAX_API_KEY'] = 'test-minimax-key'
+    os.environ.pop('OPENAI_API_KEY', None)
+
+    mock_tokenizer = MagicMock()
+    mock_tokenizer.pad_token_id = 0
+    mock_tokenizer.eos_token_id = 1
+
+    model = MiniMaxChatAPIEvalWrapper(
+        om_model_config=DictConfig({
+            'name': 'MiniMax-M2.7',
+        }),
+        tokenizer=mock_tokenizer,
+    )
+    assert model.model_name == 'MiniMax-M2.7'
+
+
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
+def test_minimax_inherits_chat_api_methods():
+    """Test MiniMax wrapper inherits OpenAI chat API behavior correctly."""
+    _ = pytest.importorskip('openai')
+
+    os.environ['MINIMAX_API_KEY'] = 'test-minimax-key'
+    os.environ.pop('OPENAI_API_KEY', None)
+
+    mock_tokenizer = MagicMock()
+    mock_tokenizer.pad_token_id = 0
+    mock_tokenizer.eos_token_id = 1
+
+    chatmodel = MiniMaxChatAPIEvalWrapper(
+        om_model_config=DictConfig({
+            'version': 'MiniMax-M2.7',
+        }),
+        tokenizer=mock_tokenizer,
+    )
+
+    # Verify the model has the expected attributes from OpenAIChatAPIEvalWrapper
+    assert hasattr(chatmodel, 'client')
+    assert hasattr(chatmodel, 'model_name')
+    assert hasattr(chatmodel, 'tokenizer')
+    assert hasattr(chatmodel, 'generate_completion')
+    assert hasattr(chatmodel, 'eval_forward')
+    assert hasattr(chatmodel, 'rebatch')
+    assert hasattr(chatmodel, 'process_result')
+    assert hasattr(chatmodel, 'try_generate_completion')

--- a/tests/models/inference_api_wrapper/test_minimax.py
+++ b/tests/models/inference_api_wrapper/test_minimax.py
@@ -60,7 +60,7 @@ def test_minimax_missing_api_key():
     with pytest.raises(ValueError, match='No MiniMax API key found'):
         MiniMaxChatAPIEvalWrapper(
             om_model_config=DictConfig({
-                'version': 'MiniMax-M2.7',
+                'version': 'MiniMax-M3',
             }),
             tokenizer=mock_tokenizer,
         )
@@ -80,11 +80,11 @@ def test_minimax_uses_minimax_api_key():
 
     model = MiniMaxChatAPIEvalWrapper(
         om_model_config=DictConfig({
-            'version': 'MiniMax-M2.7',
+            'version': 'MiniMax-M3',
         }),
         tokenizer=mock_tokenizer,
     )
-    assert model.model_name == 'MiniMax-M2.7'
+    assert model.model_name == 'MiniMax-M3'
     assert model.client.base_url.host == 'api.minimax.io'
 
 
@@ -102,12 +102,12 @@ def test_minimax_uses_openai_key_if_set():
 
     model = MiniMaxChatAPIEvalWrapper(
         om_model_config=DictConfig({
-            'version': 'MiniMax-M2.7',
+            'version': 'MiniMax-M3',
         }),
         tokenizer=mock_tokenizer,
     )
     # Should succeed without MINIMAX_API_KEY when OPENAI_API_KEY is set
-    assert model.model_name == 'MiniMax-M2.7'
+    assert model.model_name == 'MiniMax-M3'
 
 
 @pytest.mark.filterwarnings('ignore::DeprecationWarning')
@@ -124,7 +124,7 @@ def test_minimax_default_base_url():
 
     model = MiniMaxChatAPIEvalWrapper(
         om_model_config=DictConfig({
-            'version': 'MiniMax-M2.7',
+            'version': 'MiniMax-M3',
         }),
         tokenizer=mock_tokenizer,
     )
@@ -146,7 +146,7 @@ def test_minimax_custom_base_url():
 
     model = MiniMaxChatAPIEvalWrapper(
         om_model_config=DictConfig({
-            'version': 'MiniMax-M2.7',
+            'version': 'MiniMax-M3',
             'base_url': 'https://custom.minimax.io/v1',
         }),
         tokenizer=mock_tokenizer,
@@ -168,11 +168,11 @@ def test_minimax_model_name_from_version():
 
     model = MiniMaxChatAPIEvalWrapper(
         om_model_config=DictConfig({
-            'version': 'MiniMax-M2.5-highspeed',
+            'version': 'MiniMax-M2.7-highspeed',
         }),
         tokenizer=mock_tokenizer,
     )
-    assert model.model_name == 'MiniMax-M2.5-highspeed'
+    assert model.model_name == 'MiniMax-M2.7-highspeed'
 
 
 @pytest.mark.filterwarnings('ignore::DeprecationWarning')
@@ -210,7 +210,7 @@ def test_minimax_inherits_chat_api_methods():
 
     chatmodel = MiniMaxChatAPIEvalWrapper(
         om_model_config=DictConfig({
-            'version': 'MiniMax-M2.7',
+            'version': 'MiniMax-M3',
         }),
         tokenizer=mock_tokenizer,
     )

--- a/tests/models/inference_api_wrapper/test_minimax_integration.py
+++ b/tests/models/inference_api_wrapper/test_minimax_integration.py
@@ -53,14 +53,14 @@ def test_minimax_chat_completion_live():
 
     model = MiniMaxChatAPIEvalWrapper(
         om_model_config=DictConfig({
-            'version': 'MiniMax-M2.7',
+            'version': 'MiniMax-M3',
         }),
         tokenizer=mock_tokenizer,
     )
 
     # Make a real API call
     completion = model.client.chat.completions.create(
-        model='MiniMax-M2.7',
+        model='MiniMax-M3',
         messages=[{
             'role': 'user',
             'content': 'Say "hello" and nothing else.',
@@ -80,8 +80,8 @@ def test_minimax_chat_completion_live():
     reason='MINIMAX_API_KEY not set',
 )
 @pytest.mark.filterwarnings('ignore::DeprecationWarning')
-def test_minimax_m25_highspeed_live():
-    """Integration test: verify MiniMax-M2.5-highspeed model works."""
+def test_minimax_m27_highspeed_live():
+    """Integration test: verify MiniMax-M2.7-highspeed model works."""
     openai = pytest.importorskip('openai')
 
     os.environ.pop('OPENAI_API_KEY', None)
@@ -96,13 +96,13 @@ def test_minimax_m25_highspeed_live():
 
     model = MiniMaxChatAPIEvalWrapper(
         om_model_config=DictConfig({
-            'version': 'MiniMax-M2.5-highspeed',
+            'version': 'MiniMax-M2.7-highspeed',
         }),
         tokenizer=mock_tokenizer,
     )
 
     completion = model.client.chat.completions.create(
-        model='MiniMax-M2.5-highspeed',
+        model='MiniMax-M2.7-highspeed',
         messages=[{
             'role': 'user',
             'content': 'Say "hello world" and nothing else.',
@@ -138,13 +138,13 @@ def test_minimax_streaming_live():
 
     model = MiniMaxChatAPIEvalWrapper(
         om_model_config=DictConfig({
-            'version': 'MiniMax-M2.7',
+            'version': 'MiniMax-M3',
         }),
         tokenizer=mock_tokenizer,
     )
 
     stream = model.client.chat.completions.create(
-        model='MiniMax-M2.7',
+        model='MiniMax-M3',
         messages=[{
             'role': 'user',
             'content': 'Say "test" and nothing else.',

--- a/tests/models/inference_api_wrapper/test_minimax_integration.py
+++ b/tests/models/inference_api_wrapper/test_minimax_integration.py
@@ -1,0 +1,158 @@
+# Copyright 2022 MosaicML LLM Foundry authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Integration tests for MiniMax inference API wrapper.
+
+These tests verify the MiniMax wrapper works correctly with the
+MiniMax API. They require a valid MINIMAX_API_KEY environment variable.
+
+Run with: pytest tests/models/inference_api_wrapper/test_minimax_integration.py -v
+"""
+
+import os
+
+import pytest
+from omegaconf import DictConfig
+from unittest.mock import MagicMock
+
+
+@pytest.fixture(autouse=True)
+def clean_env():
+    """Save and restore env vars around each test."""
+    old_openai = os.environ.get('OPENAI_API_KEY')
+    old_minimax = os.environ.get('MINIMAX_API_KEY')
+    yield
+    if old_openai is not None:
+        os.environ['OPENAI_API_KEY'] = old_openai
+    else:
+        os.environ.pop('OPENAI_API_KEY', None)
+    if old_minimax is not None:
+        os.environ['MINIMAX_API_KEY'] = old_minimax
+    else:
+        os.environ.pop('MINIMAX_API_KEY', None)
+
+
+@pytest.mark.skipif(
+    not os.environ.get('MINIMAX_API_KEY'),
+    reason='MINIMAX_API_KEY not set',
+)
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
+def test_minimax_chat_completion_live():
+    """Integration test: verify a real chat completion call to MiniMax API."""
+    openai = pytest.importorskip('openai')
+
+    os.environ.pop('OPENAI_API_KEY', None)
+
+    from llmfoundry.models.inference_api_wrapper.minimax import (
+        MiniMaxChatAPIEvalWrapper,
+    )
+
+    mock_tokenizer = MagicMock()
+    mock_tokenizer.pad_token_id = 0
+    mock_tokenizer.eos_token_id = 1
+
+    model = MiniMaxChatAPIEvalWrapper(
+        om_model_config=DictConfig({
+            'version': 'MiniMax-M2.7',
+        }),
+        tokenizer=mock_tokenizer,
+    )
+
+    # Make a real API call
+    completion = model.client.chat.completions.create(
+        model='MiniMax-M2.7',
+        messages=[{
+            'role': 'user',
+            'content': 'Say "hello" and nothing else.',
+        }],
+        max_tokens=10,
+        temperature=0.0,
+    )
+
+    assert completion is not None
+    assert len(completion.choices) > 0
+    assert completion.choices[0].message.content is not None
+    assert len(completion.choices[0].message.content) > 0
+
+
+@pytest.mark.skipif(
+    not os.environ.get('MINIMAX_API_KEY'),
+    reason='MINIMAX_API_KEY not set',
+)
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
+def test_minimax_m25_highspeed_live():
+    """Integration test: verify MiniMax-M2.5-highspeed model works."""
+    openai = pytest.importorskip('openai')
+
+    os.environ.pop('OPENAI_API_KEY', None)
+
+    from llmfoundry.models.inference_api_wrapper.minimax import (
+        MiniMaxChatAPIEvalWrapper,
+    )
+
+    mock_tokenizer = MagicMock()
+    mock_tokenizer.pad_token_id = 0
+    mock_tokenizer.eos_token_id = 1
+
+    model = MiniMaxChatAPIEvalWrapper(
+        om_model_config=DictConfig({
+            'version': 'MiniMax-M2.5-highspeed',
+        }),
+        tokenizer=mock_tokenizer,
+    )
+
+    completion = model.client.chat.completions.create(
+        model='MiniMax-M2.5-highspeed',
+        messages=[{
+            'role': 'user',
+            'content': 'Say "hello world" and nothing else.',
+        }],
+        max_tokens=20,
+        temperature=0.0,
+    )
+
+    assert completion is not None
+    assert len(completion.choices) > 0
+    assert completion.choices[0].message.content is not None
+    assert len(completion.choices[0].message.content) > 0
+
+
+@pytest.mark.skipif(
+    not os.environ.get('MINIMAX_API_KEY'),
+    reason='MINIMAX_API_KEY not set',
+)
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
+def test_minimax_streaming_live():
+    """Integration test: verify streaming chat completion works."""
+    openai = pytest.importorskip('openai')
+
+    os.environ.pop('OPENAI_API_KEY', None)
+
+    from llmfoundry.models.inference_api_wrapper.minimax import (
+        MiniMaxChatAPIEvalWrapper,
+    )
+
+    mock_tokenizer = MagicMock()
+    mock_tokenizer.pad_token_id = 0
+    mock_tokenizer.eos_token_id = 1
+
+    model = MiniMaxChatAPIEvalWrapper(
+        om_model_config=DictConfig({
+            'version': 'MiniMax-M2.7',
+        }),
+        tokenizer=mock_tokenizer,
+    )
+
+    stream = model.client.chat.completions.create(
+        model='MiniMax-M2.7',
+        messages=[{
+            'role': 'user',
+            'content': 'Say "test" and nothing else.',
+        }],
+        max_tokens=10,
+        temperature=0.0,
+        stream=True,
+    )
+
+    chunks = list(stream)
+    assert len(chunks) > 0


### PR DESCRIPTION
## Summary

Add [MiniMax](https://www.minimax.io) as a first-class inference API provider for LLM evaluation, following the same pattern as the existing OpenAI and FMAPI wrappers.

MiniMax provides an OpenAI-compatible API at `https://api.minimax.io/v1`, supporting high-performance models including:
- **MiniMax-M3** (default) — 512K context window, up to 128K output, image input support
- **MiniMax-M2.7** — previous generation model
- **MiniMax-M2.7-highspeed** — previous generation, optimized for low latency

### Changes

| File | Description |
|------|-------------|
| `llmfoundry/models/inference_api_wrapper/minimax.py` | `MiniMaxEvalInterface` + `MiniMaxChatAPIEvalWrapper` |
| `llmfoundry/models/inference_api_wrapper/__init__.py` | Export new classes |
| `llmfoundry/models/__init__.py` | Register `minimax_chat` in models registry |
| `scripts/eval/yamls/minimax_eval.yaml` | Example evaluation config (M3 as default, M2.7 + M2.7-highspeed kept) |
| `tests/.../test_minimax.py` | 10 unit tests (default version updated to M3) |
| `tests/.../test_minimax_integration.py` | 3 integration tests (M3 default + M2.7-highspeed coverage) |

### Usage

```bash
export MINIMAX_API_KEY=your-key
python scripts/eval/eval.py scripts/eval/yamls/minimax_eval.yaml
```

Or configure in any eval YAML:
```yaml
models:
-
  model_name: minimax/MiniMax-M3
  model:
    name: minimax_chat
    version: MiniMax-M3
  tokenizer:
    name: tiktoken
    kwargs:
      model_name: gpt-4
```

### Design

- `MiniMaxEvalInterface` extends `OpenAIEvalInterface`, overriding initialization to properly handle the `MINIMAX_API_KEY` env var and auto-configure the MiniMax base URL
- `MiniMaxChatAPIEvalWrapper` combines `MiniMaxEvalInterface` with `OpenAIChatAPIEvalWrapper` via multiple inheritance (same pattern as FMAPI)
- Falls back to `OPENAI_API_KEY` if `MINIMAX_API_KEY` is not set
- Default model is now `MiniMax-M3`; older models (`M2.5`/`M2.1`/`M2`/`M1`) have been removed from the example config and tests

## Test plan

- [x] 10 unit tests pass (mock-based, no network required)
- [x] 3 integration tests pass with live MiniMax API (M3 default + M2.7-highspeed)
- [x] Existing OpenAI/FMAPI wrapper tests unaffected
- [ ] CI pipeline validation